### PR TITLE
feat(core): implement base input registry (PZ-001)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,15 +13,44 @@
 
 export const VERSION = "0.0.1";
 
-// Placeholder exports - to be implemented in Phase 1
-export type InputType = "text" | "number" | "email" | "url" | "date" | "checkbox" | "select" | "radio" | "textarea";
+// Input Registry (PZ-001)
+export {
+  // Registry factory and utilities
+  createDefaultInputRegistry,
+  createInputRegistry,
+  getInputRegistry,
+  resetGlobalRegistry,
+  // Default input definitions
+  checkboxDefinition,
+  datePickerDefinition,
+  defaultInputDefinitions,
+  fileUploadDefinition,
+  multiSelectDefinition,
+  numberInputDefinition,
+  selectDefinition,
+  textAreaDefinition,
+  textInputDefinition,
+} from "./registry";
 
-export interface InputRegistryEntry {
-  type: InputType;
-  component: React.ComponentType<unknown>;
-}
-
-// Will be implemented in PZ-001
-export function registerInput(_entry: InputRegistryEntry): never {
-  throw new Error("Not implemented - see PZ-001: https://github.com/ezmode-games/phantom-zone/issues/26");
-}
+export type {
+  // Core types
+  AcceptedFile,
+  BaseInputDefinition,
+  BaseInputProps,
+  InputProps,
+  InputRegistry,
+  InputTypeId,
+  InputValue,
+  SelectOption,
+  TypedInputDefinition,
+  ValidationRuleId,
+  // Input-specific prop types
+  CheckboxProps,
+  DatePickerProps,
+  FileUploadProps,
+  MultiSelectProps,
+  NumberInputProps,
+  SelectProps,
+  TextAreaProps,
+  TextInputProps,
+} from "./registry";

--- a/packages/core/src/registry/index.ts
+++ b/packages/core/src/registry/index.ts
@@ -1,0 +1,50 @@
+/**
+ * Input Registry
+ *
+ * Provides a registry of base input types for the form builder.
+ * Each input type defines its component, compatible validation rules,
+ * and default props.
+ */
+
+// Types
+export type {
+  AcceptedFile,
+  BaseInputDefinition,
+  BaseInputProps,
+  CheckboxProps,
+  DatePickerProps,
+  FileUploadProps,
+  InputProps,
+  InputRegistry,
+  InputTypeId,
+  InputValue,
+  MultiSelectProps,
+  NumberInputProps,
+  SelectOption,
+  SelectProps,
+  TextAreaProps,
+  TextInputProps,
+  TypedInputDefinition,
+  ValidationRuleId,
+} from "./types";
+
+// Registry factory and utilities
+export {
+  createDefaultInputRegistry,
+  createInputRegistry,
+  getInputRegistry,
+  resetGlobalRegistry,
+} from "./inputs";
+
+// Default input definitions (for customization/extension)
+export {
+  checkboxDefinition,
+  datePickerDefinition,
+  defaultInputDefinitions,
+  fileUploadDefinition,
+  multiSelectDefinition,
+  numberInputDefinition,
+  selectDefinition,
+  textAreaDefinition,
+  textInputDefinition,
+} from "./inputs";

--- a/packages/core/src/registry/inputs.ts
+++ b/packages/core/src/registry/inputs.ts
@@ -1,0 +1,320 @@
+import type {
+  BaseInputDefinition,
+  CheckboxProps,
+  DatePickerProps,
+  FileUploadProps,
+  InputRegistry,
+  InputTypeId,
+  MultiSelectProps,
+  NumberInputProps,
+  SelectProps,
+  TextAreaProps,
+  TextInputProps,
+  TypedInputDefinition,
+} from "./types";
+
+/**
+ * Creates a new input registry instance.
+ * The registry stores input definitions and provides methods to manage them.
+ */
+export function createInputRegistry(): InputRegistry {
+  const registry = new Map<InputTypeId, BaseInputDefinition>();
+
+  return {
+    register(definition: BaseInputDefinition): void {
+      if (registry.has(definition.id)) {
+        throw new Error(
+          `Input type "${definition.id}" is already registered. ` +
+            "Use unregister() first if you want to replace it."
+        );
+      }
+      registry.set(definition.id, definition);
+    },
+
+    get(id: InputTypeId): BaseInputDefinition | undefined {
+      return registry.get(id);
+    },
+
+    getAll(): BaseInputDefinition[] {
+      return Array.from(registry.values());
+    },
+
+    getByCategory(
+      category: BaseInputDefinition["category"]
+    ): BaseInputDefinition[] {
+      return Array.from(registry.values()).filter(
+        (def) => def.category === category
+      );
+    },
+
+    has(id: InputTypeId): boolean {
+      return registry.has(id);
+    },
+
+    unregister(id: InputTypeId): boolean {
+      return registry.delete(id);
+    },
+
+    clear(): void {
+      registry.clear();
+    },
+  };
+}
+
+/**
+ * Placeholder component for text input.
+ * Users should replace with their own implementation (e.g., shadcn/ui Input).
+ */
+function PlaceholderTextInput(props: TextInputProps): null {
+  void props;
+  return null;
+}
+
+/**
+ * Placeholder component for textarea.
+ */
+function PlaceholderTextArea(props: TextAreaProps): null {
+  void props;
+  return null;
+}
+
+/**
+ * Placeholder component for number input.
+ */
+function PlaceholderNumberInput(props: NumberInputProps): null {
+  void props;
+  return null;
+}
+
+/**
+ * Placeholder component for checkbox.
+ */
+function PlaceholderCheckbox(props: CheckboxProps): null {
+  void props;
+  return null;
+}
+
+/**
+ * Placeholder component for select.
+ */
+function PlaceholderSelect(props: SelectProps): null {
+  void props;
+  return null;
+}
+
+/**
+ * Placeholder component for multi-select.
+ */
+function PlaceholderMultiSelect(props: MultiSelectProps): null {
+  void props;
+  return null;
+}
+
+/**
+ * Placeholder component for date picker.
+ */
+function PlaceholderDatePicker(props: DatePickerProps): null {
+  void props;
+  return null;
+}
+
+/**
+ * Placeholder component for file upload.
+ */
+function PlaceholderFileUpload(props: FileUploadProps): null {
+  void props;
+  return null;
+}
+
+/**
+ * Text Input definition - single line text entry
+ */
+export const textInputDefinition: TypedInputDefinition<TextInputProps> = {
+  id: "text",
+  name: "Text Input",
+  icon: "type",
+  component: PlaceholderTextInput,
+  compatibleRules: [
+    "required",
+    "minLength",
+    "maxLength",
+    "pattern",
+    "email",
+    "url",
+    "uuid",
+  ],
+  defaultProps: {
+    type: "text",
+  },
+  description: "Single-line text input for short text entries",
+  category: "text",
+};
+
+/**
+ * Text Area definition - multi-line text entry
+ */
+export const textAreaDefinition: TypedInputDefinition<TextAreaProps> = {
+  id: "textarea",
+  name: "Text Area",
+  icon: "align-left",
+  component: PlaceholderTextArea,
+  compatibleRules: ["required", "minLength", "maxLength"],
+  defaultProps: {
+    rows: 4,
+  },
+  description: "Multi-line text input for longer content",
+  category: "text",
+};
+
+/**
+ * Number Input definition - numeric entry
+ */
+export const numberInputDefinition: TypedInputDefinition<NumberInputProps> = {
+  id: "number",
+  name: "Number Input",
+  icon: "hash",
+  component: PlaceholderNumberInput,
+  compatibleRules: [
+    "required",
+    "min",
+    "max",
+    "step",
+    "integer",
+    "positive",
+    "negative",
+  ],
+  defaultProps: {},
+  description: "Numeric input with optional min/max/step constraints",
+  category: "text",
+};
+
+/**
+ * Checkbox definition - boolean toggle
+ */
+export const checkboxDefinition: TypedInputDefinition<CheckboxProps> = {
+  id: "checkbox",
+  name: "Checkbox",
+  icon: "check-square",
+  component: PlaceholderCheckbox,
+  compatibleRules: ["required"],
+  defaultProps: {},
+  description: "Boolean checkbox for true/false values",
+  category: "choice",
+};
+
+/**
+ * Select definition - single choice dropdown
+ */
+export const selectDefinition: TypedInputDefinition<SelectProps> = {
+  id: "select",
+  name: "Select",
+  icon: "chevron-down",
+  component: PlaceholderSelect,
+  compatibleRules: ["required"],
+  defaultProps: {
+    options: [],
+    clearable: false,
+    searchable: false,
+  },
+  description: "Dropdown for selecting a single option",
+  category: "choice",
+};
+
+/**
+ * Multi-Select definition - multiple choice
+ */
+export const multiSelectDefinition: TypedInputDefinition<MultiSelectProps> = {
+  id: "multiselect",
+  name: "Multi-Select",
+  icon: "list-checks",
+  component: PlaceholderMultiSelect,
+  compatibleRules: ["required", "minItems", "maxItems"],
+  defaultProps: {
+    options: [],
+    searchable: false,
+  },
+  description: "Select multiple options from a list",
+  category: "choice",
+};
+
+/**
+ * Date Picker definition - date selection
+ */
+export const datePickerDefinition: TypedInputDefinition<DatePickerProps> = {
+  id: "date",
+  name: "Date Picker",
+  icon: "calendar",
+  component: PlaceholderDatePicker,
+  compatibleRules: ["required", "minDate", "maxDate"],
+  defaultProps: {},
+  description: "Calendar picker for date selection",
+  category: "date",
+};
+
+/**
+ * File Upload definition - file selection
+ */
+export const fileUploadDefinition: TypedInputDefinition<FileUploadProps> = {
+  id: "file",
+  name: "File Upload",
+  icon: "upload",
+  component: PlaceholderFileUpload,
+  compatibleRules: ["required", "fileSize", "fileType", "maxItems"],
+  defaultProps: {
+    multiple: false,
+  },
+  description: "File upload with drag-and-drop support",
+  category: "file",
+};
+
+/**
+ * All default input definitions.
+ */
+export const defaultInputDefinitions: BaseInputDefinition[] = [
+  textInputDefinition,
+  textAreaDefinition,
+  numberInputDefinition,
+  checkboxDefinition,
+  selectDefinition,
+  multiSelectDefinition,
+  datePickerDefinition,
+  fileUploadDefinition,
+];
+
+/**
+ * Creates a registry pre-populated with all default input types.
+ */
+export function createDefaultInputRegistry(): InputRegistry {
+  const registry = createInputRegistry();
+
+  for (const definition of defaultInputDefinitions) {
+    registry.register(definition);
+  }
+
+  return registry;
+}
+
+/**
+ * Global default registry instance.
+ * Use createInputRegistry() or createDefaultInputRegistry() for isolated instances.
+ */
+let globalRegistry: InputRegistry | null = null;
+
+/**
+ * Gets the global input registry, creating it if necessary.
+ * The global registry is pre-populated with default input types.
+ */
+export function getInputRegistry(): InputRegistry {
+  if (!globalRegistry) {
+    globalRegistry = createDefaultInputRegistry();
+  }
+  return globalRegistry;
+}
+
+/**
+ * Resets the global registry to a fresh default state.
+ * Primarily useful for testing.
+ */
+export function resetGlobalRegistry(): void {
+  globalRegistry = null;
+}

--- a/packages/core/src/registry/types.ts
+++ b/packages/core/src/registry/types.ts
@@ -1,0 +1,311 @@
+import type { ComponentType } from "react";
+
+/**
+ * Standard validation rule identifiers that inputs can declare compatibility with.
+ * These map to common Zod validation checks.
+ */
+export type ValidationRuleId =
+  | "required"
+  | "minLength"
+  | "maxLength"
+  | "pattern"
+  | "email"
+  | "url"
+  | "uuid"
+  | "min"
+  | "max"
+  | "step"
+  | "integer"
+  | "positive"
+  | "negative"
+  | "minDate"
+  | "maxDate"
+  | "minItems"
+  | "maxItems"
+  | "fileSize"
+  | "fileType";
+
+/**
+ * Input type identifiers used in the registry.
+ */
+export type InputTypeId =
+  | "text"
+  | "textarea"
+  | "number"
+  | "checkbox"
+  | "select"
+  | "multiselect"
+  | "date"
+  | "file";
+
+/**
+ * Base props that all input components must accept.
+ * Generic over the value type T.
+ */
+export interface BaseInputProps<T = unknown> {
+  /** Unique field identifier */
+  id: string;
+
+  /** Field name for form submission */
+  name: string;
+
+  /** Current field value */
+  value: T;
+
+  /** Called when the value changes */
+  onChange: (value: T) => void;
+
+  /** Called when the field loses focus */
+  onBlur?: () => void;
+
+  /** Whether the field is disabled */
+  disabled?: boolean;
+
+  /** Whether the field is read-only */
+  readOnly?: boolean;
+
+  /** Placeholder text */
+  placeholder?: string;
+
+  /** Accessible label (visually hidden if using FormField wrapper) */
+  "aria-label"?: string;
+
+  /** ID of element describing this input */
+  "aria-describedby"?: string;
+
+  /** Whether field has an error */
+  "aria-invalid"?: boolean;
+
+  /** Error message ID for aria-errormessage */
+  "aria-errormessage"?: string;
+}
+
+/**
+ * Props for text input (single line)
+ */
+export interface TextInputProps extends BaseInputProps<string> {
+  type?: "text" | "email" | "url" | "tel" | "password";
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
+  autoComplete?: string;
+}
+
+/**
+ * Props for textarea (multi-line)
+ */
+export interface TextAreaProps extends BaseInputProps<string> {
+  minLength?: number;
+  maxLength?: number;
+  rows?: number;
+  autoComplete?: string;
+}
+
+/**
+ * Props for number input
+ */
+export interface NumberInputProps extends BaseInputProps<number | null> {
+  min?: number;
+  max?: number;
+  step?: number;
+}
+
+/**
+ * Props for checkbox (boolean)
+ */
+export interface CheckboxProps extends BaseInputProps<boolean> {
+  /** Label displayed next to checkbox */
+  label?: string;
+}
+
+/**
+ * Option for select/multiselect
+ */
+export interface SelectOption {
+  value: string;
+  label: string;
+  disabled?: boolean;
+}
+
+/**
+ * Props for single select
+ */
+export interface SelectProps extends BaseInputProps<string | null> {
+  options: SelectOption[];
+  /** Allow clearing the selection */
+  clearable?: boolean;
+  /** Searchable/filterable dropdown */
+  searchable?: boolean;
+}
+
+/**
+ * Props for multi-select
+ */
+export interface MultiSelectProps extends BaseInputProps<string[]> {
+  options: SelectOption[];
+  /** Minimum selections required */
+  minItems?: number;
+  /** Maximum selections allowed */
+  maxItems?: number;
+  /** Searchable/filterable dropdown */
+  searchable?: boolean;
+}
+
+/**
+ * Props for date picker
+ */
+export interface DatePickerProps extends BaseInputProps<Date | null> {
+  /** Minimum selectable date */
+  minDate?: Date;
+  /** Maximum selectable date */
+  maxDate?: Date;
+  /** Date format display string */
+  format?: string;
+}
+
+/**
+ * Accepted file specification
+ */
+export interface AcceptedFile {
+  /** MIME type pattern (e.g., "image/*", "application/pdf") */
+  mimeType: string;
+  /** File extensions (e.g., [".pdf", ".doc"]) */
+  extensions?: string[];
+}
+
+/**
+ * Props for file upload
+ */
+export interface FileUploadProps extends BaseInputProps<File | File[] | null> {
+  /** Allow multiple file selection */
+  multiple?: boolean;
+  /** Accepted file types */
+  accept?: AcceptedFile[];
+  /** Maximum file size in bytes */
+  maxSize?: number;
+  /** Maximum number of files (when multiple) */
+  maxFiles?: number;
+}
+
+/**
+ * Union of all input prop types for type narrowing
+ */
+export type InputProps =
+  | TextInputProps
+  | TextAreaProps
+  | NumberInputProps
+  | CheckboxProps
+  | SelectProps
+  | MultiSelectProps
+  | DatePickerProps
+  | FileUploadProps;
+
+/**
+ * All supported input value types
+ */
+export type InputValue =
+  | string
+  | number
+  | boolean
+  | Date
+  | File
+  | File[]
+  | string[]
+  | null;
+
+/**
+ * Definition for a base input type in the registry.
+ * Used by the form designer to show available inputs.
+ *
+ * Note: The component prop uses a general type to allow storing
+ * heterogeneous input definitions in the registry. Type safety
+ * for specific input types is maintained through the typed
+ * definition exports (e.g., textInputDefinition).
+ */
+export interface BaseInputDefinition {
+  /** Unique identifier for this input type */
+  id: InputTypeId;
+
+  /** Human-readable display name */
+  name: string;
+
+  /** Icon identifier (e.g., Lucide icon name or custom) */
+  icon: string;
+
+  /** The React component that renders this input */
+  // biome-ignore lint/suspicious/noExplicitAny: Required for heterogeneous registry storage
+  component: ComponentType<any>;
+
+  /** Validation rules this input is compatible with */
+  compatibleRules: ValidationRuleId[];
+
+  /** Default props when adding this input to a form */
+  defaultProps?: Record<string, unknown>;
+
+  /** Description shown in the input palette */
+  description?: string;
+
+  /** Category for grouping in the palette */
+  category?: "text" | "choice" | "date" | "file" | "other";
+}
+
+/**
+ * Typed input definition for creating new input types with full type safety.
+ * Use this when defining custom inputs to ensure type correctness.
+ *
+ * The generic parameter P should be your specific props interface
+ * (e.g., TextInputProps, SelectProps).
+ */
+export interface TypedInputDefinition<P> {
+  /** Unique identifier for this input type */
+  id: InputTypeId;
+
+  /** Human-readable display name */
+  name: string;
+
+  /** Icon identifier (e.g., Lucide icon name or custom) */
+  icon: string;
+
+  /** The React component that renders this input */
+  component: ComponentType<P>;
+
+  /** Validation rules this input is compatible with */
+  compatibleRules: ValidationRuleId[];
+
+  /** Default props when adding this input to a form (excludes base props) */
+  defaultProps?: Partial<Omit<P, "id" | "name" | "value" | "onChange">>;
+
+  /** Description shown in the input palette */
+  description?: string;
+
+  /** Category for grouping in the palette */
+  category?: "text" | "choice" | "date" | "file" | "other";
+}
+
+/**
+ * The input registry interface for managing registered inputs
+ */
+export interface InputRegistry {
+  /** Register a new input type */
+  register(definition: BaseInputDefinition): void;
+
+  /** Get an input definition by ID */
+  get(id: InputTypeId): BaseInputDefinition | undefined;
+
+  /** Get all registered inputs */
+  getAll(): BaseInputDefinition[];
+
+  /** Get inputs by category */
+  getByCategory(
+    category: BaseInputDefinition["category"]
+  ): BaseInputDefinition[];
+
+  /** Check if an input type is registered */
+  has(id: InputTypeId): boolean;
+
+  /** Unregister an input type */
+  unregister(id: InputTypeId): boolean;
+
+  /** Clear all registrations */
+  clear(): void;
+}

--- a/packages/core/test/index.test.ts
+++ b/packages/core/test/index.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+describe("@phantom-zone/core", () => {
+  it("should export module", async () => {
+    const module = await import("../src/index");
+    expect(module).toBeDefined();
+  });
+
+  it("exports VERSION", async () => {
+    const { VERSION } = await import("../src/index");
+    expect(VERSION).toBe("0.0.1");
+  });
+
+  describe("Registry Exports", () => {
+    it("exports registry factory functions", async () => {
+      const module = await import("../src/index");
+      expect(module.createInputRegistry).toBeDefined();
+      expect(module.createDefaultInputRegistry).toBeDefined();
+      expect(module.getInputRegistry).toBeDefined();
+      expect(module.resetGlobalRegistry).toBeDefined();
+    });
+
+    it("exports all default input definitions", async () => {
+      const module = await import("../src/index");
+      expect(module.textInputDefinition).toBeDefined();
+      expect(module.textAreaDefinition).toBeDefined();
+      expect(module.numberInputDefinition).toBeDefined();
+      expect(module.checkboxDefinition).toBeDefined();
+      expect(module.selectDefinition).toBeDefined();
+      expect(module.multiSelectDefinition).toBeDefined();
+      expect(module.datePickerDefinition).toBeDefined();
+      expect(module.fileUploadDefinition).toBeDefined();
+      expect(module.defaultInputDefinitions).toHaveLength(8);
+    });
+  });
+
+  describe("Type Exports", () => {
+    it("exports core types (compile-time check)", async () => {
+      // These are type-only exports, so we just verify the module loads
+      // Type checking is done by TypeScript compiler
+      const module = await import("../src/index");
+      expect(module).toBeDefined();
+    });
+  });
+});

--- a/packages/core/test/registry/inputs.test.ts
+++ b/packages/core/test/registry/inputs.test.ts
@@ -1,0 +1,386 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  checkboxDefinition,
+  createDefaultInputRegistry,
+  createInputRegistry,
+  datePickerDefinition,
+  defaultInputDefinitions,
+  fileUploadDefinition,
+  getInputRegistry,
+  multiSelectDefinition,
+  numberInputDefinition,
+  resetGlobalRegistry,
+  selectDefinition,
+  textAreaDefinition,
+  textInputDefinition,
+} from "../../src/registry";
+import type {
+  BaseInputDefinition,
+  InputRegistry,
+  TextInputProps,
+  TypedInputDefinition,
+} from "../../src/registry";
+
+describe("Input Registry", () => {
+  describe("createInputRegistry", () => {
+    let registry: InputRegistry;
+
+    beforeEach(() => {
+      registry = createInputRegistry();
+    });
+
+    it("creates an empty registry", () => {
+      expect(registry.getAll()).toHaveLength(0);
+    });
+
+    it("registers a new input type", () => {
+      registry.register(textInputDefinition);
+      expect(registry.has("text")).toBe(true);
+      expect(registry.get("text")).toBeDefined();
+    });
+
+    it("throws when registering duplicate input type", () => {
+      registry.register(textInputDefinition);
+      expect(() => registry.register(textInputDefinition)).toThrow(
+        'Input type "text" is already registered'
+      );
+    });
+
+    it("retrieves input by ID", () => {
+      registry.register(numberInputDefinition);
+      const input = registry.get("number");
+      expect(input).toBeDefined();
+      expect(input?.id).toBe("number");
+      expect(input?.name).toBe("Number Input");
+    });
+
+    it("returns undefined for unregistered ID", () => {
+      expect(registry.get("text")).toBeUndefined();
+    });
+
+    it("returns all registered inputs", () => {
+      registry.register(textInputDefinition);
+      registry.register(checkboxDefinition);
+      const all = registry.getAll();
+      expect(all).toHaveLength(2);
+      expect(all.map((i) => i.id)).toContain("text");
+      expect(all.map((i) => i.id)).toContain("checkbox");
+    });
+
+    it("filters inputs by category", () => {
+      registry.register(textInputDefinition);
+      registry.register(textAreaDefinition);
+      registry.register(checkboxDefinition);
+      registry.register(selectDefinition);
+
+      const textInputs = registry.getByCategory("text");
+      expect(textInputs).toHaveLength(2);
+      expect(textInputs.map((i) => i.id)).toContain("text");
+      expect(textInputs.map((i) => i.id)).toContain("textarea");
+
+      const choiceInputs = registry.getByCategory("choice");
+      expect(choiceInputs).toHaveLength(2);
+      expect(choiceInputs.map((i) => i.id)).toContain("checkbox");
+      expect(choiceInputs.map((i) => i.id)).toContain("select");
+    });
+
+    it("unregisters an input type", () => {
+      registry.register(textInputDefinition);
+      expect(registry.has("text")).toBe(true);
+
+      const result = registry.unregister("text");
+      expect(result).toBe(true);
+      expect(registry.has("text")).toBe(false);
+      expect(registry.get("text")).toBeUndefined();
+    });
+
+    it("returns false when unregistering non-existent type", () => {
+      const result = registry.unregister("text");
+      expect(result).toBe(false);
+    });
+
+    it("clears all registrations", () => {
+      registry.register(textInputDefinition);
+      registry.register(checkboxDefinition);
+      expect(registry.getAll()).toHaveLength(2);
+
+      registry.clear();
+      expect(registry.getAll()).toHaveLength(0);
+      expect(registry.has("text")).toBe(false);
+    });
+
+    it("allows re-registration after unregister", () => {
+      registry.register(textInputDefinition);
+      registry.unregister("text");
+
+      const customText: TypedInputDefinition<TextInputProps> = {
+        ...textInputDefinition,
+        name: "Custom Text Input",
+      };
+      registry.register(customText);
+
+      expect(registry.get("text")?.name).toBe("Custom Text Input");
+    });
+  });
+
+  describe("createDefaultInputRegistry", () => {
+    it("creates registry with all default inputs", () => {
+      const registry = createDefaultInputRegistry();
+      expect(registry.getAll()).toHaveLength(8);
+    });
+
+    it("includes all required input types", () => {
+      const registry = createDefaultInputRegistry();
+      expect(registry.has("text")).toBe(true);
+      expect(registry.has("textarea")).toBe(true);
+      expect(registry.has("number")).toBe(true);
+      expect(registry.has("checkbox")).toBe(true);
+      expect(registry.has("select")).toBe(true);
+      expect(registry.has("multiselect")).toBe(true);
+      expect(registry.has("date")).toBe(true);
+      expect(registry.has("file")).toBe(true);
+    });
+
+    it("creates isolated registry instances", () => {
+      const registry1 = createDefaultInputRegistry();
+      const registry2 = createDefaultInputRegistry();
+
+      registry1.unregister("text");
+      expect(registry1.has("text")).toBe(false);
+      expect(registry2.has("text")).toBe(true);
+    });
+  });
+
+  describe("getInputRegistry (global)", () => {
+    afterEach(() => {
+      resetGlobalRegistry();
+    });
+
+    it("returns a pre-populated registry", () => {
+      const registry = getInputRegistry();
+      expect(registry.getAll()).toHaveLength(8);
+    });
+
+    it("returns the same instance on multiple calls", () => {
+      const registry1 = getInputRegistry();
+      const registry2 = getInputRegistry();
+      expect(registry1).toBe(registry2);
+    });
+
+    it("persists modifications across calls", () => {
+      const registry = getInputRegistry();
+      registry.unregister("text");
+
+      const sameRegistry = getInputRegistry();
+      expect(sameRegistry.has("text")).toBe(false);
+    });
+  });
+
+  describe("resetGlobalRegistry", () => {
+    it("resets the global registry to fresh state", () => {
+      const registry = getInputRegistry();
+      registry.unregister("text");
+      registry.unregister("checkbox");
+
+      resetGlobalRegistry();
+
+      const freshRegistry = getInputRegistry();
+      expect(freshRegistry.has("text")).toBe(true);
+      expect(freshRegistry.has("checkbox")).toBe(true);
+    });
+  });
+
+  describe("Default Input Definitions", () => {
+    it("exports all default definitions", () => {
+      expect(defaultInputDefinitions).toHaveLength(8);
+    });
+
+    describe("textInputDefinition", () => {
+      it("has correct properties", () => {
+        expect(textInputDefinition.id).toBe("text");
+        expect(textInputDefinition.name).toBe("Text Input");
+        expect(textInputDefinition.icon).toBe("type");
+        expect(textInputDefinition.category).toBe("text");
+        expect(textInputDefinition.component).toBeDefined();
+      });
+
+      it("has appropriate compatible rules", () => {
+        expect(textInputDefinition.compatibleRules).toContain("required");
+        expect(textInputDefinition.compatibleRules).toContain("minLength");
+        expect(textInputDefinition.compatibleRules).toContain("maxLength");
+        expect(textInputDefinition.compatibleRules).toContain("pattern");
+        expect(textInputDefinition.compatibleRules).toContain("email");
+        expect(textInputDefinition.compatibleRules).toContain("url");
+      });
+
+      it("has correct default props", () => {
+        expect(textInputDefinition.defaultProps?.type).toBe("text");
+      });
+    });
+
+    describe("textAreaDefinition", () => {
+      it("has correct properties", () => {
+        expect(textAreaDefinition.id).toBe("textarea");
+        expect(textAreaDefinition.name).toBe("Text Area");
+        expect(textAreaDefinition.icon).toBe("align-left");
+        expect(textAreaDefinition.category).toBe("text");
+      });
+
+      it("has text-focused compatible rules", () => {
+        expect(textAreaDefinition.compatibleRules).toContain("required");
+        expect(textAreaDefinition.compatibleRules).toContain("minLength");
+        expect(textAreaDefinition.compatibleRules).toContain("maxLength");
+        expect(textAreaDefinition.compatibleRules).not.toContain("min");
+      });
+
+      it("has default rows", () => {
+        expect(textAreaDefinition.defaultProps?.rows).toBe(4);
+      });
+    });
+
+    describe("numberInputDefinition", () => {
+      it("has correct properties", () => {
+        expect(numberInputDefinition.id).toBe("number");
+        expect(numberInputDefinition.name).toBe("Number Input");
+        expect(numberInputDefinition.icon).toBe("hash");
+        expect(numberInputDefinition.category).toBe("text");
+      });
+
+      it("has numeric compatible rules", () => {
+        expect(numberInputDefinition.compatibleRules).toContain("required");
+        expect(numberInputDefinition.compatibleRules).toContain("min");
+        expect(numberInputDefinition.compatibleRules).toContain("max");
+        expect(numberInputDefinition.compatibleRules).toContain("step");
+        expect(numberInputDefinition.compatibleRules).toContain("integer");
+        expect(numberInputDefinition.compatibleRules).toContain("positive");
+      });
+    });
+
+    describe("checkboxDefinition", () => {
+      it("has correct properties", () => {
+        expect(checkboxDefinition.id).toBe("checkbox");
+        expect(checkboxDefinition.name).toBe("Checkbox");
+        expect(checkboxDefinition.icon).toBe("check-square");
+        expect(checkboxDefinition.category).toBe("choice");
+      });
+
+      it("has only required as compatible rule", () => {
+        expect(checkboxDefinition.compatibleRules).toEqual(["required"]);
+      });
+    });
+
+    describe("selectDefinition", () => {
+      it("has correct properties", () => {
+        expect(selectDefinition.id).toBe("select");
+        expect(selectDefinition.name).toBe("Select");
+        expect(selectDefinition.icon).toBe("chevron-down");
+        expect(selectDefinition.category).toBe("choice");
+      });
+
+      it("has correct default props", () => {
+        expect(selectDefinition.defaultProps?.options).toEqual([]);
+        expect(selectDefinition.defaultProps?.clearable).toBe(false);
+        expect(selectDefinition.defaultProps?.searchable).toBe(false);
+      });
+    });
+
+    describe("multiSelectDefinition", () => {
+      it("has correct properties", () => {
+        expect(multiSelectDefinition.id).toBe("multiselect");
+        expect(multiSelectDefinition.name).toBe("Multi-Select");
+        expect(multiSelectDefinition.icon).toBe("list-checks");
+        expect(multiSelectDefinition.category).toBe("choice");
+      });
+
+      it("has array-focused compatible rules", () => {
+        expect(multiSelectDefinition.compatibleRules).toContain("required");
+        expect(multiSelectDefinition.compatibleRules).toContain("minItems");
+        expect(multiSelectDefinition.compatibleRules).toContain("maxItems");
+      });
+    });
+
+    describe("datePickerDefinition", () => {
+      it("has correct properties", () => {
+        expect(datePickerDefinition.id).toBe("date");
+        expect(datePickerDefinition.name).toBe("Date Picker");
+        expect(datePickerDefinition.icon).toBe("calendar");
+        expect(datePickerDefinition.category).toBe("date");
+      });
+
+      it("has date-focused compatible rules", () => {
+        expect(datePickerDefinition.compatibleRules).toContain("required");
+        expect(datePickerDefinition.compatibleRules).toContain("minDate");
+        expect(datePickerDefinition.compatibleRules).toContain("maxDate");
+      });
+    });
+
+    describe("fileUploadDefinition", () => {
+      it("has correct properties", () => {
+        expect(fileUploadDefinition.id).toBe("file");
+        expect(fileUploadDefinition.name).toBe("File Upload");
+        expect(fileUploadDefinition.icon).toBe("upload");
+        expect(fileUploadDefinition.category).toBe("file");
+      });
+
+      it("has file-focused compatible rules", () => {
+        expect(fileUploadDefinition.compatibleRules).toContain("required");
+        expect(fileUploadDefinition.compatibleRules).toContain("fileSize");
+        expect(fileUploadDefinition.compatibleRules).toContain("fileType");
+        expect(fileUploadDefinition.compatibleRules).toContain("maxItems");
+      });
+
+      it("has correct default props", () => {
+        expect(fileUploadDefinition.defaultProps?.multiple).toBe(false);
+      });
+    });
+  });
+
+  describe("Placeholder Components", () => {
+    it("all definitions have components that return null", () => {
+      for (const def of defaultInputDefinitions) {
+        const Component = def.component;
+        const result = Component({
+          id: "test",
+          name: "test",
+          value: undefined,
+          onChange: () => {},
+        } as never);
+        expect(result).toBeNull();
+      }
+    });
+  });
+
+  describe("Category Grouping", () => {
+    it("groups text inputs correctly", () => {
+      const registry = createDefaultInputRegistry();
+      const textInputs = registry.getByCategory("text");
+      expect(textInputs.map((i) => i.id).sort()).toEqual([
+        "number",
+        "text",
+        "textarea",
+      ]);
+    });
+
+    it("groups choice inputs correctly", () => {
+      const registry = createDefaultInputRegistry();
+      const choiceInputs = registry.getByCategory("choice");
+      expect(choiceInputs.map((i) => i.id).sort()).toEqual([
+        "checkbox",
+        "multiselect",
+        "select",
+      ]);
+    });
+
+    it("groups date inputs correctly", () => {
+      const registry = createDefaultInputRegistry();
+      const dateInputs = registry.getByCategory("date");
+      expect(dateInputs.map((i) => i.id)).toEqual(["date"]);
+    });
+
+    it("groups file inputs correctly", () => {
+      const registry = createDefaultInputRegistry();
+      const fileInputs = registry.getByCategory("file");
+      expect(fileInputs.map((i) => i.id)).toEqual(["file"]);
+    });
+  });
+});

--- a/packages/core/test/registry/types.test.ts
+++ b/packages/core/test/registry/types.test.ts
@@ -1,0 +1,391 @@
+import { describe, expect, it } from "vitest";
+import type {
+  BaseInputDefinition,
+  BaseInputProps,
+  CheckboxProps,
+  DatePickerProps,
+  FileUploadProps,
+  InputProps,
+  InputRegistry,
+  InputTypeId,
+  MultiSelectProps,
+  NumberInputProps,
+  SelectOption,
+  SelectProps,
+  TextAreaProps,
+  TextInputProps,
+  ValidationRuleId,
+} from "../../src/registry";
+
+describe("Registry Types", () => {
+  describe("InputTypeId", () => {
+    it("supports all required input types", () => {
+      const types: InputTypeId[] = [
+        "text",
+        "textarea",
+        "number",
+        "checkbox",
+        "select",
+        "multiselect",
+        "date",
+        "file",
+      ];
+      expect(types).toHaveLength(8);
+    });
+  });
+
+  describe("ValidationRuleId", () => {
+    it("supports common validation rules", () => {
+      const rules: ValidationRuleId[] = [
+        "required",
+        "minLength",
+        "maxLength",
+        "pattern",
+        "email",
+        "url",
+        "uuid",
+        "min",
+        "max",
+        "step",
+        "integer",
+        "positive",
+        "negative",
+        "minDate",
+        "maxDate",
+        "minItems",
+        "maxItems",
+        "fileSize",
+        "fileType",
+      ];
+      expect(rules).toHaveLength(19);
+    });
+  });
+
+  describe("BaseInputProps", () => {
+    it("accepts minimal required props", () => {
+      const props: BaseInputProps = {
+        id: "field-1",
+        name: "username",
+        value: "test",
+        onChange: () => {},
+      };
+      expect(props.id).toBe("field-1");
+      expect(props.name).toBe("username");
+    });
+
+    it("accepts all optional props", () => {
+      const props: BaseInputProps = {
+        id: "field-1",
+        name: "username",
+        value: "test",
+        onChange: () => {},
+        onBlur: () => {},
+        disabled: true,
+        readOnly: true,
+        placeholder: "Enter username",
+        "aria-label": "Username field",
+        "aria-describedby": "username-help",
+        "aria-invalid": true,
+        "aria-errormessage": "username-error",
+      };
+      expect(props.disabled).toBe(true);
+      expect(props["aria-invalid"]).toBe(true);
+    });
+  });
+
+  describe("TextInputProps", () => {
+    it("accepts text input specific props", () => {
+      const props: TextInputProps = {
+        id: "email-field",
+        name: "email",
+        value: "user@example.com",
+        onChange: () => {},
+        type: "email",
+        minLength: 5,
+        maxLength: 100,
+        pattern: "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$",
+        autoComplete: "email",
+      };
+      expect(props.type).toBe("email");
+      expect(props.pattern).toBeDefined();
+    });
+
+    it("restricts type to valid HTML input types", () => {
+      const types: TextInputProps["type"][] = [
+        "text",
+        "email",
+        "url",
+        "tel",
+        "password",
+      ];
+      expect(types).toHaveLength(5);
+    });
+  });
+
+  describe("TextAreaProps", () => {
+    it("accepts textarea specific props", () => {
+      const props: TextAreaProps = {
+        id: "bio-field",
+        name: "bio",
+        value: "My biography",
+        onChange: () => {},
+        minLength: 10,
+        maxLength: 1000,
+        rows: 6,
+      };
+      expect(props.rows).toBe(6);
+    });
+  });
+
+  describe("NumberInputProps", () => {
+    it("accepts number input specific props", () => {
+      const props: NumberInputProps = {
+        id: "age-field",
+        name: "age",
+        value: 25,
+        onChange: () => {},
+        min: 0,
+        max: 150,
+        step: 1,
+      };
+      expect(props.min).toBe(0);
+      expect(props.max).toBe(150);
+    });
+
+    it("accepts null value for empty state", () => {
+      const props: NumberInputProps = {
+        id: "optional-number",
+        name: "count",
+        value: null,
+        onChange: () => {},
+      };
+      expect(props.value).toBeNull();
+    });
+  });
+
+  describe("CheckboxProps", () => {
+    it("accepts checkbox specific props", () => {
+      const props: CheckboxProps = {
+        id: "terms-field",
+        name: "acceptTerms",
+        value: true,
+        onChange: () => {},
+        label: "I accept the terms and conditions",
+      };
+      expect(props.label).toBeDefined();
+      expect(props.value).toBe(true);
+    });
+  });
+
+  describe("SelectOption", () => {
+    it("accepts basic option", () => {
+      const option: SelectOption = {
+        value: "admin",
+        label: "Administrator",
+      };
+      expect(option.value).toBe("admin");
+    });
+
+    it("accepts disabled option", () => {
+      const option: SelectOption = {
+        value: "deprecated",
+        label: "Deprecated Role",
+        disabled: true,
+      };
+      expect(option.disabled).toBe(true);
+    });
+  });
+
+  describe("SelectProps", () => {
+    it("accepts select specific props", () => {
+      const props: SelectProps = {
+        id: "role-field",
+        name: "role",
+        value: "user",
+        onChange: () => {},
+        options: [
+          { value: "admin", label: "Admin" },
+          { value: "user", label: "User" },
+        ],
+        clearable: true,
+        searchable: true,
+      };
+      expect(props.options).toHaveLength(2);
+      expect(props.clearable).toBe(true);
+    });
+
+    it("accepts null value for unselected state", () => {
+      const props: SelectProps = {
+        id: "unselected",
+        name: "choice",
+        value: null,
+        onChange: () => {},
+        options: [],
+      };
+      expect(props.value).toBeNull();
+    });
+  });
+
+  describe("MultiSelectProps", () => {
+    it("accepts multi-select specific props", () => {
+      const props: MultiSelectProps = {
+        id: "tags-field",
+        name: "tags",
+        value: ["react", "typescript"],
+        onChange: () => {},
+        options: [
+          { value: "react", label: "React" },
+          { value: "typescript", label: "TypeScript" },
+          { value: "node", label: "Node.js" },
+        ],
+        minItems: 1,
+        maxItems: 5,
+        searchable: true,
+      };
+      expect(props.value).toHaveLength(2);
+      expect(props.minItems).toBe(1);
+    });
+  });
+
+  describe("DatePickerProps", () => {
+    it("accepts date picker specific props", () => {
+      const props: DatePickerProps = {
+        id: "dob-field",
+        name: "dateOfBirth",
+        value: new Date("1990-01-15"),
+        onChange: () => {},
+        minDate: new Date("1900-01-01"),
+        maxDate: new Date(),
+        format: "yyyy-MM-dd",
+      };
+      expect(props.format).toBe("yyyy-MM-dd");
+    });
+
+    it("accepts null value for empty state", () => {
+      const props: DatePickerProps = {
+        id: "optional-date",
+        name: "expiry",
+        value: null,
+        onChange: () => {},
+      };
+      expect(props.value).toBeNull();
+    });
+  });
+
+  describe("FileUploadProps", () => {
+    it("accepts file upload specific props", () => {
+      const props: FileUploadProps = {
+        id: "avatar-field",
+        name: "avatar",
+        value: null,
+        onChange: () => {},
+        multiple: false,
+        accept: [
+          { mimeType: "image/*", extensions: [".jpg", ".png", ".gif"] },
+        ],
+        maxSize: 5 * 1024 * 1024, // 5MB
+      };
+      expect(props.maxSize).toBe(5 * 1024 * 1024);
+    });
+
+    it("accepts multiple files config", () => {
+      const props: FileUploadProps = {
+        id: "documents-field",
+        name: "documents",
+        value: null,
+        onChange: () => {},
+        multiple: true,
+        maxFiles: 10,
+        accept: [{ mimeType: "application/pdf" }],
+      };
+      expect(props.multiple).toBe(true);
+      expect(props.maxFiles).toBe(10);
+    });
+  });
+
+  describe("InputProps union", () => {
+    it("allows discriminating between input types", () => {
+      const textProps: InputProps = {
+        id: "text",
+        name: "text",
+        value: "hello",
+        onChange: () => {},
+        type: "text",
+      } satisfies TextInputProps;
+
+      const numberProps: InputProps = {
+        id: "number",
+        name: "number",
+        value: 42,
+        onChange: () => {},
+        min: 0,
+      } satisfies NumberInputProps;
+
+      expect(textProps).toBeDefined();
+      expect(numberProps).toBeDefined();
+    });
+  });
+
+  describe("BaseInputDefinition", () => {
+    it("accepts complete definition", () => {
+      const mockComponent = () => null;
+      const definition: BaseInputDefinition = {
+        id: "text",
+        name: "Text Input",
+        icon: "type",
+        component: mockComponent,
+        compatibleRules: ["required", "minLength", "maxLength"],
+        defaultProps: { type: "text" },
+        description: "A text input field",
+        category: "text",
+      };
+      expect(definition.id).toBe("text");
+      expect(definition.compatibleRules).toContain("required");
+    });
+
+    it("accepts minimal definition without optional fields", () => {
+      const definition: BaseInputDefinition = {
+        id: "text",
+        name: "Text Input",
+        icon: "type",
+        component: () => null,
+        compatibleRules: [],
+      };
+      expect(definition.defaultProps).toBeUndefined();
+      expect(definition.description).toBeUndefined();
+    });
+
+    it("supports all category values", () => {
+      const categories: BaseInputDefinition["category"][] = [
+        "text",
+        "choice",
+        "date",
+        "file",
+        "other",
+        undefined,
+      ];
+      expect(categories).toHaveLength(6);
+    });
+  });
+
+  describe("InputRegistry interface", () => {
+    it("defines all required methods", () => {
+      const mockRegistry: InputRegistry = {
+        register: () => {},
+        get: () => undefined,
+        getAll: () => [],
+        getByCategory: () => [],
+        has: () => false,
+        unregister: () => false,
+        clear: () => {},
+      };
+      expect(mockRegistry.register).toBeDefined();
+      expect(mockRegistry.get).toBeDefined();
+      expect(mockRegistry.getAll).toBeDefined();
+      expect(mockRegistry.getByCategory).toBeDefined();
+      expect(mockRegistry.has).toBeDefined();
+      expect(mockRegistry.unregister).toBeDefined();
+      expect(mockRegistry.clear).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements the Base Input Registry for the form designer canvas (Issue #26 / PZ-001).

### Changes

- **Types** (`packages/core/src/registry/types.ts`):
  - `InputTypeId` - 8 input types: text, textarea, number, checkbox, select, multiselect, date, file
  - `ValidationRuleId` - 19 validation rule identifiers
  - `BaseInputProps<T>` - Generic base props for all inputs
  - Specific prop interfaces for each input type
  - `BaseInputDefinition` and `InputRegistry` interfaces

- **Registry** (`packages/core/src/registry/inputs.ts`):
  - `createInputRegistry()` - Factory for isolated registry instances
  - `createDefaultInputRegistry()` - Pre-populated with 8 default inputs
  - `getInputRegistry()` / `resetGlobalRegistry()` - Global singleton management
  - 8 exported input definitions with compatible validation rules

- **Tests** (`packages/core/test/registry/`):
  - 72 tests covering types, registry operations, and all input definitions

### Test Plan

- [x] `pnpm build` passes
- [x] `pnpm test:unit` passes (72 tests)
- [x] `pnpm typecheck` passes

Closes #26

---
Generated with [Claude Code](https://claude.ai/code)