### PR TITLE
feat(introspection): implement schema unwrapping utility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master, main]
+    branches: [main]
   pull_request:
-    branches: [master, main]
+    branches: [main]
 
 jobs:
   ci:

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,4 +5,8 @@ export type {
   FieldMetadata,
   FieldType,
   FormDescriptor,
+  UnwrapResult,
 } from "./introspection";
+
+// Introspection functions
+export { unwrapSchema } from "./introspection";

--- a/src/introspection/index.ts
+++ b/src/introspection/index.ts
@@ -5,3 +5,5 @@ export type {
   FieldType,
   FormDescriptor,
 } from "./types";
+
+export { type UnwrapResult, unwrapSchema } from "./unwrap";

--- a/src/introspection/unwrap.ts
+++ b/src/introspection/unwrap.ts
@@ -1,0 +1,71 @@
+import type { $ZodType } from "zod/v4/core";
+
+export interface UnwrapResult {
+  /** The innermost non-wrapper schema */
+  inner: $ZodType;
+  /** Whether z.optional() was present */
+  isOptional: boolean;
+}
+
+/** Type guard to check if schema has unwrap method */
+function hasUnwrap(
+  schema: unknown,
+): schema is { unwrap: () => $ZodType } & $ZodType {
+  return (
+    typeof schema === "object" &&
+    schema !== null &&
+    "unwrap" in schema &&
+    typeof (schema as Record<string, unknown>).unwrap === "function"
+  );
+}
+
+/** Validates that the schema is a Zod 4 schema with required properties */
+function isValidZod4Schema(schema: unknown): schema is $ZodType {
+  if (!schema || typeof schema !== "object") {
+    return false;
+  }
+
+  const s = schema as Record<string, unknown>;
+  if (!("_zod" in s) || !s._zod || typeof s._zod !== "object") {
+    return false;
+  }
+
+  const zod = s._zod as Record<string, unknown>;
+  if (!("def" in zod) || !zod.def || typeof zod.def !== "object") {
+    return false;
+  }
+
+  const def = zod.def as Record<string, unknown>;
+  return "type" in def;
+}
+
+/**
+ * Unwraps optional wrapper from a Zod schema.
+ * Handles: z.optional(), z.string().optional()
+ */
+export function unwrapSchema(schema: $ZodType): UnwrapResult {
+  // Validate that this is a Zod 4 schema
+  if (!isValidZod4Schema(schema)) {
+    throw new Error(
+      "Schema is not a Zod 4 schema. Ensure you are using zod >= 4.0.0",
+    );
+  }
+
+  let current = schema;
+  let isOptional = false;
+
+  // Unwrap nested optionals
+  while (current._zod.def.type === "optional") {
+    isOptional = true;
+    // Verify unwrap method exists before calling
+    if (!hasUnwrap(current)) {
+      throw new Error("Optional schema missing unwrap method");
+    }
+    current = current.unwrap();
+  }
+
+  return {
+    inner: current,
+    isOptional,
+  };
+}

--- a/test/introspection/unwrap.test.ts
+++ b/test/introspection/unwrap.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod/v4";
+import { unwrapSchema } from "../../src/introspection/unwrap";
+
+describe("unwrapSchema", () => {
+  it("returns non-optional string as-is with isOptional: false", () => {
+    const schema = z.string();
+    const result = unwrapSchema(schema);
+
+    expect(result.isOptional).toBe(false);
+    expect(result.inner._zod.def.type).toBe("string");
+  });
+
+  it("unwraps optional string and returns isOptional: true", () => {
+    const schema = z.string().optional();
+    const result = unwrapSchema(schema);
+
+    expect(result.isOptional).toBe(true);
+    expect(result.inner._zod.def.type).toBe("string");
+  });
+
+  it("unwraps optional number and returns isOptional: true", () => {
+    const schema = z.number().optional();
+    const result = unwrapSchema(schema);
+
+    expect(result.isOptional).toBe(true);
+    expect(result.inner._zod.def.type).toBe("number");
+  });
+
+  it("unwraps z.optional() wrapper", () => {
+    const schema = z.optional(z.boolean());
+    const result = unwrapSchema(schema);
+
+    expect(result.isOptional).toBe(true);
+    expect(result.inner._zod.def.type).toBe("boolean");
+  });
+
+  it("handles deeply nested optionals", () => {
+    const schema = z.optional(z.optional(z.string()));
+    const result = unwrapSchema(schema);
+
+    expect(result.isOptional).toBe(true);
+    expect(result.inner._zod.def.type).toBe("string");
+  });
+
+  it("handles non-optional boolean", () => {
+    const schema = z.boolean();
+    const result = unwrapSchema(schema);
+
+    expect(result.isOptional).toBe(false);
+    expect(result.inner._zod.def.type).toBe("boolean");
+  });
+
+  it("handles non-optional date", () => {
+    const schema = z.date();
+    const result = unwrapSchema(schema);
+
+    expect(result.isOptional).toBe(false);
+    expect(result.inner._zod.def.type).toBe("date");
+  });
+
+  it("handles optional enum", () => {
+    const schema = z.enum(["a", "b", "c"]).optional();
+    const result = unwrapSchema(schema);
+
+    expect(result.isOptional).toBe(true);
+    expect(result.inner._zod.def.type).toBe("enum");
+  });
+
+  it("throws for non-Zod4 schema (null)", () => {
+    expect(() => unwrapSchema(null as unknown as z.ZodType)).toThrow(
+      "Schema is not a Zod 4 schema",
+    );
+  });
+
+  it("throws for non-Zod4 schema (plain object)", () => {
+    expect(() => unwrapSchema({} as unknown as z.ZodType)).toThrow(
+      "Schema is not a Zod 4 schema",
+    );
+  });
+
+  it("throws for non-Zod4 schema (undefined)", () => {
+    expect(() => unwrapSchema(undefined as unknown as z.ZodType)).toThrow(
+      "Schema is not a Zod 4 schema",
+    );
+  });
+
+  // Complex schema types
+  it("handles optional object schema", () => {
+    const schema = z.object({ name: z.string() }).optional();
+    const result = unwrapSchema(schema);
+
+    expect(result.isOptional).toBe(true);
+    expect(result.inner._zod.def.type).toBe("object");
+  });
+
+  it("handles optional array schema", () => {
+    const schema = z.array(z.string()).optional();
+    const result = unwrapSchema(schema);
+
+    expect(result.isOptional).toBe(true);
+    expect(result.inner._zod.def.type).toBe("array");
+  });
+
+  it("handles optional union schema", () => {
+    const schema = z.union([z.string(), z.number()]).optional();
+    const result = unwrapSchema(schema);
+
+    expect(result.isOptional).toBe(true);
+    expect(result.inner._zod.def.type).toBe("union");
+  });
+
+  it("throws for malformed schema with _zod but no def", () => {
+    const malformed = { _zod: {} } as unknown as z.ZodType;
+    expect(() => unwrapSchema(malformed)).toThrow(
+      "Schema is not a Zod 4 schema",
+    );
+  });
+
+  it("throws for malformed schema with _zod.def but no type", () => {
+    const malformed = { _zod: { def: {} } } as unknown as z.ZodType;
+    expect(() => unwrapSchema(malformed)).toThrow(
+      "Schema is not a Zod 4 schema",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add `unwrapSchema` function to unwrap `z.optional()` wrappers from Zod schemas
- Returns `UnwrapResult` with the inner schema and whether it was optional
- Validates Zod 4 schema structure before processing
- Uses type guards for safe type narrowing (no unsafe casts)

## Code Review Findings (Addressed)
Ran automated code review before PR creation:

1. **Type Casting Safety** - Fixed by adding `hasUnwrap` type guard function
2. **Incomplete Validation** - Fixed by adding `isValidZod4Schema` that validates full property path (`_zod.def.type`)
3. **Missing Complex Type Tests** - Added tests for object, array, union schemas and malformed inputs

## Test plan
- [x] 16 unit tests covering:
  - All primitive types (string, number, boolean, date, enum)
  - Complex types (object, array, union)  
  - Nested optionals
  - Invalid/malformed schema inputs
- [x] Preflight passes (lint, typecheck, test)
- [x] Flightcheck passes

## Also includes
- CI workflow updated to use `main` branch only (removed `master`)

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)