### PR TITLE
fix(codegen): change default UI import path to @/components/ui

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,7 +19,7 @@ program
   .option("-o, --output <path>", "Output file path")
   .option("-n, --name <name>", "Form component name")
   .option("-s, --schema <name>", "Exported schema name", "schema")
-  .option("--ui <path>", "UI import path", "@rafters/ui")
+  .option("--ui <path>", "UI import path", "@/components/ui")
   .action(async (schemaPath: string, options: GenerateCommandOptions) => {
     try {
       await runGenerate(schemaPath, options);

--- a/src/codegen/generator.ts
+++ b/src/codegen/generator.ts
@@ -41,7 +41,7 @@ export function generate(options: GenerateOptions): GenerateResult {
     formName,
     schemaImportPath,
     schemaExportName,
-    uiImportPath = "@rafters/ui",
+    uiImportPath = "@/components/ui",
   } = options;
 
   const warnings: string[] = [];

--- a/test/cli.spec.ts
+++ b/test/cli.spec.ts
@@ -114,11 +114,11 @@ describe("CLI", () => {
         "-s",
         "userSchema",
         "--ui",
-        "@/components/ui",
+        "@custom/ui",
       ]);
 
       const content = fs.readFileSync(outputPath, "utf-8");
-      expect(content).toContain("from '@/components/ui'");
+      expect(content).toContain("from '@custom/ui'");
     });
 
     it("shows error for non-existent file", () => {

--- a/test/codegen/form-wrapper.test.ts
+++ b/test/codegen/form-wrapper.test.ts
@@ -83,7 +83,7 @@ describe("generateFormFile", () => {
       const output = generateFormFile({
         form,
         fieldConfigs,
-        uiImportPath: "@rafters/ui",
+        uiImportPath: "@/components/ui",
       });
 
       expect(output.startsWith("'use client';")).toBe(true);
@@ -96,7 +96,7 @@ describe("generateFormFile", () => {
       const output = generateFormFile({
         form,
         fieldConfigs,
-        uiImportPath: "@rafters/ui",
+        uiImportPath: "@/components/ui",
       });
 
       expect(output).toContain("export function UserForm(");
@@ -109,7 +109,7 @@ describe("generateFormFile", () => {
       const output = generateFormFile({
         form,
         fieldConfigs,
-        uiImportPath: "@rafters/ui",
+        uiImportPath: "@/components/ui",
       });
 
       expect(output).toContain("defaultValues: initialValues");
@@ -123,7 +123,7 @@ describe("generateFormFile", () => {
       const output = generateFormFile({
         form,
         fieldConfigs,
-        uiImportPath: "@rafters/ui",
+        uiImportPath: "@/components/ui",
       });
 
       expect(output).toContain('<button type="submit">Submit</button>');
@@ -138,7 +138,7 @@ describe("generateFormFile", () => {
       const output = generateFormFile({
         form,
         fieldConfigs,
-        uiImportPath: "@rafters/ui",
+        uiImportPath: "@/components/ui",
       });
 
       expect(output).toContain(
@@ -156,7 +156,7 @@ describe("generateFormFile", () => {
       const output = generateFormFile({
         form,
         fieldConfigs,
-        uiImportPath: "@rafters/ui",
+        uiImportPath: "@/components/ui",
       });
 
       expect(output).toContain(
@@ -171,11 +171,11 @@ describe("generateFormFile", () => {
       const output = generateFormFile({
         form,
         fieldConfigs,
-        uiImportPath: "@rafters/ui",
+        uiImportPath: "@/components/ui",
       });
 
       expect(output).toContain("Field,");
-      expect(output).toContain("} from '@rafters/ui';");
+      expect(output).toContain("} from '@/components/ui';");
     });
 
     it("imports only used components", () => {
@@ -189,7 +189,7 @@ describe("generateFormFile", () => {
       const output = generateFormFile({
         form,
         fieldConfigs,
-        uiImportPath: "@rafters/ui",
+        uiImportPath: "@/components/ui",
       });
 
       expect(output).toContain("Input,");
@@ -208,7 +208,7 @@ describe("generateFormFile", () => {
       const output = generateFormFile({
         form,
         fieldConfigs,
-        uiImportPath: "@rafters/ui",
+        uiImportPath: "@/components/ui",
       });
 
       expect(output).toContain("RadioGroup,");
@@ -237,7 +237,7 @@ describe("generateFormFile", () => {
       const output = generateFormFile({
         form,
         fieldConfigs,
-        uiImportPath: "@rafters/ui",
+        uiImportPath: "@/components/ui",
       });
 
       expect(output).toContain("interface ProfileFormProps {");
@@ -253,7 +253,7 @@ describe("generateFormFile", () => {
       const output = generateFormFile({
         form,
         fieldConfigs,
-        uiImportPath: "@rafters/ui",
+        uiImportPath: "@/components/ui",
       });
 
       expect(output).toContain("defaultValues?: Partial<User>;");
@@ -269,7 +269,7 @@ describe("generateFormFile", () => {
       const output = generateFormFile({
         form,
         fieldConfigs,
-        uiImportPath: "@rafters/ui",
+        uiImportPath: "@/components/ui",
       });
 
       expect(output).toContain(
@@ -290,7 +290,7 @@ describe("generateFormFile", () => {
       const output = generateFormFile({
         form,
         fieldConfigs,
-        uiImportPath: "@rafters/ui",
+        uiImportPath: "@/components/ui",
       });
 
       expect(output).toContain('name: "",');
@@ -313,7 +313,7 @@ describe("generateFormFile", () => {
       const output = generateFormFile({
         form,
         fieldConfigs,
-        uiImportPath: "@rafters/ui",
+        uiImportPath: "@/components/ui",
       });
 
       expect(output).toContain("age: 0,");
@@ -342,7 +342,7 @@ describe("generateFormFile", () => {
       const output = generateFormFile({
         form,
         fieldConfigs,
-        uiImportPath: "@rafters/ui",
+        uiImportPath: "@/components/ui",
       });
 
       expect(output).toContain("priority: 1,");
@@ -365,7 +365,7 @@ describe("generateFormFile", () => {
       const output = generateFormFile({
         form,
         fieldConfigs,
-        uiImportPath: "@rafters/ui",
+        uiImportPath: "@/components/ui",
       });
 
       expect(output).toContain("active: false,");
@@ -388,7 +388,7 @@ describe("generateFormFile", () => {
       const output = generateFormFile({
         form,
         fieldConfigs,
-        uiImportPath: "@rafters/ui",
+        uiImportPath: "@/components/ui",
       });
 
       expect(output).toContain("birthDate: undefined,");
@@ -411,7 +411,7 @@ describe("generateFormFile", () => {
       const output = generateFormFile({
         form,
         fieldConfigs,
-        uiImportPath: "@rafters/ui",
+        uiImportPath: "@/components/ui",
       });
 
       expect(output).toContain('role: "admin",');
@@ -426,7 +426,7 @@ describe("generateFormFile", () => {
       const output = generateFormFile({
         form,
         fieldConfigs,
-        uiImportPath: "@rafters/ui",
+        uiImportPath: "@/components/ui",
       });
 
       expect(output).toContain("onSubmit: userSchema,");
@@ -439,7 +439,7 @@ describe("generateFormFile", () => {
       const output = generateFormFile({
         form,
         fieldConfigs,
-        uiImportPath: "@rafters/ui",
+        uiImportPath: "@/components/ui",
       });
 
       expect(output).toContain("await onSubmit(value);");
@@ -452,7 +452,7 @@ describe("generateFormFile", () => {
       const output = generateFormFile({
         form,
         fieldConfigs,
-        uiImportPath: "@rafters/ui",
+        uiImportPath: "@/components/ui",
       });
 
       expect(output).toContain("e.preventDefault();");
@@ -482,7 +482,7 @@ describe("generateFormFile", () => {
       const output = generateFormFile({
         form,
         fieldConfigs,
-        uiImportPath: "@rafters/ui",
+        uiImportPath: "@/components/ui",
       });
 
       expect(output).toContain('name="firstName"');
@@ -506,7 +506,7 @@ describe("generateFormFile", () => {
       const output = generateFormFile({
         form,
         fieldConfigs,
-        uiImportPath: "@rafters/ui",
+        uiImportPath: "@/components/ui",
       });
 
       expect(output).toContain('name="name"');
@@ -567,7 +567,7 @@ describe("generateFormFile", () => {
       const output = generateFormFile({
         form,
         fieldConfigs,
-        uiImportPath: "@rafters/ui",
+        uiImportPath: "@/components/ui",
       });
 
       // Verify structure

--- a/test/codegen/generator.test.ts
+++ b/test/codegen/generator.test.ts
@@ -75,7 +75,7 @@ describe("generate", () => {
         schemaExportName: "testSchema",
       });
 
-      expect(result.code).toContain("from '@rafters/ui'");
+      expect(result.code).toContain("from '@/components/ui'");
     });
 
     it("uses custom UI import path when specified", () => {


### PR DESCRIPTION
## Summary
- Changed default `--ui` path from `@rafters/ui` to `@/components/ui`

Rafters and shadcn are registry-based component libraries where components are copied into your project, not installed as npm packages. The default path should reflect the typical project structure where components live in `src/components/ui` aliased as `@/components/ui`.

## Changes
- `src/cli.ts`: Updated default `--ui` option value
- `src/codegen/generator.ts`: Updated default `uiImportPath`
- Tests: Updated to use new default path

🤖 Generated with [Claude Code](https://claude.com/claude-code)