### PR TITLE
feat(core): implement validation rule registry (PZ-001b)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,6 +32,39 @@ export {
   textInputDefinition,
 } from "./registry";
 
+// Validation Rule Registry (PZ-001b)
+export {
+  // Registry factory and utilities
+  createValidationRuleRegistry,
+  createDefaultValidationRuleRegistry,
+  getValidationRuleRegistry,
+  resetGlobalRuleRegistry,
+  applyValidationRules,
+  // Default rule definitions - Constraint rules
+  defaultValidationRuleDefinitions,
+  requiredRuleDefinition,
+  minItemsRuleDefinition,
+  maxItemsRuleDefinition,
+  positiveRuleDefinition,
+  negativeRuleDefinition,
+  fileSizeRuleDefinition,
+  fileTypeRuleDefinition,
+  // Format rules
+  patternRuleDefinition,
+  emailRuleDefinition,
+  urlRuleDefinition,
+  uuidRuleDefinition,
+  integerRuleDefinition,
+  // Range rules
+  minLengthRuleDefinition,
+  maxLengthRuleDefinition,
+  minRuleDefinition,
+  maxRuleDefinition,
+  stepRuleDefinition,
+  minDateRuleDefinition,
+  maxDateRuleDefinition,
+} from "./registry";
+
 export type {
   // Core types
   AcceptedFile,
@@ -53,4 +86,12 @@ export type {
   SelectProps,
   TextAreaProps,
   TextInputProps,
+  // Validation rule types
+  AppliedRule,
+  RuleConfigProps,
+  RuleConfigComponentRef,
+  ValidationRuleCategory,
+  ValidationRuleDefinition,
+  ValidationRuleRegistry,
+  ZodSchemaTransformer,
 } from "./registry";

--- a/packages/core/src/registry/index.ts
+++ b/packages/core/src/registry/index.ts
@@ -26,6 +26,13 @@ export type {
   TextInputProps,
   TypedInputDefinition,
   ValidationRuleId,
+  // Validation rule types
+  RuleConfigProps,
+  RuleConfigComponentRef,
+  ValidationRuleCategory,
+  ValidationRuleDefinition,
+  ValidationRuleRegistry,
+  ZodSchemaTransformer,
 } from "./types";
 
 // Registry factory and utilities
@@ -48,3 +55,49 @@ export {
   textAreaDefinition,
   textInputDefinition,
 } from "./inputs";
+
+/**
+ * Validation Rule Registry
+ *
+ * Provides a registry of validation rules for form fields.
+ * Each rule defines how to transform a Zod schema with the validation.
+ */
+
+// Validation rule registry factory and utilities
+export {
+  createValidationRuleRegistry,
+  createDefaultValidationRuleRegistry,
+  getValidationRuleRegistry,
+  resetGlobalRuleRegistry,
+  applyValidationRules,
+} from "./rules";
+
+// Re-export AppliedRule type
+export type { AppliedRule } from "./rules";
+
+// Default validation rule definitions (for customization/extension)
+export {
+  defaultValidationRuleDefinitions,
+  // Constraint rules
+  requiredRuleDefinition,
+  minItemsRuleDefinition,
+  maxItemsRuleDefinition,
+  positiveRuleDefinition,
+  negativeRuleDefinition,
+  fileSizeRuleDefinition,
+  fileTypeRuleDefinition,
+  // Format rules
+  patternRuleDefinition,
+  emailRuleDefinition,
+  urlRuleDefinition,
+  uuidRuleDefinition,
+  integerRuleDefinition,
+  // Range rules
+  minLengthRuleDefinition,
+  maxLengthRuleDefinition,
+  minRuleDefinition,
+  maxRuleDefinition,
+  stepRuleDefinition,
+  minDateRuleDefinition,
+  maxDateRuleDefinition,
+} from "./rules";

--- a/packages/core/src/registry/rules.ts
+++ b/packages/core/src/registry/rules.ts
@@ -1,0 +1,690 @@
+import { z } from "zod";
+import type {
+  InputTypeId,
+  ValidationRuleCategory,
+  ValidationRuleDefinition,
+  ValidationRuleId,
+  ValidationRuleRegistry,
+} from "./types";
+
+/**
+ * Creates a new validation rule registry instance.
+ * The registry stores rule definitions and provides methods to manage them.
+ */
+export function createValidationRuleRegistry(): ValidationRuleRegistry {
+  const registry = new Map<ValidationRuleId, ValidationRuleDefinition>();
+
+  return {
+    register(definition: ValidationRuleDefinition): void {
+      if (registry.has(definition.id)) {
+        throw new Error(
+          `Validation rule "${definition.id}" is already registered. ` +
+            "Use unregister() first if you want to replace it."
+        );
+      }
+      registry.set(definition.id, definition);
+    },
+
+    get(id: ValidationRuleId): ValidationRuleDefinition | undefined {
+      return registry.get(id);
+    },
+
+    getAll(): ValidationRuleDefinition[] {
+      return Array.from(registry.values());
+    },
+
+    getByCategory(category: ValidationRuleCategory): ValidationRuleDefinition[] {
+      return Array.from(registry.values()).filter(
+        (def) => def.category === category
+      );
+    },
+
+    getCompatibleRules(inputType: InputTypeId): ValidationRuleDefinition[] {
+      return Array.from(registry.values()).filter((def) =>
+        def.compatibleInputs.includes(inputType)
+      );
+    },
+
+    has(id: ValidationRuleId): boolean {
+      return registry.has(id);
+    },
+
+    unregister(id: ValidationRuleId): boolean {
+      return registry.delete(id);
+    },
+
+    clear(): void {
+      registry.clear();
+    },
+  };
+}
+
+// ============================================================================
+// Constraint Rules
+// ============================================================================
+
+/**
+ * Required rule - value must be present (non-empty).
+ * Compatible with all input types.
+ */
+export const requiredRuleDefinition: ValidationRuleDefinition = {
+  id: "required",
+  name: "Required",
+  icon: "asterisk",
+  category: "constraint",
+  compatibleInputs: [
+    "text",
+    "textarea",
+    "number",
+    "checkbox",
+    "select",
+    "multiselect",
+    "date",
+    "file",
+  ],
+  configComponent: "RequiredConfig",
+  description: "Field must have a value",
+  defaultConfig: {},
+  toZod: (_config: unknown) => (schema: unknown) => {
+    // For strings, use min(1) to require non-empty
+    if (schema instanceof z.ZodString) {
+      return schema.min(1, "This field is required");
+    }
+    // For arrays (multiselect, file[]), use min(1)
+    if (schema instanceof z.ZodArray) {
+      return schema.min(1, "At least one item is required");
+    }
+    // For booleans (checkbox), refine to require true
+    if (schema instanceof z.ZodBoolean) {
+      return schema.refine((val) => val === true, "This field is required");
+    }
+    // For nullable types, make them non-nullable
+    if (schema instanceof z.ZodNullable) {
+      return schema.unwrap();
+    }
+    // For optional types, make them required
+    if (schema instanceof z.ZodOptional) {
+      return schema.unwrap();
+    }
+    return schema;
+  },
+};
+
+/**
+ * Min Items rule - array must have at least N items.
+ * Compatible with multi-select and file (multiple).
+ */
+export const minItemsRuleDefinition: ValidationRuleDefinition = {
+  id: "minItems",
+  name: "Min Items",
+  icon: "list-minus",
+  category: "constraint",
+  compatibleInputs: ["multiselect", "file"],
+  configComponent: "MinItemsConfig",
+  description: "Minimum number of items required",
+  defaultConfig: { min: 1 },
+  toZod: (config: unknown) => (schema: unknown) => {
+    const { min } = config as { min: number };
+    if (schema instanceof z.ZodArray) {
+      return schema.min(min, `At least ${min} item(s) required`);
+    }
+    return schema;
+  },
+};
+
+/**
+ * Max Items rule - array must have at most N items.
+ * Compatible with multi-select and file (multiple).
+ */
+export const maxItemsRuleDefinition: ValidationRuleDefinition = {
+  id: "maxItems",
+  name: "Max Items",
+  icon: "list-plus",
+  category: "constraint",
+  compatibleInputs: ["multiselect", "file"],
+  configComponent: "MaxItemsConfig",
+  description: "Maximum number of items allowed",
+  defaultConfig: { max: 10 },
+  toZod: (config: unknown) => (schema: unknown) => {
+    const { max } = config as { max: number };
+    if (schema instanceof z.ZodArray) {
+      return schema.max(max, `At most ${max} item(s) allowed`);
+    }
+    return schema;
+  },
+};
+
+// ============================================================================
+// Text Length Rules (Range category)
+// ============================================================================
+
+/**
+ * Min Length rule - string must be at least N characters.
+ * Compatible with text inputs.
+ */
+export const minLengthRuleDefinition: ValidationRuleDefinition = {
+  id: "minLength",
+  name: "Min Length",
+  icon: "text-cursor-input",
+  category: "range",
+  compatibleInputs: ["text", "textarea"],
+  configComponent: "MinLengthConfig",
+  description: "Minimum character count",
+  defaultConfig: { length: 1 },
+  toZod: (config: unknown) => (schema: unknown) => {
+    const { length } = config as { length: number };
+    if (schema instanceof z.ZodString) {
+      return schema.min(length, `Must be at least ${length} character(s)`);
+    }
+    return schema;
+  },
+};
+
+/**
+ * Max Length rule - string must be at most N characters.
+ * Compatible with text inputs.
+ */
+export const maxLengthRuleDefinition: ValidationRuleDefinition = {
+  id: "maxLength",
+  name: "Max Length",
+  icon: "text-cursor",
+  category: "range",
+  compatibleInputs: ["text", "textarea"],
+  configComponent: "MaxLengthConfig",
+  description: "Maximum character count",
+  defaultConfig: { length: 255 },
+  toZod: (config: unknown) => (schema: unknown) => {
+    const { length } = config as { length: number };
+    if (schema instanceof z.ZodString) {
+      return schema.max(length, `Must be at most ${length} character(s)`);
+    }
+    return schema;
+  },
+};
+
+// ============================================================================
+// Format Rules
+// ============================================================================
+
+/**
+ * Pattern rule - string must match a regex pattern.
+ * Compatible with text inputs.
+ */
+export const patternRuleDefinition: ValidationRuleDefinition = {
+  id: "pattern",
+  name: "Pattern",
+  icon: "regex",
+  category: "format",
+  compatibleInputs: ["text", "textarea"],
+  configComponent: "PatternConfig",
+  description: "Must match a regular expression pattern",
+  defaultConfig: { pattern: ".*", message: "Invalid format" },
+  toZod: (config: unknown) => (schema: unknown) => {
+    const { pattern, message } = config as { pattern: string; message?: string };
+    if (schema instanceof z.ZodString) {
+      return schema.regex(new RegExp(pattern), message ?? "Invalid format");
+    }
+    return schema;
+  },
+};
+
+/**
+ * Email rule - string must be a valid email address.
+ * Compatible with text input.
+ */
+export const emailRuleDefinition: ValidationRuleDefinition = {
+  id: "email",
+  name: "Email",
+  icon: "mail",
+  category: "format",
+  compatibleInputs: ["text"],
+  configComponent: "EmailConfig",
+  description: "Must be a valid email address",
+  defaultConfig: {},
+  toZod: (_config: unknown) => (schema: unknown) => {
+    if (schema instanceof z.ZodString) {
+      return schema.email("Must be a valid email address");
+    }
+    return schema;
+  },
+};
+
+/**
+ * URL rule - string must be a valid URL.
+ * Compatible with text input.
+ */
+export const urlRuleDefinition: ValidationRuleDefinition = {
+  id: "url",
+  name: "URL",
+  icon: "link",
+  category: "format",
+  compatibleInputs: ["text"],
+  configComponent: "UrlConfig",
+  description: "Must be a valid URL",
+  defaultConfig: {},
+  toZod: (_config: unknown) => (schema: unknown) => {
+    if (schema instanceof z.ZodString) {
+      return schema.url("Must be a valid URL");
+    }
+    return schema;
+  },
+};
+
+/**
+ * UUID rule - string must be a valid UUID.
+ * Compatible with text input.
+ */
+export const uuidRuleDefinition: ValidationRuleDefinition = {
+  id: "uuid",
+  name: "UUID",
+  icon: "fingerprint",
+  category: "format",
+  compatibleInputs: ["text"],
+  configComponent: "UuidConfig",
+  description: "Must be a valid UUID",
+  defaultConfig: {},
+  toZod: (_config: unknown) => (schema: unknown) => {
+    if (schema instanceof z.ZodString) {
+      return schema.uuid("Must be a valid UUID");
+    }
+    return schema;
+  },
+};
+
+// ============================================================================
+// Numeric Range Rules
+// ============================================================================
+
+/**
+ * Min rule - number must be at least N.
+ * Compatible with number input.
+ */
+export const minRuleDefinition: ValidationRuleDefinition = {
+  id: "min",
+  name: "Minimum",
+  icon: "arrow-down-to-line",
+  category: "range",
+  compatibleInputs: ["number"],
+  configComponent: "MinConfig",
+  description: "Minimum numeric value",
+  defaultConfig: { value: 0 },
+  toZod: (config: unknown) => (schema: unknown) => {
+    const { value } = config as { value: number };
+    if (schema instanceof z.ZodNumber) {
+      return schema.min(value, `Must be at least ${value}`);
+    }
+    return schema;
+  },
+};
+
+/**
+ * Max rule - number must be at most N.
+ * Compatible with number input.
+ */
+export const maxRuleDefinition: ValidationRuleDefinition = {
+  id: "max",
+  name: "Maximum",
+  icon: "arrow-up-to-line",
+  category: "range",
+  compatibleInputs: ["number"],
+  configComponent: "MaxConfig",
+  description: "Maximum numeric value",
+  defaultConfig: { value: 100 },
+  toZod: (config: unknown) => (schema: unknown) => {
+    const { value } = config as { value: number };
+    if (schema instanceof z.ZodNumber) {
+      return schema.max(value, `Must be at most ${value}`);
+    }
+    return schema;
+  },
+};
+
+/**
+ * Step rule - number must be a multiple of N.
+ * Compatible with number input.
+ */
+export const stepRuleDefinition: ValidationRuleDefinition = {
+  id: "step",
+  name: "Step",
+  icon: "git-commit-vertical",
+  category: "range",
+  compatibleInputs: ["number"],
+  configComponent: "StepConfig",
+  description: "Value must be a multiple of the step",
+  defaultConfig: { step: 1 },
+  toZod: (config: unknown) => (schema: unknown) => {
+    const { step } = config as { step: number };
+    if (schema instanceof z.ZodNumber) {
+      return schema.multipleOf(step, `Must be a multiple of ${step}`);
+    }
+    return schema;
+  },
+};
+
+/**
+ * Integer rule - number must be a whole number.
+ * Compatible with number input.
+ */
+export const integerRuleDefinition: ValidationRuleDefinition = {
+  id: "integer",
+  name: "Integer",
+  icon: "hash",
+  category: "format",
+  compatibleInputs: ["number"],
+  configComponent: "IntegerConfig",
+  description: "Must be a whole number",
+  defaultConfig: {},
+  toZod: (_config: unknown) => (schema: unknown) => {
+    if (schema instanceof z.ZodNumber) {
+      return schema.int("Must be a whole number");
+    }
+    return schema;
+  },
+};
+
+/**
+ * Positive rule - number must be positive (> 0).
+ * Compatible with number input.
+ */
+export const positiveRuleDefinition: ValidationRuleDefinition = {
+  id: "positive",
+  name: "Positive",
+  icon: "plus",
+  category: "constraint",
+  compatibleInputs: ["number"],
+  configComponent: "PositiveConfig",
+  description: "Must be a positive number",
+  defaultConfig: {},
+  toZod: (_config: unknown) => (schema: unknown) => {
+    if (schema instanceof z.ZodNumber) {
+      return schema.positive("Must be a positive number");
+    }
+    return schema;
+  },
+};
+
+/**
+ * Negative rule - number must be negative (< 0).
+ * Compatible with number input.
+ */
+export const negativeRuleDefinition: ValidationRuleDefinition = {
+  id: "negative",
+  name: "Negative",
+  icon: "minus",
+  category: "constraint",
+  compatibleInputs: ["number"],
+  configComponent: "NegativeConfig",
+  description: "Must be a negative number",
+  defaultConfig: {},
+  toZod: (_config: unknown) => (schema: unknown) => {
+    if (schema instanceof z.ZodNumber) {
+      return schema.negative("Must be a negative number");
+    }
+    return schema;
+  },
+};
+
+// ============================================================================
+// Date Range Rules
+// ============================================================================
+
+/**
+ * Min Date rule - date must be on or after a minimum date.
+ * Compatible with date picker.
+ */
+export const minDateRuleDefinition: ValidationRuleDefinition = {
+  id: "minDate",
+  name: "Min Date",
+  icon: "calendar-arrow-up",
+  category: "range",
+  compatibleInputs: ["date"],
+  configComponent: "MinDateConfig",
+  description: "Earliest allowed date",
+  defaultConfig: { date: null },
+  toZod: (config: unknown) => (schema: unknown) => {
+    const { date } = config as { date: string | Date | null };
+    if (schema instanceof z.ZodDate && date != null) {
+      const minDate = typeof date === "string" ? new Date(date) : date;
+      return schema.min(minDate, `Date must be on or after ${minDate.toLocaleDateString()}`);
+    }
+    return schema;
+  },
+};
+
+/**
+ * Max Date rule - date must be on or before a maximum date.
+ * Compatible with date picker.
+ */
+export const maxDateRuleDefinition: ValidationRuleDefinition = {
+  id: "maxDate",
+  name: "Max Date",
+  icon: "calendar-arrow-down",
+  category: "range",
+  compatibleInputs: ["date"],
+  configComponent: "MaxDateConfig",
+  description: "Latest allowed date",
+  defaultConfig: { date: null },
+  toZod: (config: unknown) => (schema: unknown) => {
+    const { date } = config as { date: string | Date | null };
+    if (schema instanceof z.ZodDate && date != null) {
+      const maxDate = typeof date === "string" ? new Date(date) : date;
+      return schema.max(maxDate, `Date must be on or before ${maxDate.toLocaleDateString()}`);
+    }
+    return schema;
+  },
+};
+
+// ============================================================================
+// File Rules
+// ============================================================================
+
+/**
+ * File Size rule - file must not exceed a maximum size.
+ * Compatible with file upload.
+ */
+export const fileSizeRuleDefinition: ValidationRuleDefinition = {
+  id: "fileSize",
+  name: "File Size",
+  icon: "hard-drive",
+  category: "constraint",
+  compatibleInputs: ["file"],
+  configComponent: "FileSizeConfig",
+  description: "Maximum file size in bytes",
+  defaultConfig: { maxBytes: 5 * 1024 * 1024 }, // 5MB default
+  toZod: (config: unknown) => (schema: unknown) => {
+    const { maxBytes } = config as { maxBytes: number };
+    // File validation happens at a higher level since Zod doesn't have File type
+    // We attach metadata that the form runtime uses for client-side validation
+    if (schema instanceof z.ZodType) {
+      return schema.refine(
+        (val) => {
+          if (val instanceof File) {
+            return val.size <= maxBytes;
+          }
+          if (Array.isArray(val)) {
+            return val.every((f) => f instanceof File && f.size <= maxBytes);
+          }
+          return true;
+        },
+        { message: `File size must not exceed ${formatBytes(maxBytes)}` }
+      );
+    }
+    return schema;
+  },
+};
+
+/**
+ * File Type rule - file must match allowed MIME types.
+ * Compatible with file upload.
+ */
+export const fileTypeRuleDefinition: ValidationRuleDefinition = {
+  id: "fileType",
+  name: "File Type",
+  icon: "file-type",
+  category: "constraint",
+  compatibleInputs: ["file"],
+  configComponent: "FileTypeConfig",
+  description: "Allowed file types (MIME patterns)",
+  defaultConfig: { types: ["image/*", "application/pdf"] },
+  toZod: (config: unknown) => (schema: unknown) => {
+    const { types } = config as { types: string[] };
+    if (schema instanceof z.ZodType) {
+      return schema.refine(
+        (val) => {
+          if (val instanceof File) {
+            return matchesMimeType(val.type, types);
+          }
+          if (Array.isArray(val)) {
+            return val.every(
+              (f) => f instanceof File && matchesMimeType(f.type, types)
+            );
+          }
+          return true;
+        },
+        { message: `File type must be one of: ${types.join(", ")}` }
+      );
+    }
+    return schema;
+  },
+};
+
+// ============================================================================
+// Utility Functions
+// ============================================================================
+
+/**
+ * Format bytes into human-readable string.
+ */
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return "0 Bytes";
+  const k = 1024;
+  const sizes = ["Bytes", "KB", "MB", "GB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${Number.parseFloat((bytes / k ** i).toFixed(2))} ${sizes[i]}`;
+}
+
+/**
+ * Check if a MIME type matches any of the allowed patterns.
+ * Supports wildcards like "image/*".
+ */
+function matchesMimeType(mimeType: string, patterns: string[]): boolean {
+  for (const pattern of patterns) {
+    if (pattern === mimeType) return true;
+    if (pattern.endsWith("/*")) {
+      const prefix = pattern.slice(0, -2);
+      if (mimeType.startsWith(`${prefix}/`)) return true;
+    }
+  }
+  return false;
+}
+
+// ============================================================================
+// Default Rule Definitions
+// ============================================================================
+
+/**
+ * All default validation rule definitions.
+ */
+export const defaultValidationRuleDefinitions: ValidationRuleDefinition[] = [
+  // Constraint rules
+  requiredRuleDefinition,
+  minItemsRuleDefinition,
+  maxItemsRuleDefinition,
+  positiveRuleDefinition,
+  negativeRuleDefinition,
+  fileSizeRuleDefinition,
+  fileTypeRuleDefinition,
+  // Format rules
+  patternRuleDefinition,
+  emailRuleDefinition,
+  urlRuleDefinition,
+  uuidRuleDefinition,
+  integerRuleDefinition,
+  // Range rules
+  minLengthRuleDefinition,
+  maxLengthRuleDefinition,
+  minRuleDefinition,
+  maxRuleDefinition,
+  stepRuleDefinition,
+  minDateRuleDefinition,
+  maxDateRuleDefinition,
+];
+
+/**
+ * Creates a registry pre-populated with all default validation rules.
+ */
+export function createDefaultValidationRuleRegistry(): ValidationRuleRegistry {
+  const registry = createValidationRuleRegistry();
+
+  for (const definition of defaultValidationRuleDefinitions) {
+    registry.register(definition);
+  }
+
+  return registry;
+}
+
+/**
+ * Global default registry instance.
+ * Use createValidationRuleRegistry() or createDefaultValidationRuleRegistry()
+ * for isolated instances.
+ */
+let globalRuleRegistry: ValidationRuleRegistry | null = null;
+
+/**
+ * Gets the global validation rule registry, creating it if necessary.
+ * The global registry is pre-populated with default rules.
+ */
+export function getValidationRuleRegistry(): ValidationRuleRegistry {
+  if (!globalRuleRegistry) {
+    globalRuleRegistry = createDefaultValidationRuleRegistry();
+  }
+  return globalRuleRegistry;
+}
+
+/**
+ * Resets the global rule registry to a fresh default state.
+ * Primarily useful for testing.
+ */
+export function resetGlobalRuleRegistry(): void {
+  globalRuleRegistry = null;
+}
+
+// ============================================================================
+// Schema Builder Utilities
+// ============================================================================
+
+/**
+ * Configuration for an applied validation rule.
+ */
+export interface AppliedRule {
+  /** The rule ID */
+  ruleId: ValidationRuleId;
+  /** The rule configuration */
+  config: unknown;
+}
+
+/**
+ * Apply multiple validation rules to a Zod schema.
+ * Rules are applied in order.
+ *
+ * @param schema - The base Zod schema
+ * @param rules - Array of rules to apply
+ * @param registry - The rule registry to use (defaults to global)
+ * @returns The schema with all rules applied
+ */
+export function applyValidationRules<T extends z.ZodTypeAny>(
+  schema: T,
+  rules: AppliedRule[],
+  registry: ValidationRuleRegistry = getValidationRuleRegistry()
+): z.ZodTypeAny {
+  let result: z.ZodTypeAny = schema;
+
+  for (const { ruleId, config } of rules) {
+    const ruleDef = registry.get(ruleId);
+    if (ruleDef) {
+      result = ruleDef.toZod(config)(result) as z.ZodTypeAny;
+    }
+  }
+
+  return result;
+}

--- a/packages/core/src/registry/types.ts
+++ b/packages/core/src/registry/types.ts
@@ -309,3 +309,110 @@ export interface InputRegistry {
   /** Clear all registrations */
   clear(): void;
 }
+
+/**
+ * Categories for validation rules.
+ */
+export type ValidationRuleCategory = "constraint" | "format" | "range";
+
+/**
+ * Props passed to rule configuration components.
+ * Generic over the configuration type C.
+ */
+export interface RuleConfigProps<C = unknown> {
+  /** Current rule configuration */
+  config: C;
+
+  /** Called when configuration changes */
+  onChange: (config: C) => void;
+
+  /** Whether the config form is disabled */
+  disabled?: boolean;
+}
+
+/**
+ * Placeholder component type for rule configuration.
+ * Since this is the core package, actual React components live in the UI package.
+ * This type allows storing a reference to a component that will be provided later.
+ */
+export type RuleConfigComponentRef = string;
+
+/**
+ * Schema transformer function type.
+ * Takes a Zod schema and returns a modified version with the validation applied.
+ *
+ * Note: We use unknown for both config and schema to avoid Zod version coupling
+ * at the type level. Runtime validation ensures correctness.
+ */
+export type ZodSchemaTransformer = (
+  config: unknown
+) => (schema: unknown) => unknown;
+
+/**
+ * Definition for a validation rule in the registry.
+ * Used by the form designer to show available rules and generate Zod schemas.
+ */
+export interface ValidationRuleDefinition {
+  /** Unique identifier for this rule (must match ValidationRuleId) */
+  id: ValidationRuleId;
+
+  /** Human-readable display name */
+  name: string;
+
+  /** Icon identifier (e.g., Lucide icon name) */
+  icon: string;
+
+  /** Rule category for grouping */
+  category: ValidationRuleCategory;
+
+  /** Input types this rule is compatible with */
+  compatibleInputs: InputTypeId[];
+
+  /**
+   * Reference to the configuration component.
+   * In core package, this is a string identifier.
+   * UI package maps these to actual React components.
+   */
+  configComponent: RuleConfigComponentRef;
+
+  /**
+   * Transform a Zod schema by applying this validation rule.
+   * Takes the rule config and returns a function that transforms the schema.
+   */
+  toZod: ZodSchemaTransformer;
+
+  /** Description shown in the rule palette */
+  description?: string;
+
+  /** Default configuration for this rule */
+  defaultConfig?: Record<string, unknown>;
+}
+
+/**
+ * The validation rule registry interface for managing registered rules.
+ */
+export interface ValidationRuleRegistry {
+  /** Register a new validation rule */
+  register(definition: ValidationRuleDefinition): void;
+
+  /** Get a rule definition by ID */
+  get(id: ValidationRuleId): ValidationRuleDefinition | undefined;
+
+  /** Get all registered rules */
+  getAll(): ValidationRuleDefinition[];
+
+  /** Get rules by category */
+  getByCategory(category: ValidationRuleCategory): ValidationRuleDefinition[];
+
+  /** Get rules compatible with a specific input type */
+  getCompatibleRules(inputType: InputTypeId): ValidationRuleDefinition[];
+
+  /** Check if a rule is registered */
+  has(id: ValidationRuleId): boolean;
+
+  /** Unregister a rule */
+  unregister(id: ValidationRuleId): boolean;
+
+  /** Clear all registrations */
+  clear(): void;
+}

--- a/packages/core/src/validation/messages.ts
+++ b/packages/core/src/validation/messages.ts
@@ -1,0 +1,283 @@
+/**
+ * Gaming-friendly error message transformers.
+ * Converts technical Zod error codes into player-friendly language.
+ */
+
+import type { ErrorMessageTransformer, ZodIssueInfo } from "./types";
+
+/**
+ * Transform "too_small" errors into gaming-friendly messages.
+ */
+export const tooSmallTransformer: ErrorMessageTransformer = (error) => {
+  const min = error.minimum;
+
+  if (error.type === "string") {
+    if (min === 1) {
+      return "This field cannot be empty.";
+    }
+    return `Needs at least ${String(min)} characters.`;
+  }
+
+  if (error.type === "number" || error.type === "bigint") {
+    if (error.inclusive) {
+      return `Must be ${String(min)} or higher.`;
+    }
+    return `Must be greater than ${String(min)}.`;
+  }
+
+  if (error.type === "array") {
+    if (min === 1) {
+      return "Select at least one option.";
+    }
+    return `Select at least ${String(min)} options.`;
+  }
+
+  if (error.type === "date") {
+    return "Date is too early.";
+  }
+
+  // Fallback
+  return error.message;
+};
+
+/**
+ * Transform "too_big" errors into gaming-friendly messages.
+ */
+export const tooBigTransformer: ErrorMessageTransformer = (error) => {
+  const max = error.maximum;
+
+  if (error.type === "string") {
+    return `Maximum ${String(max)} characters allowed.`;
+  }
+
+  if (error.type === "number" || error.type === "bigint") {
+    if (error.inclusive) {
+      return `Must be ${String(max)} or lower.`;
+    }
+    return `Must be less than ${String(max)}.`;
+  }
+
+  if (error.type === "array") {
+    return `Maximum ${String(max)} selections allowed.`;
+  }
+
+  if (error.type === "date") {
+    return "Date is too late.";
+  }
+
+  // Fallback
+  return error.message;
+};
+
+/**
+ * Transform "invalid_type" errors into gaming-friendly messages.
+ */
+export const invalidTypeTransformer: ErrorMessageTransformer = (error) => {
+  const { expected, received } = error;
+
+  // Handle null/undefined for required fields
+  if (received === "undefined" || received === "null") {
+    return "This field is required.";
+  }
+
+  // Handle common type mismatches
+  if (expected === "number" && received === "string") {
+    return "Enter a valid number.";
+  }
+
+  if (expected === "string" && received === "number") {
+    return "Enter text, not a number.";
+  }
+
+  if (expected === "date" || expected === "Date") {
+    return "Enter a valid date.";
+  }
+
+  if (expected === "boolean") {
+    return "This must be checked or unchecked.";
+  }
+
+  if (expected === "array") {
+    return "Select one or more options.";
+  }
+
+  // Fallback for other type mismatches
+  return `Expected ${expected ?? "unknown"}, got ${received ?? "unknown"}.`;
+};
+
+/**
+ * Transform "invalid_string" errors into gaming-friendly messages.
+ */
+export const invalidStringTransformer: ErrorMessageTransformer = (error) => {
+  const message = error.message.toLowerCase();
+
+  if (message.includes("email")) {
+    return "Enter a valid email address.";
+  }
+
+  if (message.includes("url")) {
+    return "Enter a valid URL.";
+  }
+
+  if (message.includes("uuid")) {
+    return "Invalid identifier format.";
+  }
+
+  if (message.includes("regex") || message.includes("pattern")) {
+    return "Format is incorrect.";
+  }
+
+  if (message.includes("datetime") || message.includes("date")) {
+    return "Enter a valid date.";
+  }
+
+  if (message.includes("time")) {
+    return "Enter a valid time.";
+  }
+
+  // Fallback
+  return "Invalid format.";
+};
+
+/**
+ * Transform "invalid_enum_value" errors into gaming-friendly messages.
+ */
+export const invalidEnumTransformer: ErrorMessageTransformer = () => {
+  return "Select a valid option.";
+};
+
+/**
+ * Transform "invalid_literal" errors into gaming-friendly messages.
+ */
+export const invalidLiteralTransformer: ErrorMessageTransformer = (error) => {
+  // Often used for checkbox acknowledgments
+  // Note: expected can be "true" (string) when Zod serializes boolean literals
+  if (error.expected === "true") {
+    return "This must be accepted.";
+  }
+
+  return "Invalid value.";
+};
+
+/**
+ * Transform "custom" errors (z.refine, z.superRefine).
+ * These pass through as-is since they already have custom messages.
+ */
+export const customTransformer: ErrorMessageTransformer = (error) => {
+  return error.message;
+};
+
+/**
+ * Transform "invalid_union" errors into gaming-friendly messages.
+ */
+export const invalidUnionTransformer: ErrorMessageTransformer = () => {
+  return "Invalid selection.";
+};
+
+/**
+ * Transform "invalid_date" errors into gaming-friendly messages.
+ */
+export const invalidDateTransformer: ErrorMessageTransformer = () => {
+  return "Enter a valid date.";
+};
+
+/**
+ * Transform "not_multiple_of" errors into gaming-friendly messages.
+ */
+export const notMultipleOfTransformer: ErrorMessageTransformer = (error) => {
+  // For step validation
+  const step = error.minimum; // Zod uses minimum for step value in this error
+  if (step !== undefined) {
+    return `Must be in increments of ${String(step)}.`;
+  }
+  return "Invalid increment.";
+};
+
+/**
+ * Transform "not_finite" errors into gaming-friendly messages.
+ */
+export const notFiniteTransformer: ErrorMessageTransformer = () => {
+  return "Enter a finite number.";
+};
+
+/**
+ * Transform "invalid_intersection_types" errors.
+ */
+export const invalidIntersectionTransformer: ErrorMessageTransformer = () => {
+  return "Invalid data format.";
+};
+
+/**
+ * Transform "unrecognized_keys" errors.
+ */
+export const unrecognizedKeysTransformer: ErrorMessageTransformer = () => {
+  return "Unknown fields detected.";
+};
+
+/**
+ * Default transformers for all Zod error codes.
+ */
+export const defaultMessageTransformers: Record<string, ErrorMessageTransformer> = {
+  too_small: tooSmallTransformer,
+  too_big: tooBigTransformer,
+  invalid_type: invalidTypeTransformer,
+  invalid_string: invalidStringTransformer,
+  invalid_enum_value: invalidEnumTransformer,
+  invalid_literal: invalidLiteralTransformer,
+  custom: customTransformer,
+  invalid_union: invalidUnionTransformer,
+  invalid_union_discriminator: invalidUnionTransformer,
+  invalid_date: invalidDateTransformer,
+  not_multiple_of: notMultipleOfTransformer,
+  not_finite: notFiniteTransformer,
+  invalid_intersection_types: invalidIntersectionTransformer,
+  unrecognized_keys: unrecognizedKeysTransformer,
+};
+
+/**
+ * Transform a Zod issue into a gaming-friendly error message.
+ *
+ * @param error - The Zod issue info
+ * @param customTransformers - Optional custom transformers to override defaults
+ * @returns Gaming-friendly error message
+ */
+export function transformErrorMessage(
+  error: ZodIssueInfo,
+  customTransformers?: Partial<Record<string, ErrorMessageTransformer>>
+): string {
+  const transformers = customTransformers
+    ? { ...defaultMessageTransformers, ...customTransformers }
+    : defaultMessageTransformers;
+
+  const transformer = transformers[error.code];
+
+  if (transformer) {
+    return transformer(error);
+  }
+
+  // Fallback to original message if no transformer found
+  return error.message;
+}
+
+/**
+ * Get the display label for a field path.
+ * Converts "userName" to "User Name", "address.city" to "City".
+ *
+ * @param path - The field path (e.g., "userName", "address.city")
+ * @returns Human-readable field label
+ */
+export function getFieldLabel(path: string): string {
+  // Get the last segment of the path
+  const segments = path.split(".");
+  const fieldName = segments[segments.length - 1];
+
+  if (!fieldName) {
+    return "Field";
+  }
+
+  // Convert camelCase/PascalCase to Title Case
+  return fieldName
+    .replace(/([A-Z])/g, " $1")
+    .replace(/^./, (str) => str.toUpperCase())
+    .trim();
+}

--- a/packages/core/src/validation/types.ts
+++ b/packages/core/src/validation/types.ts
@@ -1,0 +1,202 @@
+/**
+ * Validation error types for phantom-zone forms.
+ * Provides gaming-friendly error display with Zod integration.
+ */
+
+/**
+ * A single validation error for a field.
+ */
+export interface FieldValidationError {
+  /** The field path (e.g., "email", "address.city") */
+  path: string;
+
+  /** The original error code from Zod */
+  code: string;
+
+  /** The gaming-friendly error message */
+  message: string;
+
+  /** Optional minimum value that was violated */
+  minimum?: number | bigint;
+
+  /** Optional maximum value that was violated */
+  maximum?: number | bigint;
+
+  /** Whether the constraint is inclusive */
+  inclusive?: boolean;
+
+  /** Expected type when type mismatch */
+  expected?: string;
+
+  /** Received type when type mismatch */
+  received?: string;
+}
+
+/**
+ * Collection of validation errors for a form.
+ */
+export interface ValidationErrors {
+  /** Map of field path to errors for that field */
+  fieldErrors: Map<string, FieldValidationError[]>;
+
+  /** Form-level errors not tied to a specific field */
+  formErrors: FieldValidationError[];
+
+  /** Whether there are any errors */
+  hasErrors: boolean;
+
+  /** Total number of errors across all fields */
+  errorCount: number;
+
+  /** Get the first error for a specific field */
+  getFieldError: (path: string) => FieldValidationError | undefined;
+
+  /** Get all errors for a specific field */
+  getFieldErrors: (path: string) => FieldValidationError[];
+
+  /** Check if a field has errors */
+  hasFieldError: (path: string) => boolean;
+
+  /** Get the first field with an error (for scroll-to-first-error) */
+  getFirstErrorField: () => string | undefined;
+}
+
+/**
+ * Props for the FieldError component.
+ */
+export interface FieldErrorProps {
+  /** Field path to display errors for */
+  fieldPath: string;
+
+  /** Validation errors object */
+  errors: ValidationErrors;
+
+  /** Optional CSS class name */
+  className?: string;
+
+  /** Whether to show all errors or just the first */
+  showAll?: boolean;
+
+  /** Unique ID for aria-describedby linking */
+  id?: string;
+}
+
+/**
+ * Props for the ErrorSummary component.
+ */
+export interface ErrorSummaryProps {
+  /** Validation errors object */
+  errors: ValidationErrors;
+
+  /** Optional CSS class name */
+  className?: string;
+
+  /** Title for the error summary */
+  title?: string;
+
+  /** Whether to enable scroll-to-error when clicking */
+  scrollToError?: boolean;
+
+  /** Custom scroll behavior */
+  scrollBehavior?: ScrollBehavior;
+
+  /** Ref to focus when summary is shown */
+  summaryRef?: React.RefObject<HTMLElement>;
+}
+
+/**
+ * Options for creating a ValidationErrors object from Zod errors.
+ */
+export interface ParseErrorsOptions {
+  /** Custom error message transformers by Zod error code */
+  messageTransformers?: Partial<Record<string, ErrorMessageTransformer>>;
+
+  /** Whether to use gaming-friendly messages (default: true) */
+  useGamingMessages?: boolean;
+}
+
+/**
+ * Function that transforms a Zod error into a gaming-friendly message.
+ */
+export type ErrorMessageTransformer = (
+  error: ZodIssueInfo
+) => string;
+
+/**
+ * Minimal Zod issue info needed for message transformation.
+ * This avoids tight coupling to a specific Zod version.
+ */
+export interface ZodIssueInfo {
+  /** Error code (e.g., "too_small", "invalid_type") */
+  code: string;
+
+  /** Original message from Zod */
+  message: string;
+
+  /** Field path as array */
+  path: (string | number)[];
+
+  /** Minimum constraint if applicable */
+  minimum?: number | bigint;
+
+  /** Maximum constraint if applicable */
+  maximum?: number | bigint;
+
+  /** Whether constraint is inclusive */
+  inclusive?: boolean;
+
+  /** Expected type for type errors */
+  expected?: string;
+
+  /** Received type for type errors */
+  received?: string;
+
+  /** Type of constraint (string, number, array, etc.) */
+  type?: string;
+
+  /** For exact length errors */
+  exact?: boolean;
+}
+
+/**
+ * State managed by useValidationErrors hook.
+ */
+export interface ValidationErrorsState {
+  /** Current validation errors */
+  errors: ValidationErrors;
+
+  /** Set errors from a Zod error or issue array */
+  setErrors: (issues: ZodIssueInfo[]) => void;
+
+  /** Clear all errors */
+  clearErrors: () => void;
+
+  /** Clear errors for a specific field */
+  clearFieldErrors: (path: string) => void;
+
+  /** Add a manual error for a field */
+  addError: (path: string, message: string, code?: string) => void;
+
+  /** Scroll to the first field with an error */
+  scrollToFirstError: (options?: ScrollToErrorOptions) => void;
+}
+
+/**
+ * Options for scrolling to an error field.
+ */
+export interface ScrollToErrorOptions {
+  /** Scroll behavior (smooth or auto) */
+  behavior?: ScrollBehavior;
+
+  /** Block position (start, center, end, nearest) */
+  block?: ScrollLogicalPosition;
+
+  /** Inline position (start, center, end, nearest) */
+  inline?: ScrollLogicalPosition;
+
+  /** Whether to focus the field after scrolling */
+  focus?: boolean;
+
+  /** Offset from top when scrolling (for fixed headers) */
+  offsetTop?: number;
+}

--- a/packages/core/test/registry/rules.test.ts
+++ b/packages/core/test/registry/rules.test.ts
@@ -1,0 +1,375 @@
+/**
+ * Tests for the Validation Rule Registry
+ */
+
+import { z } from "zod";
+import { describe, expect, it, beforeEach } from "vitest";
+import {
+  createValidationRuleRegistry,
+  createDefaultValidationRuleRegistry,
+  getValidationRuleRegistry,
+  resetGlobalRuleRegistry,
+  applyValidationRules,
+  requiredRuleDefinition,
+  minLengthRuleDefinition,
+  maxLengthRuleDefinition,
+  minRuleDefinition,
+  maxRuleDefinition,
+  emailRuleDefinition,
+  patternRuleDefinition,
+  defaultValidationRuleDefinitions,
+  minItemsRuleDefinition,
+  maxItemsRuleDefinition,
+  positiveRuleDefinition,
+  negativeRuleDefinition,
+  fileSizeRuleDefinition,
+  fileTypeRuleDefinition,
+  urlRuleDefinition,
+  uuidRuleDefinition,
+  integerRuleDefinition,
+  stepRuleDefinition,
+  minDateRuleDefinition,
+  maxDateRuleDefinition,
+} from "../../src/registry";
+import type { ValidationRuleDefinition } from "../../src/registry";
+
+describe("ValidationRuleRegistry", () => {
+  beforeEach(() => {
+    resetGlobalRuleRegistry();
+  });
+
+  describe("createValidationRuleRegistry", () => {
+    it("creates an empty registry", () => {
+      const registry = createValidationRuleRegistry();
+      expect(registry.getAll()).toHaveLength(0);
+    });
+
+    it("allows registering a rule", () => {
+      const registry = createValidationRuleRegistry();
+      registry.register(requiredRuleDefinition);
+      expect(registry.has("required")).toBe(true);
+      expect(registry.get("required")).toEqual(requiredRuleDefinition);
+    });
+
+    it("throws when registering duplicate rule", () => {
+      const registry = createValidationRuleRegistry();
+      registry.register(requiredRuleDefinition);
+      expect(() => registry.register(requiredRuleDefinition)).toThrow(
+        'Validation rule "required" is already registered'
+      );
+    });
+
+    it("allows unregistering a rule", () => {
+      const registry = createValidationRuleRegistry();
+      registry.register(requiredRuleDefinition);
+      expect(registry.unregister("required")).toBe(true);
+      expect(registry.has("required")).toBe(false);
+    });
+
+    it("returns false when unregistering non-existent rule", () => {
+      const registry = createValidationRuleRegistry();
+      expect(registry.unregister("nonexistent" as any)).toBe(false);
+    });
+
+    it("clears all rules", () => {
+      const registry = createValidationRuleRegistry();
+      registry.register(requiredRuleDefinition);
+      registry.register(minLengthRuleDefinition);
+      registry.clear();
+      expect(registry.getAll()).toHaveLength(0);
+    });
+  });
+
+  describe("createDefaultValidationRuleRegistry", () => {
+    it("creates registry with all default rules", () => {
+      const registry = createDefaultValidationRuleRegistry();
+      expect(registry.getAll().length).toBe(defaultValidationRuleDefinitions.length);
+    });
+
+    it("includes all expected rules", () => {
+      const registry = createDefaultValidationRuleRegistry();
+      expect(registry.has("required")).toBe(true);
+      expect(registry.has("min")).toBe(true);
+      expect(registry.has("max")).toBe(true);
+      expect(registry.has("minLength")).toBe(true);
+      expect(registry.has("maxLength")).toBe(true);
+      expect(registry.has("email")).toBe(true);
+      expect(registry.has("pattern")).toBe(true);
+    });
+  });
+
+  describe("getValidationRuleRegistry (global)", () => {
+    it("returns same instance on multiple calls", () => {
+      const registry1 = getValidationRuleRegistry();
+      const registry2 = getValidationRuleRegistry();
+      expect(registry1).toBe(registry2);
+    });
+
+    it("includes default rules", () => {
+      const registry = getValidationRuleRegistry();
+      expect(registry.has("required")).toBe(true);
+    });
+
+    it("can be reset", () => {
+      const registry1 = getValidationRuleRegistry();
+      registry1.clear();
+      expect(registry1.getAll()).toHaveLength(0);
+
+      resetGlobalRuleRegistry();
+      const registry2 = getValidationRuleRegistry();
+      expect(registry2.getAll().length).toBe(defaultValidationRuleDefinitions.length);
+      expect(registry1).not.toBe(registry2);
+    });
+  });
+
+  describe("getByCategory", () => {
+    it("returns constraint rules", () => {
+      const registry = createDefaultValidationRuleRegistry();
+      const constraintRules = registry.getByCategory("constraint");
+      expect(constraintRules.every((r) => r.category === "constraint")).toBe(true);
+      expect(constraintRules.length).toBeGreaterThan(0);
+    });
+
+    it("returns format rules", () => {
+      const registry = createDefaultValidationRuleRegistry();
+      const formatRules = registry.getByCategory("format");
+      expect(formatRules.every((r) => r.category === "format")).toBe(true);
+      expect(formatRules.length).toBeGreaterThan(0);
+    });
+
+    it("returns range rules", () => {
+      const registry = createDefaultValidationRuleRegistry();
+      const rangeRules = registry.getByCategory("range");
+      expect(rangeRules.every((r) => r.category === "range")).toBe(true);
+      expect(rangeRules.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("getCompatibleRules", () => {
+    it("returns rules compatible with text input", () => {
+      const registry = createDefaultValidationRuleRegistry();
+      const textRules = registry.getCompatibleRules("text");
+      expect(textRules.some((r) => r.id === "required")).toBe(true);
+      expect(textRules.some((r) => r.id === "minLength")).toBe(true);
+      expect(textRules.some((r) => r.id === "email")).toBe(true);
+    });
+
+    it("returns rules compatible with number input", () => {
+      const registry = createDefaultValidationRuleRegistry();
+      const numberRules = registry.getCompatibleRules("number");
+      expect(numberRules.some((r) => r.id === "required")).toBe(true);
+      expect(numberRules.some((r) => r.id === "min")).toBe(true);
+      expect(numberRules.some((r) => r.id === "max")).toBe(true);
+      expect(numberRules.some((r) => r.id === "positive")).toBe(true);
+    });
+
+    it("returns rules compatible with multiselect", () => {
+      const registry = createDefaultValidationRuleRegistry();
+      const multiselectRules = registry.getCompatibleRules("multiselect");
+      expect(multiselectRules.some((r) => r.id === "minItems")).toBe(true);
+      expect(multiselectRules.some((r) => r.id === "maxItems")).toBe(true);
+    });
+  });
+});
+
+describe("Validation Rule Definitions", () => {
+  describe("required rule", () => {
+    it("makes string required", () => {
+      const schema = z.string();
+      const transformed = requiredRuleDefinition.toZod({})(schema);
+      expect(transformed.safeParse("").success).toBe(false);
+      expect(transformed.safeParse("hello").success).toBe(true);
+    });
+
+    it("makes array require at least one item", () => {
+      const schema = z.array(z.string());
+      const transformed = requiredRuleDefinition.toZod({})(schema);
+      expect(transformed.safeParse([]).success).toBe(false);
+      expect(transformed.safeParse(["item"]).success).toBe(true);
+    });
+
+    it("makes boolean require true", () => {
+      const schema = z.boolean();
+      const transformed = requiredRuleDefinition.toZod({})(schema);
+      expect(transformed.safeParse(false).success).toBe(false);
+      expect(transformed.safeParse(true).success).toBe(true);
+    });
+  });
+
+  describe("minLength rule", () => {
+    it("enforces minimum string length", () => {
+      const schema = z.string();
+      const transformed = minLengthRuleDefinition.toZod({ length: 3 })(schema);
+      expect(transformed.safeParse("ab").success).toBe(false);
+      expect(transformed.safeParse("abc").success).toBe(true);
+    });
+  });
+
+  describe("maxLength rule", () => {
+    it("enforces maximum string length", () => {
+      const schema = z.string();
+      const transformed = maxLengthRuleDefinition.toZod({ length: 5 })(schema);
+      expect(transformed.safeParse("abcdef").success).toBe(false);
+      expect(transformed.safeParse("abcde").success).toBe(true);
+    });
+  });
+
+  describe("min rule", () => {
+    it("enforces minimum number value", () => {
+      const schema = z.number();
+      const transformed = minRuleDefinition.toZod({ value: 10 })(schema);
+      expect(transformed.safeParse(9).success).toBe(false);
+      expect(transformed.safeParse(10).success).toBe(true);
+    });
+  });
+
+  describe("max rule", () => {
+    it("enforces maximum number value", () => {
+      const schema = z.number();
+      const transformed = maxRuleDefinition.toZod({ value: 100 })(schema);
+      expect(transformed.safeParse(101).success).toBe(false);
+      expect(transformed.safeParse(100).success).toBe(true);
+    });
+  });
+
+  describe("email rule", () => {
+    it("validates email format", () => {
+      const schema = z.string();
+      const transformed = emailRuleDefinition.toZod({})(schema);
+      expect(transformed.safeParse("notanemail").success).toBe(false);
+      expect(transformed.safeParse("test@example.com").success).toBe(true);
+    });
+  });
+
+  describe("pattern rule", () => {
+    it("validates against regex pattern", () => {
+      const schema = z.string();
+      const transformed = patternRuleDefinition.toZod({ pattern: "^[A-Z]+$" })(
+        schema
+      );
+      expect(transformed.safeParse("abc").success).toBe(false);
+      expect(transformed.safeParse("ABC").success).toBe(true);
+    });
+  });
+
+  describe("minItems rule", () => {
+    it("enforces minimum array length", () => {
+      const schema = z.array(z.string());
+      const transformed = minItemsRuleDefinition.toZod({ min: 2 })(schema);
+      expect(transformed.safeParse(["one"]).success).toBe(false);
+      expect(transformed.safeParse(["one", "two"]).success).toBe(true);
+    });
+  });
+
+  describe("maxItems rule", () => {
+    it("enforces maximum array length", () => {
+      const schema = z.array(z.string());
+      const transformed = maxItemsRuleDefinition.toZod({ max: 3 })(schema);
+      expect(transformed.safeParse(["a", "b", "c", "d"]).success).toBe(false);
+      expect(transformed.safeParse(["a", "b", "c"]).success).toBe(true);
+    });
+  });
+
+  describe("positive rule", () => {
+    it("requires positive number", () => {
+      const schema = z.number();
+      const transformed = positiveRuleDefinition.toZod({})(schema);
+      expect(transformed.safeParse(0).success).toBe(false);
+      expect(transformed.safeParse(-1).success).toBe(false);
+      expect(transformed.safeParse(1).success).toBe(true);
+    });
+  });
+
+  describe("negative rule", () => {
+    it("requires negative number", () => {
+      const schema = z.number();
+      const transformed = negativeRuleDefinition.toZod({})(schema);
+      expect(transformed.safeParse(0).success).toBe(false);
+      expect(transformed.safeParse(1).success).toBe(false);
+      expect(transformed.safeParse(-1).success).toBe(true);
+    });
+  });
+
+  describe("integer rule", () => {
+    it("requires integer value", () => {
+      const schema = z.number();
+      const transformed = integerRuleDefinition.toZod({})(schema);
+      expect(transformed.safeParse(1.5).success).toBe(false);
+      expect(transformed.safeParse(42).success).toBe(true);
+    });
+  });
+
+  describe("url rule", () => {
+    it("validates URL format", () => {
+      const schema = z.string();
+      const transformed = urlRuleDefinition.toZod({})(schema);
+      expect(transformed.safeParse("not a url").success).toBe(false);
+      expect(transformed.safeParse("https://example.com").success).toBe(true);
+    });
+  });
+
+  describe("uuid rule", () => {
+    it("validates UUID format", () => {
+      const schema = z.string();
+      const transformed = uuidRuleDefinition.toZod({})(schema);
+      expect(transformed.safeParse("not-a-uuid").success).toBe(false);
+      expect(
+        transformed.safeParse("550e8400-e29b-41d4-a716-446655440000").success
+      ).toBe(true);
+    });
+  });
+});
+
+describe("applyValidationRules", () => {
+  beforeEach(() => {
+    resetGlobalRuleRegistry();
+  });
+
+  it("applies multiple rules in order", () => {
+    const schema = z.string();
+    const result = applyValidationRules(schema, [
+      { ruleId: "required", config: {} },
+      { ruleId: "minLength", config: { length: 3 } },
+      { ruleId: "maxLength", config: { length: 10 } },
+    ]);
+
+    expect(result.safeParse("").success).toBe(false);
+    expect(result.safeParse("ab").success).toBe(false);
+    expect(result.safeParse("abc").success).toBe(true);
+    expect(result.safeParse("abcdefghijk").success).toBe(false);
+    expect(result.safeParse("abcdefghij").success).toBe(true);
+  });
+
+  it("skips unknown rules", () => {
+    const schema = z.string();
+    const result = applyValidationRules(schema, [
+      { ruleId: "required", config: {} },
+      { ruleId: "unknownRule" as any, config: {} },
+    ]);
+
+    // Should still apply the required rule
+    expect(result.safeParse("").success).toBe(false);
+    expect(result.safeParse("hello").success).toBe(true);
+  });
+
+  it("uses custom registry when provided", () => {
+    const customRegistry = createValidationRuleRegistry();
+    customRegistry.register({
+      ...requiredRuleDefinition,
+      toZod: () => (schema) => {
+        // Custom implementation that always passes
+        return schema;
+      },
+    });
+
+    const schema = z.string();
+    const result = applyValidationRules(
+      schema,
+      [{ ruleId: "required", config: {} }],
+      customRegistry
+    );
+
+    // Custom implementation should not enforce required
+    expect(result.safeParse("").success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the Validation Rule Registry (#27, PZ-001b) - a composable system for managing and applying validation rules to form fields.

### Registry Features
- `createValidationRuleRegistry()` - empty registry factory
- `createDefaultValidationRuleRegistry()` - pre-populated with all built-in rules
- `getValidationRuleRegistry()` - singleton global registry with lazy init
- Filter rules by category (constraint, format, range)
- Filter rules by compatible input types

### Built-in Validation Rules

**Constraint Rules:**
- `required` - field must have a value
- `minItems` / `maxItems` - array length constraints
- `positive` / `negative` - number sign constraints

**Format Rules:**
- `email` / `url` / `uuid` - string format validation
- `pattern` - custom regex validation
- `integer` - whole number only

**Range Rules:**
- `min` / `max` - numeric bounds
- `minLength` / `maxLength` - string length bounds
- `step` - multiple-of constraint
- `minDate` / `maxDate` - date bounds

**File Rules:**
- `fileSize` - maximum file size
- `fileType` - allowed MIME types

### Schema Builder

`applyValidationRules(schema, rules)` composes multiple rules onto a Zod schema:

```typescript
const schema = applyValidationRules(z.string(), [
  { ruleId: "required", config: {} },
  { ruleId: "minLength", config: { length: 3 } },
  { ruleId: "email", config: {} },
]);
```

### Also Includes

- Validation error types for gaming-friendly error display
- Error message transformers for Zod error codes
- Type definitions for rule config components

## Test Plan

- [x] Registry creation and registration tests
- [x] Rule filtering by category and input type
- [x] Individual rule transformation tests
- [x] Multi-rule composition tests
- [x] 36 new tests, 108 total passing

Closes #27

---

Generated with [Claude Code](https://claude.ai/claude-code)