### PR TITLE
feat(edit): implement Block Registry System (PZ-201)

### DIFF
--- a/packages/edit/src/index.ts
+++ b/packages/edit/src/index.ts
@@ -145,6 +145,43 @@ export {
   type VideoBlockProps,
 } from "./model";
 
+// Block Registry System with Components (PZ-201)
+export {
+  // Types
+  type BaseComponentBlockDefinition,
+  type BlockCategoryMeta,
+  type BlockComponentProps,
+  type BlockDefinition as ComponentBlockDefinition,
+  type BlockLoader,
+  type BlockRegistrationResult,
+  type ComponentBlockRegistry,
+  type ComponentBlockRegistryOptions,
+  type BlockCategory as ExtendedBlockCategory,
+  // Category metadata
+  BLOCK_CATEGORIES,
+  // Registry factory and utilities
+  createComponentBlockRegistry,
+  createDefaultComponentBlockRegistry,
+  getComponentBlockRegistry,
+  resetGlobalComponentBlockRegistry,
+  // Default block definitions with components
+  calloutComponentBlockDefinition,
+  codeComponentBlockDefinition,
+  columnsComponentBlockDefinition,
+  defaultComponentBlockDefinitions,
+  dividerComponentBlockDefinition,
+  embedComponentBlockDefinition,
+  formComponentBlockDefinition,
+  headingComponentBlockDefinition,
+  imageComponentBlockDefinition,
+  listComponentBlockDefinition,
+  paragraphComponentBlockDefinition,
+  quoteComponentBlockDefinition,
+  sectionComponentBlockDefinition,
+  tableComponentBlockDefinition,
+  videoComponentBlockDefinition,
+} from "./registry";
+
 // Placeholder - to be implemented in Phase 2
 export function BlockEditor(): never {
   throw new Error("Not implemented - see PZ-200: https://github.com/ezmode-games/phantom-zone/issues/41");

--- a/packages/edit/src/registry/blocks.ts
+++ b/packages/edit/src/registry/blocks.ts
@@ -1,0 +1,361 @@
+/**
+ * Block Registry Implementation with Component Support
+ *
+ * Dynamic block type registration system with React component support,
+ * lazy loading, and guild-specific filtering.
+ * Implements PZ-201: Block Registry System
+ */
+
+import type { ComponentType } from "react";
+import { createDocumentError, err, ok } from "../model/types";
+import type {
+  BaseComponentBlockDefinition,
+  BlockCategory,
+  BlockCategoryMeta,
+  BlockComponentProps,
+  BlockDefinition,
+  BlockProps,
+  BlockRegistrationResult,
+  BlockTypeId,
+  ComponentBlockRegistry,
+  ComponentBlockRegistryOptions,
+  DocumentError,
+  Result,
+} from "./types";
+import { BLOCK_CATEGORIES } from "./types";
+
+/**
+ * Create a new component block registry
+ */
+export function createComponentBlockRegistry(
+  options: ComponentBlockRegistryOptions = {}
+): ComponentBlockRegistry {
+  // Use BaseComponentBlockDefinition for internal storage to handle type variance
+  const definitions = new Map<BlockTypeId, BaseComponentBlockDefinition>();
+  const loadedBlocks = new Set<BlockTypeId>();
+  const loadingPromises = new Map<BlockTypeId, Promise<Result<BaseComponentBlockDefinition, DocumentError>>>();
+
+  const registry: ComponentBlockRegistry = {
+    register<T = unknown>(definition: BlockDefinition<T>): Result<BlockRegistrationResult, DocumentError> {
+      if (definitions.has(definition.id)) {
+        return err(
+          createDocumentError(
+            "REGISTRY_ERROR",
+            `Block type "${definition.id}" is already registered`
+          )
+        );
+      }
+
+      // Validate that either component or loader is provided, but not both
+      if (definition.component && definition.loader) {
+        return err(
+          createDocumentError(
+            "VALIDATION_ERROR",
+            `Block type "${definition.id}" cannot have both component and loader`
+          )
+        );
+      }
+
+      // Apply guild filter if configured
+      if (options.guildId && definition.guildRestrictions?.length) {
+        if (!definition.guildRestrictions.includes(options.guildId)) {
+          return err(
+            createDocumentError(
+              "VALIDATION_ERROR",
+              `Block type "${definition.id}" is not available for guild "${options.guildId}"`
+            )
+          );
+        }
+      }
+
+      // Store as BaseComponentBlockDefinition for heterogeneous storage
+      definitions.set(definition.id, definition as BaseComponentBlockDefinition);
+
+      // Mark as loaded if component is provided directly
+      const isLazy = !definition.component && !!definition.loader;
+      if (!isLazy) {
+        loadedBlocks.add(definition.id);
+      }
+
+      const result: BlockRegistrationResult = {
+        typeId: definition.id,
+        isLazy,
+        loadedAt: isLazy ? undefined : new Date(),
+      };
+
+      return ok(result);
+    },
+
+    get(id: BlockTypeId): BaseComponentBlockDefinition | undefined {
+      return definitions.get(id);
+    },
+
+    getAll(): BaseComponentBlockDefinition[] {
+      return Array.from(definitions.values());
+    },
+
+    getByCategory(category: BlockCategory): BaseComponentBlockDefinition[] {
+      return Array.from(definitions.values()).filter(
+        (def) => def.category === category
+      );
+    },
+
+    getAllCategories(): Map<BlockCategory, BaseComponentBlockDefinition[]> {
+      const categoryMap = new Map<BlockCategory, BaseComponentBlockDefinition[]>();
+
+      // Initialize with all categories (including empty ones)
+      for (const meta of BLOCK_CATEGORIES) {
+        categoryMap.set(meta.id, []);
+      }
+
+      // Group blocks by category
+      for (const def of definitions.values()) {
+        const blocks = categoryMap.get(def.category) || [];
+        blocks.push(def);
+        categoryMap.set(def.category, blocks);
+      }
+
+      return categoryMap;
+    },
+
+    getCategoryMeta(category: BlockCategory): BlockCategoryMeta | undefined {
+      return BLOCK_CATEGORIES.find((meta) => meta.id === category);
+    },
+
+    has(id: BlockTypeId): boolean {
+      return definitions.has(id);
+    },
+
+    unregister(id: BlockTypeId): boolean {
+      loadedBlocks.delete(id);
+      loadingPromises.delete(id);
+      return definitions.delete(id);
+    },
+
+    clear(): void {
+      definitions.clear();
+      loadedBlocks.clear();
+      loadingPromises.clear();
+    },
+
+    validateProps(
+      typeId: BlockTypeId,
+      props: unknown
+    ): Result<BlockProps, DocumentError> {
+      const definition = definitions.get(typeId);
+      if (!definition) {
+        return err(
+          createDocumentError(
+            "INVALID_BLOCK_TYPE",
+            `Unknown block type: ${typeId}`
+          )
+        );
+      }
+
+      const result = definition.propsSchema.safeParse(props);
+      if (!result.success) {
+        return err(
+          createDocumentError(
+            "VALIDATION_ERROR",
+            `Invalid props for block type "${typeId}": ${result.error.message}`,
+            result.error
+          )
+        );
+      }
+
+      return ok(result.data as BlockProps);
+    },
+
+    canContain(
+      parentTypeId: BlockTypeId,
+      childTypeId: BlockTypeId
+    ): Result<boolean, DocumentError> {
+      const parentDef = definitions.get(parentTypeId);
+      if (!parentDef) {
+        return err(
+          createDocumentError(
+            "INVALID_BLOCK_TYPE",
+            `Unknown parent block type: ${parentTypeId}`
+          )
+        );
+      }
+
+      // Non-container blocks cannot contain children
+      if (!parentDef.isContainer) {
+        return ok(false);
+      }
+
+      // If allowedChildren is not specified, all types are allowed
+      if (!parentDef.allowedChildren || parentDef.allowedChildren.length === 0) {
+        return ok(true);
+      }
+
+      // Check if child type is in the allowed list
+      return ok(parentDef.allowedChildren.includes(childTypeId));
+    },
+
+    async loadBlock(typeId: BlockTypeId): Promise<Result<BaseComponentBlockDefinition, DocumentError>> {
+      const definition = definitions.get(typeId);
+      if (!definition) {
+        return err(
+          createDocumentError(
+            "INVALID_BLOCK_TYPE",
+            `Unknown block type: ${typeId}`
+          )
+        );
+      }
+
+      // Already loaded
+      if (loadedBlocks.has(typeId)) {
+        return ok(definition);
+      }
+
+      // No loader means it should already be loaded
+      if (!definition.loader) {
+        loadedBlocks.add(typeId);
+        return ok(definition);
+      }
+
+      // Check if already loading
+      const existingPromise = loadingPromises.get(typeId);
+      if (existingPromise) {
+        return existingPromise;
+      }
+
+      // Start loading
+      const loadPromise = (async (): Promise<Result<BaseComponentBlockDefinition, DocumentError>> => {
+        try {
+          const loaded = await definition.loader!();
+
+          // Update the definition with the loaded component
+          const updatedDefinition: BaseComponentBlockDefinition = {
+            ...definition,
+            component: loaded.component,
+          };
+
+          // Update schema if provided
+          if (loaded.propsSchema) {
+            // biome-ignore lint/suspicious/noExplicitAny: Schema types are runtime validated
+            (updatedDefinition as any).propsSchema = loaded.propsSchema;
+          }
+
+          definitions.set(typeId, updatedDefinition);
+          loadedBlocks.add(typeId);
+          loadingPromises.delete(typeId);
+
+          return ok(updatedDefinition);
+        } catch (error) {
+          loadingPromises.delete(typeId);
+          return err(
+            createDocumentError(
+              "REGISTRY_ERROR",
+              `Failed to load block type "${typeId}": ${error instanceof Error ? error.message : "Unknown error"}`,
+              error
+            )
+          );
+        }
+      })();
+
+      loadingPromises.set(typeId, loadPromise);
+      return loadPromise;
+    },
+
+    isLoaded(typeId: BlockTypeId): boolean {
+      return loadedBlocks.has(typeId);
+    },
+
+    getForGuild(guildId: string): BaseComponentBlockDefinition[] {
+      return Array.from(definitions.values()).filter((def) => {
+        // No restrictions means available to all
+        if (!def.guildRestrictions || def.guildRestrictions.length === 0) {
+          return true;
+        }
+        return def.guildRestrictions.includes(guildId);
+      });
+    },
+
+    search(query: string): BaseComponentBlockDefinition[] {
+      const normalizedQuery = query.toLowerCase().trim();
+      if (!normalizedQuery) {
+        return [];
+      }
+
+      return Array.from(definitions.values()).filter((def) => {
+        // Search in name
+        if (def.name.toLowerCase().includes(normalizedQuery)) {
+          return true;
+        }
+        // Search in description
+        if (def.description?.toLowerCase().includes(normalizedQuery)) {
+          return true;
+        }
+        // Search in keywords
+        if (def.keywords?.some((kw) => kw.toLowerCase().includes(normalizedQuery))) {
+          return true;
+        }
+        // Search in type ID
+        if (def.id.toLowerCase().includes(normalizedQuery)) {
+          return true;
+        }
+        return false;
+      });
+    },
+  };
+
+  return registry;
+}
+
+// Global registry instance (lazy initialized)
+let globalComponentRegistry: ComponentBlockRegistry | null = null;
+
+/**
+ * Get the global component block registry instance
+ * Creates one if it doesn't exist, pre-populated with default block types
+ */
+export function getComponentBlockRegistry(): ComponentBlockRegistry {
+  if (!globalComponentRegistry) {
+    globalComponentRegistry = createDefaultComponentBlockRegistry();
+  }
+  return globalComponentRegistry;
+}
+
+/**
+ * Reset the global component registry (useful for testing)
+ */
+export function resetGlobalComponentBlockRegistry(): void {
+  globalComponentRegistry = null;
+}
+
+/**
+ * Create a registry pre-populated with default block types including stub components
+ */
+export function createDefaultComponentBlockRegistry(
+  options: ComponentBlockRegistryOptions = {}
+): ComponentBlockRegistry {
+  const registry = createComponentBlockRegistry(options);
+
+  // Register all default block definitions with stub components
+  for (const definition of defaultComponentBlockDefinitions) {
+    registry.register(definition);
+  }
+
+  return registry;
+}
+
+// Re-export types
+export type {
+  BlockCategory,
+  BlockCategoryMeta,
+  BlockComponentProps,
+  BlockDefinition,
+  BlockLoader,
+  BlockRegistrationResult,
+  BlockTypeId,
+  ComponentBlockRegistry,
+  ComponentBlockRegistryOptions,
+} from "./types";
+
+export { BLOCK_CATEGORIES } from "./types";
+
+// Import default definitions after registry functions are defined
+import { defaultComponentBlockDefinitions } from "./default-blocks";

--- a/packages/edit/src/registry/default-blocks.ts
+++ b/packages/edit/src/registry/default-blocks.ts
@@ -1,0 +1,330 @@
+/**
+ * Default Block Definitions with Components
+ *
+ * Core block types with React component stubs for the block-based document editor.
+ * Implements PZ-201: Block Registry System
+ */
+
+import type { ComponentType } from "react";
+import {
+  CalloutBlockPropsSchema,
+  CodeBlockPropsSchema,
+  ColumnsBlockPropsSchema,
+  DividerBlockPropsSchema,
+  EmbedBlockPropsSchema,
+  FormBlockPropsSchema,
+  HeadingBlockPropsSchema,
+  ImageBlockPropsSchema,
+  ListBlockPropsSchema,
+  ParagraphBlockPropsSchema,
+  QuoteBlockPropsSchema,
+  SectionBlockPropsSchema,
+  TableBlockPropsSchema,
+  VideoBlockPropsSchema,
+  type CalloutBlockProps,
+  type CodeBlockProps,
+  type ColumnsBlockProps,
+  type DividerBlockProps,
+  type EmbedBlockProps,
+  type FormBlockProps,
+  type HeadingBlockProps,
+  type ImageBlockProps,
+  type ListBlockProps,
+  type ParagraphBlockProps,
+  type QuoteBlockProps,
+  type SectionBlockProps,
+  type TableBlockProps,
+  type VideoBlockProps,
+} from "../model/blocks";
+import type { BaseComponentBlockDefinition, BlockComponentProps, BlockDefinition } from "./types";
+
+/**
+ * Create a placeholder component that renders a simple div with block info
+ * Used as a stub until actual block components are implemented
+ */
+function createStubComponent<T>(blockType: string): ComponentType<BlockComponentProps<T>> {
+  // Return a minimal functional component
+  const StubComponent = function StubBlockComponent(props: BlockComponentProps<T>) {
+    return null; // Stub returns null - real components will render actual UI
+  };
+  StubComponent.displayName = `${blockType}Block`;
+  return StubComponent;
+}
+
+// Heading block with component
+export const headingComponentBlockDefinition: BlockDefinition<HeadingBlockProps> = {
+  id: "heading",
+  name: "Heading",
+  icon: "heading",
+  category: "typography",
+  description: "A heading for section titles",
+  isContainer: false,
+  propsSchema: HeadingBlockPropsSchema,
+  defaultProps: {
+    level: 2,
+    content: "",
+  },
+  keywords: ["title", "h1", "h2", "h3", "header"],
+  component: createStubComponent<HeadingBlockProps>("Heading"),
+  version: "1.0.0",
+};
+
+// Paragraph block with component
+export const paragraphComponentBlockDefinition: BlockDefinition<ParagraphBlockProps> = {
+  id: "paragraph",
+  name: "Paragraph",
+  icon: "text",
+  category: "typography",
+  description: "A paragraph of text",
+  isContainer: false,
+  propsSchema: ParagraphBlockPropsSchema,
+  defaultProps: {
+    content: "",
+  },
+  keywords: ["text", "body", "p"],
+  component: createStubComponent<ParagraphBlockProps>("Paragraph"),
+  version: "1.0.0",
+};
+
+// List block with component
+export const listComponentBlockDefinition: BlockDefinition<ListBlockProps> = {
+  id: "list",
+  name: "List",
+  icon: "list",
+  category: "typography",
+  description: "A bullet, numbered, or checkbox list",
+  isContainer: false,
+  propsSchema: ListBlockPropsSchema,
+  defaultProps: {
+    type: "bullet",
+    items: [{ content: "" }],
+  },
+  keywords: ["bullet", "numbered", "ul", "ol", "todo", "checkbox"],
+  component: createStubComponent<ListBlockProps>("List"),
+  version: "1.0.0",
+};
+
+// Quote block with component
+export const quoteComponentBlockDefinition: BlockDefinition<QuoteBlockProps> = {
+  id: "quote",
+  name: "Quote",
+  icon: "quote",
+  category: "typography",
+  description: "A blockquote with optional citation",
+  isContainer: false,
+  propsSchema: QuoteBlockPropsSchema,
+  defaultProps: {
+    content: "",
+  },
+  keywords: ["blockquote", "citation", "pullquote"],
+  component: createStubComponent<QuoteBlockProps>("Quote"),
+  version: "1.0.0",
+};
+
+// Code block with component
+export const codeComponentBlockDefinition: BlockDefinition<CodeBlockProps> = {
+  id: "code",
+  name: "Code",
+  icon: "code",
+  category: "typography",
+  description: "A code block with syntax highlighting",
+  isContainer: false,
+  propsSchema: CodeBlockPropsSchema,
+  defaultProps: {
+    content: "",
+    showLineNumbers: true,
+  },
+  keywords: ["pre", "syntax", "programming"],
+  component: createStubComponent<CodeBlockProps>("Code"),
+  version: "1.0.0",
+};
+
+// Callout block with component
+export const calloutComponentBlockDefinition: BlockDefinition<CalloutBlockProps> = {
+  id: "callout",
+  name: "Callout",
+  icon: "alert-circle",
+  category: "typography",
+  description: "A highlighted callout or alert box",
+  isContainer: false,
+  propsSchema: CalloutBlockPropsSchema,
+  defaultProps: {
+    type: "info",
+    content: "",
+  },
+  keywords: ["alert", "notice", "warning", "info", "tip"],
+  component: createStubComponent<CalloutBlockProps>("Callout"),
+  version: "1.0.0",
+};
+
+// Table block with component
+export const tableComponentBlockDefinition: BlockDefinition<TableBlockProps> = {
+  id: "table",
+  name: "Table",
+  icon: "table",
+  category: "typography",
+  description: "A data table",
+  isContainer: false,
+  propsSchema: TableBlockPropsSchema,
+  defaultProps: {
+    headers: ["Column 1", "Column 2"],
+    rows: [["", ""]],
+    striped: true,
+    bordered: true,
+  },
+  keywords: ["grid", "data", "spreadsheet"],
+  component: createStubComponent<TableBlockProps>("Table"),
+  version: "1.0.0",
+};
+
+// Divider block with component
+export const dividerComponentBlockDefinition: BlockDefinition<DividerBlockProps> = {
+  id: "divider",
+  name: "Divider",
+  icon: "minus",
+  category: "layout",
+  description: "A horizontal divider line",
+  isContainer: false,
+  propsSchema: DividerBlockPropsSchema,
+  defaultProps: {
+    style: "solid",
+  },
+  keywords: ["hr", "line", "separator"],
+  component: createStubComponent<DividerBlockProps>("Divider"),
+  version: "1.0.0",
+};
+
+// Section block with component
+export const sectionComponentBlockDefinition: BlockDefinition<SectionBlockProps> = {
+  id: "section",
+  name: "Section",
+  icon: "layout",
+  category: "layout",
+  description: "A container section for grouping blocks",
+  isContainer: true,
+  propsSchema: SectionBlockPropsSchema,
+  defaultProps: {
+    padding: "medium",
+  },
+  keywords: ["container", "group", "wrapper", "div"],
+  component: createStubComponent<SectionBlockProps>("Section"),
+  version: "1.0.0",
+};
+
+// Columns block with component
+export const columnsComponentBlockDefinition: BlockDefinition<ColumnsBlockProps> = {
+  id: "columns",
+  name: "Columns",
+  icon: "columns",
+  category: "layout",
+  description: "A multi-column layout",
+  isContainer: true,
+  propsSchema: ColumnsBlockPropsSchema,
+  defaultProps: {
+    columns: 2,
+    gap: "medium",
+  },
+  keywords: ["grid", "layout", "side-by-side"],
+  component: createStubComponent<ColumnsBlockProps>("Columns"),
+  version: "1.0.0",
+};
+
+// Image block with component
+export const imageComponentBlockDefinition: BlockDefinition<ImageBlockProps> = {
+  id: "image",
+  name: "Image",
+  icon: "image",
+  category: "media",
+  description: "An image with optional caption",
+  isContainer: false,
+  propsSchema: ImageBlockPropsSchema,
+  defaultProps: {
+    src: "",
+    alt: "",
+    align: "center",
+  },
+  keywords: ["picture", "photo", "img"],
+  component: createStubComponent<ImageBlockProps>("Image"),
+  version: "1.0.0",
+};
+
+// Video block with component
+export const videoComponentBlockDefinition: BlockDefinition<VideoBlockProps> = {
+  id: "video",
+  name: "Video",
+  icon: "video",
+  category: "media",
+  description: "An embedded video",
+  isContainer: false,
+  propsSchema: VideoBlockPropsSchema,
+  defaultProps: {
+    src: "",
+    controls: true,
+    muted: false,
+  },
+  keywords: ["movie", "clip", "mp4"],
+  component: createStubComponent<VideoBlockProps>("Video"),
+  version: "1.0.0",
+};
+
+// Embed block with component
+export const embedComponentBlockDefinition: BlockDefinition<EmbedBlockProps> = {
+  id: "embed",
+  name: "Embed",
+  icon: "globe",
+  category: "embed",
+  description: "Embed external content (YouTube, Twitter, etc.)",
+  isContainer: false,
+  propsSchema: EmbedBlockPropsSchema,
+  defaultProps: {
+    url: "",
+    aspectRatio: "16:9",
+  },
+  keywords: ["iframe", "youtube", "twitter", "external"],
+  component: createStubComponent<EmbedBlockProps>("Embed"),
+  version: "1.0.0",
+};
+
+// Form block with component
+export const formComponentBlockDefinition: BlockDefinition<FormBlockProps> = {
+  id: "form",
+  name: "Form",
+  icon: "file-text",
+  category: "form",
+  description: "Embed a form",
+  isContainer: false,
+  propsSchema: FormBlockPropsSchema,
+  defaultProps: {
+    formId: "",
+    submitButtonText: "Submit",
+  },
+  keywords: ["input", "survey", "questionnaire"],
+  component: createStubComponent<FormBlockProps>("Form"),
+  version: "1.0.0",
+};
+
+/**
+ * All default component block definitions
+ * Uses BaseComponentBlockDefinition for storage to handle type variance
+ */
+export const defaultComponentBlockDefinitions: BaseComponentBlockDefinition[] = [
+  // Typography
+  headingComponentBlockDefinition,
+  paragraphComponentBlockDefinition,
+  listComponentBlockDefinition,
+  quoteComponentBlockDefinition,
+  codeComponentBlockDefinition,
+  calloutComponentBlockDefinition,
+  tableComponentBlockDefinition,
+  // Layout
+  dividerComponentBlockDefinition,
+  sectionComponentBlockDefinition,
+  columnsComponentBlockDefinition,
+  // Media
+  imageComponentBlockDefinition,
+  videoComponentBlockDefinition,
+  // Embed
+  embedComponentBlockDefinition,
+  // Form
+  formComponentBlockDefinition,
+];

--- a/packages/edit/src/registry/index.ts
+++ b/packages/edit/src/registry/index.ts
@@ -1,0 +1,53 @@
+/**
+ * Block Registry Module
+ *
+ * Exports for the block registry system with React component support.
+ * Implements PZ-201: Block Registry System
+ */
+
+// Registry types
+export type {
+  BaseComponentBlockDefinition,
+  BlockCategory,
+  BlockCategoryMeta,
+  BlockComponentProps,
+  BlockDefinition,
+  BlockLoader,
+  BlockProps,
+  BlockRegistrationResult,
+  BlockTypeId,
+  ComponentBlockRegistry,
+  ComponentBlockRegistryOptions,
+  DocumentError,
+  Result,
+} from "./types";
+
+// Category metadata
+export { BLOCK_CATEGORIES } from "./types";
+
+// Registry factory and utilities
+export {
+  createComponentBlockRegistry,
+  createDefaultComponentBlockRegistry,
+  getComponentBlockRegistry,
+  resetGlobalComponentBlockRegistry,
+} from "./blocks";
+
+// Default block definitions with components
+export {
+  calloutComponentBlockDefinition,
+  codeComponentBlockDefinition,
+  columnsComponentBlockDefinition,
+  defaultComponentBlockDefinitions,
+  dividerComponentBlockDefinition,
+  embedComponentBlockDefinition,
+  formComponentBlockDefinition,
+  headingComponentBlockDefinition,
+  imageComponentBlockDefinition,
+  listComponentBlockDefinition,
+  paragraphComponentBlockDefinition,
+  quoteComponentBlockDefinition,
+  sectionComponentBlockDefinition,
+  tableComponentBlockDefinition,
+  videoComponentBlockDefinition,
+} from "./default-blocks";

--- a/packages/edit/src/registry/types.ts
+++ b/packages/edit/src/registry/types.ts
@@ -1,0 +1,208 @@
+/**
+ * Block Registry Types
+ *
+ * Extended type definitions for the block registry with React component support.
+ * Implements PZ-201: Block Registry System
+ */
+
+import type { ComponentType } from "react";
+import type { z } from "zod/v4";
+import type {
+  BlockCategory as BaseBlockCategory,
+  BlockDefinition as BaseBlockDefinition,
+  BlockProps,
+  BlockTypeId,
+  DocumentError,
+  Result,
+} from "../model/types";
+
+/**
+ * Extended block categories including platform and gaming
+ */
+export type BlockCategory =
+  | BaseBlockCategory
+  | "platform"
+  | "gaming";
+
+/**
+ * All available block categories with metadata for sidebar display
+ */
+export interface BlockCategoryMeta {
+  id: BlockCategory;
+  name: string;
+  description: string;
+  icon: string;
+  order: number;
+}
+
+/**
+ * Block category metadata for sidebar grouping
+ */
+export const BLOCK_CATEGORIES: readonly BlockCategoryMeta[] = [
+  { id: "typography", name: "Typography", description: "Text and content blocks", icon: "type", order: 0 },
+  { id: "media", name: "Media", description: "Images, videos, and embeds", icon: "image", order: 1 },
+  { id: "layout", name: "Layout", description: "Structural and container blocks", icon: "layout", order: 2 },
+  { id: "form", name: "Forms", description: "Form and input blocks", icon: "file-text", order: 3 },
+  { id: "embed", name: "Embeds", description: "External content embeds", icon: "globe", order: 4 },
+  { id: "platform", name: "Platform", description: "Platform-specific blocks", icon: "puzzle", order: 5 },
+  { id: "gaming", name: "Gaming", description: "Game-related blocks", icon: "gamepad-2", order: 6 },
+  { id: "other", name: "Other", description: "Miscellaneous blocks", icon: "more-horizontal", order: 7 },
+] as const;
+
+/**
+ * Lazy loader function type for dynamic block loading
+ */
+export type BlockLoader<T = unknown> = () => Promise<{
+  component: ComponentType<BlockComponentProps<T>>;
+  propsSchema?: z.ZodType<T>;
+}>;
+
+/**
+ * Props passed to block components
+ */
+export interface BlockComponentProps<T = unknown> {
+  /** Block ID */
+  id: string;
+  /** Block-specific props */
+  props: BlockProps<T>;
+  /** Whether the block is selected */
+  isSelected?: boolean;
+  /** Whether the block is in edit mode */
+  isEditing?: boolean;
+  /** Callback to update block props */
+  onPropsChange?: (props: Partial<T>) => void;
+  /** Children for container blocks */
+  children?: React.ReactNode;
+}
+
+/**
+ * Base block definition for storage in heterogeneous registry.
+ * Uses any for component type to allow storing different block types together.
+ */
+export interface BaseComponentBlockDefinition {
+  /** Unique type identifier */
+  id: BlockTypeId;
+  /** Human-readable display name */
+  name: string;
+  /** Icon identifier (e.g., Lucide icon name) */
+  icon: string;
+  /** Category for grouping in sidebar (extended) */
+  category: BlockCategory;
+  /** Description shown in block palette */
+  description?: string;
+  /** Whether this block can contain children */
+  isContainer: boolean;
+  /** Allowed child block types (if container, empty = all allowed) */
+  allowedChildren?: BlockTypeId[];
+  /** Zod schema for validating block props */
+  // biome-ignore lint/suspicious/noExplicitAny: Required for heterogeneous registry storage
+  propsSchema: z.ZodType<any>;
+  /** Default props when creating new block */
+  // biome-ignore lint/suspicious/noExplicitAny: Required for heterogeneous registry storage
+  defaultProps: any;
+  /** Keywords for search in block palette */
+  keywords?: string[];
+  /** React component for rendering the block */
+  // biome-ignore lint/suspicious/noExplicitAny: Required for heterogeneous registry storage
+  component?: ComponentType<any>;
+  /** Lazy loader for dynamic loading (mutually exclusive with component) */
+  // biome-ignore lint/suspicious/noExplicitAny: Required for heterogeneous registry storage
+  loader?: () => Promise<{ component: ComponentType<any>; propsSchema?: z.ZodType<any> }>;
+  /** Guild IDs that can use this block (empty = all guilds) */
+  guildRestrictions?: string[];
+  /** Whether this is a premium/paid block */
+  isPremium?: boolean;
+  /** Version info for the block */
+  version?: string;
+}
+
+/**
+ * Extended block definition with React component support.
+ * Use this typed version when defining custom blocks for full type safety.
+ */
+export interface BlockDefinition<T = unknown> extends Omit<BaseBlockDefinition<T>, "category"> {
+  /** Category for grouping in sidebar (extended) */
+  category: BlockCategory;
+  /** React component for rendering the block */
+  component?: ComponentType<BlockComponentProps<T>>;
+  /** Lazy loader for dynamic loading (mutually exclusive with component) */
+  loader?: BlockLoader<T>;
+  /** Guild IDs that can use this block (empty = all guilds) */
+  guildRestrictions?: string[];
+  /** Whether this is a premium/paid block */
+  isPremium?: boolean;
+  /** Version info for the block */
+  version?: string;
+}
+
+/**
+ * Registration result for tracking loaded state
+ */
+export interface BlockRegistrationResult {
+  typeId: BlockTypeId;
+  isLazy: boolean;
+  loadedAt?: Date;
+}
+
+/**
+ * Extended block registry interface with component support.
+ * Uses BaseComponentBlockDefinition for return types to handle heterogeneous storage.
+ */
+export interface ComponentBlockRegistry {
+  /** Register a new block type with component */
+  register<T = unknown>(definition: BlockDefinition<T>): Result<BlockRegistrationResult, DocumentError>;
+
+  /** Get a block definition by ID */
+  get(id: BlockTypeId): BaseComponentBlockDefinition | undefined;
+
+  /** Get all registered block types */
+  getAll(): BaseComponentBlockDefinition[];
+
+  /** Get block types by category */
+  getByCategory(category: BlockCategory): BaseComponentBlockDefinition[];
+
+  /** Get all available categories with their blocks */
+  getAllCategories(): Map<BlockCategory, BaseComponentBlockDefinition[]>;
+
+  /** Get category metadata */
+  getCategoryMeta(category: BlockCategory): BlockCategoryMeta | undefined;
+
+  /** Check if a block type is registered */
+  has(id: BlockTypeId): boolean;
+
+  /** Unregister a block type */
+  unregister(id: BlockTypeId): boolean;
+
+  /** Clear all registrations */
+  clear(): void;
+
+  /** Validate block props against its schema */
+  validateProps(typeId: BlockTypeId, props: unknown): Result<BlockProps, DocumentError>;
+
+  /** Check if a block can contain a child of given type */
+  canContain(parentTypeId: BlockTypeId, childTypeId: BlockTypeId): Result<boolean, DocumentError>;
+
+  /** Load a lazy block's component */
+  loadBlock(typeId: BlockTypeId): Promise<Result<BaseComponentBlockDefinition, DocumentError>>;
+
+  /** Check if a block is loaded (for lazy blocks) */
+  isLoaded(typeId: BlockTypeId): boolean;
+
+  /** Get blocks available for a specific guild */
+  getForGuild(guildId: string): BaseComponentBlockDefinition[];
+
+  /** Search blocks by keyword */
+  search(query: string): BaseComponentBlockDefinition[];
+}
+
+/**
+ * Options for creating a component block registry
+ */
+export interface ComponentBlockRegistryOptions {
+  /** Pre-load all lazy blocks on registry creation */
+  preloadAll?: boolean;
+  /** Filter blocks by guild ID on creation */
+  guildId?: string;
+}
+
+export type { BlockTypeId, BlockProps, DocumentError, Result };

--- a/packages/edit/test/registry/blocks.test.ts
+++ b/packages/edit/test/registry/blocks.test.ts
@@ -1,0 +1,833 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod/v4";
+import {
+  createComponentBlockRegistry,
+  createDefaultComponentBlockRegistry,
+  getComponentBlockRegistry,
+  resetGlobalComponentBlockRegistry,
+  defaultComponentBlockDefinitions,
+  headingComponentBlockDefinition,
+  paragraphComponentBlockDefinition,
+  sectionComponentBlockDefinition,
+  BLOCK_CATEGORIES,
+} from "../../src/registry";
+import type {
+  BlockDefinition,
+  BlockComponentProps,
+  ComponentBlockRegistry,
+  BlockLoader,
+} from "../../src/registry";
+import { BaseBlockPropsSchema } from "../../src/model/types";
+
+describe("Component Block Registry (PZ-201)", () => {
+  describe("createComponentBlockRegistry", () => {
+    let registry: ComponentBlockRegistry;
+
+    beforeEach(() => {
+      registry = createComponentBlockRegistry();
+    });
+
+    it("creates an empty registry", () => {
+      expect(registry.getAll()).toHaveLength(0);
+    });
+
+    it("registers a new block type with component", () => {
+      const result = registry.register(paragraphComponentBlockDefinition);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.typeId).toBe("paragraph");
+        expect(result.value.isLazy).toBe(false);
+        expect(result.value.loadedAt).toBeInstanceOf(Date);
+      }
+      expect(registry.has("paragraph")).toBe(true);
+      expect(registry.get("paragraph")).toBeDefined();
+    });
+
+    it("returns error when registering duplicate block type", () => {
+      registry.register(paragraphComponentBlockDefinition);
+      const result = registry.register(paragraphComponentBlockDefinition);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("REGISTRY_ERROR");
+        expect(result.error.message).toContain("paragraph");
+        expect(result.error.message).toContain("already registered");
+      }
+    });
+
+    it("retrieves block by ID", () => {
+      registry.register(headingComponentBlockDefinition);
+      const block = registry.get("heading");
+      expect(block).toBeDefined();
+      expect(block?.id).toBe("heading");
+      expect(block?.name).toBe("Heading");
+      expect(block?.component).toBeDefined();
+    });
+
+    it("returns undefined for unregistered ID", () => {
+      expect(registry.get("nonexistent")).toBeUndefined();
+    });
+
+    it("returns all registered blocks", () => {
+      registry.register(paragraphComponentBlockDefinition);
+      registry.register(headingComponentBlockDefinition);
+      const all = registry.getAll();
+      expect(all).toHaveLength(2);
+      expect(all.map((b) => b.id)).toContain("paragraph");
+      expect(all.map((b) => b.id)).toContain("heading");
+    });
+
+    it("filters blocks by category", () => {
+      registry.register(paragraphComponentBlockDefinition);
+      registry.register(headingComponentBlockDefinition);
+      registry.register(sectionComponentBlockDefinition);
+
+      const typography = registry.getByCategory("typography");
+      expect(typography.map((b) => b.id)).toContain("paragraph");
+      expect(typography.map((b) => b.id)).toContain("heading");
+
+      const layout = registry.getByCategory("layout");
+      expect(layout.map((b) => b.id)).toContain("section");
+    });
+
+    it("unregisters a block type", () => {
+      registry.register(paragraphComponentBlockDefinition);
+      expect(registry.has("paragraph")).toBe(true);
+
+      const result = registry.unregister("paragraph");
+      expect(result).toBe(true);
+      expect(registry.has("paragraph")).toBe(false);
+      expect(registry.get("paragraph")).toBeUndefined();
+    });
+
+    it("returns false when unregistering non-existent type", () => {
+      const result = registry.unregister("nonexistent");
+      expect(result).toBe(false);
+    });
+
+    it("clears all registrations", () => {
+      registry.register(paragraphComponentBlockDefinition);
+      registry.register(headingComponentBlockDefinition);
+      expect(registry.getAll()).toHaveLength(2);
+
+      registry.clear();
+      expect(registry.getAll()).toHaveLength(0);
+      expect(registry.has("paragraph")).toBe(false);
+    });
+  });
+
+  describe("validateProps", () => {
+    let registry: ComponentBlockRegistry;
+
+    beforeEach(() => {
+      registry = createComponentBlockRegistry();
+      registry.register(paragraphComponentBlockDefinition);
+      registry.register(headingComponentBlockDefinition);
+    });
+
+    it("validates valid props", () => {
+      const result = registry.validateProps("paragraph", {
+        content: "Hello world",
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.content).toBe("Hello world");
+      }
+    });
+
+    it("returns error for invalid props", () => {
+      const result = registry.validateProps("heading", {
+        level: 10, // Invalid: must be 1-6
+        content: "Title",
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("VALIDATION_ERROR");
+      }
+    });
+
+    it("returns error for unknown block type", () => {
+      const result = registry.validateProps("nonexistent", {});
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("INVALID_BLOCK_TYPE");
+      }
+    });
+
+    it("validates optional props", () => {
+      const result = registry.validateProps("paragraph", {
+        content: "Text",
+        align: "center",
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it("rejects invalid enum values", () => {
+      const result = registry.validateProps("paragraph", {
+        content: "Text",
+        align: "invalid",
+      });
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  describe("canContain", () => {
+    let registry: ComponentBlockRegistry;
+
+    beforeEach(() => {
+      registry = createComponentBlockRegistry();
+      registry.register(paragraphComponentBlockDefinition);
+      registry.register(sectionComponentBlockDefinition);
+
+      // Register a container with restricted children
+      const restrictedContainer: BlockDefinition<{ name: string }> = {
+        id: "restricted-container",
+        name: "Restricted Container",
+        icon: "box",
+        category: "layout",
+        isContainer: true,
+        allowedChildren: ["paragraph"],
+        propsSchema: z.object({ name: z.string() }),
+        defaultProps: { name: "" },
+        component: () => null,
+      };
+      registry.register(restrictedContainer);
+    });
+
+    it("non-container blocks cannot contain children", () => {
+      const result = registry.canContain("paragraph", "paragraph");
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toBe(false);
+      }
+    });
+
+    it("container without restrictions allows any type", () => {
+      const result = registry.canContain("section", "paragraph");
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toBe(true);
+      }
+    });
+
+    it("restricted container allows specified types", () => {
+      const result = registry.canContain("restricted-container", "paragraph");
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toBe(true);
+      }
+    });
+
+    it("restricted container rejects non-allowed types", () => {
+      const result = registry.canContain("restricted-container", "section");
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toBe(false);
+      }
+    });
+
+    it("returns error for unknown parent type", () => {
+      const result = registry.canContain("nonexistent", "paragraph");
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("INVALID_BLOCK_TYPE");
+      }
+    });
+  });
+
+  describe("createDefaultComponentBlockRegistry", () => {
+    it("creates registry with all default blocks", () => {
+      const registry = createDefaultComponentBlockRegistry();
+      expect(registry.getAll().length).toBe(defaultComponentBlockDefinitions.length);
+    });
+
+    it("includes all required block types", () => {
+      const registry = createDefaultComponentBlockRegistry();
+      expect(registry.has("heading")).toBe(true);
+      expect(registry.has("paragraph")).toBe(true);
+      expect(registry.has("list")).toBe(true);
+      expect(registry.has("quote")).toBe(true);
+      expect(registry.has("code")).toBe(true);
+      expect(registry.has("section")).toBe(true);
+      expect(registry.has("columns")).toBe(true);
+      expect(registry.has("image")).toBe(true);
+      expect(registry.has("form")).toBe(true);
+    });
+
+    it("creates isolated registry instances", () => {
+      const registry1 = createDefaultComponentBlockRegistry();
+      const registry2 = createDefaultComponentBlockRegistry();
+
+      registry1.unregister("heading");
+      expect(registry1.has("heading")).toBe(false);
+      expect(registry2.has("heading")).toBe(true);
+    });
+
+    it("all default blocks have components", () => {
+      const registry = createDefaultComponentBlockRegistry();
+      for (const def of registry.getAll()) {
+        expect(def.component).toBeDefined();
+        expect(typeof def.component).toBe("function");
+      }
+    });
+
+    it("all default blocks have version info", () => {
+      const registry = createDefaultComponentBlockRegistry();
+      for (const def of registry.getAll()) {
+        expect(def.version).toBeDefined();
+      }
+    });
+  });
+
+  describe("getComponentBlockRegistry (global)", () => {
+    afterEach(() => {
+      resetGlobalComponentBlockRegistry();
+    });
+
+    it("returns a pre-populated registry", () => {
+      const registry = getComponentBlockRegistry();
+      expect(registry.getAll().length).toBe(defaultComponentBlockDefinitions.length);
+    });
+
+    it("returns the same instance on multiple calls", () => {
+      const registry1 = getComponentBlockRegistry();
+      const registry2 = getComponentBlockRegistry();
+      expect(registry1).toBe(registry2);
+    });
+
+    it("persists modifications across calls", () => {
+      const registry = getComponentBlockRegistry();
+      registry.unregister("heading");
+
+      const sameRegistry = getComponentBlockRegistry();
+      expect(sameRegistry.has("heading")).toBe(false);
+    });
+  });
+
+  describe("resetGlobalComponentBlockRegistry", () => {
+    it("resets the global registry to fresh state", () => {
+      const registry = getComponentBlockRegistry();
+      registry.unregister("heading");
+      registry.unregister("paragraph");
+
+      resetGlobalComponentBlockRegistry();
+
+      const freshRegistry = getComponentBlockRegistry();
+      expect(freshRegistry.has("heading")).toBe(true);
+      expect(freshRegistry.has("paragraph")).toBe(true);
+    });
+  });
+
+  describe("Category grouping", () => {
+    it("groups typography blocks correctly", () => {
+      const registry = createDefaultComponentBlockRegistry();
+      const typography = registry.getByCategory("typography");
+      const ids = typography.map((b) => b.id).sort();
+      expect(ids).toContain("heading");
+      expect(ids).toContain("paragraph");
+      expect(ids).toContain("list");
+      expect(ids).toContain("quote");
+      expect(ids).toContain("code");
+      expect(ids).toContain("callout");
+      expect(ids).toContain("table");
+    });
+
+    it("groups layout blocks correctly", () => {
+      const registry = createDefaultComponentBlockRegistry();
+      const layout = registry.getByCategory("layout");
+      const ids = layout.map((b) => b.id).sort();
+      expect(ids).toContain("divider");
+      expect(ids).toContain("section");
+      expect(ids).toContain("columns");
+    });
+
+    it("groups media blocks correctly", () => {
+      const registry = createDefaultComponentBlockRegistry();
+      const media = registry.getByCategory("media");
+      const ids = media.map((b) => b.id).sort();
+      expect(ids).toContain("image");
+      expect(ids).toContain("video");
+    });
+
+    it("groups form blocks correctly", () => {
+      const registry = createDefaultComponentBlockRegistry();
+      const form = registry.getByCategory("form");
+      expect(form.map((b) => b.id)).toContain("form");
+    });
+
+    it("groups embed blocks correctly", () => {
+      const registry = createDefaultComponentBlockRegistry();
+      const embed = registry.getByCategory("embed");
+      expect(embed.map((b) => b.id)).toContain("embed");
+    });
+  });
+
+  describe("getAllCategories", () => {
+    it("returns a map of all categories with their blocks", () => {
+      const registry = createDefaultComponentBlockRegistry();
+      const categories = registry.getAllCategories();
+
+      expect(categories).toBeInstanceOf(Map);
+      expect(categories.has("typography")).toBe(true);
+      expect(categories.has("layout")).toBe(true);
+      expect(categories.has("media")).toBe(true);
+      expect(categories.has("form")).toBe(true);
+      expect(categories.has("embed")).toBe(true);
+      expect(categories.has("platform")).toBe(true);
+      expect(categories.has("gaming")).toBe(true);
+      expect(categories.has("other")).toBe(true);
+    });
+
+    it("includes empty categories", () => {
+      const registry = createDefaultComponentBlockRegistry();
+      const categories = registry.getAllCategories();
+
+      // Platform and gaming should exist but be empty with default blocks
+      expect(categories.get("platform")).toEqual([]);
+      expect(categories.get("gaming")).toEqual([]);
+    });
+
+    it("returns blocks grouped by their categories", () => {
+      const registry = createDefaultComponentBlockRegistry();
+      const categories = registry.getAllCategories();
+
+      const typography = categories.get("typography");
+      expect(typography).toBeDefined();
+      expect(typography!.length).toBeGreaterThan(0);
+      expect(typography!.every((b) => b.category === "typography")).toBe(true);
+    });
+  });
+
+  describe("getCategoryMeta", () => {
+    it("returns metadata for valid category", () => {
+      const registry = createDefaultComponentBlockRegistry();
+      const meta = registry.getCategoryMeta("typography");
+
+      expect(meta).toBeDefined();
+      expect(meta?.id).toBe("typography");
+      expect(meta?.name).toBe("Typography");
+      expect(meta?.icon).toBeDefined();
+      expect(meta?.order).toBe(0);
+    });
+
+    it("returns undefined for invalid category", () => {
+      const registry = createDefaultComponentBlockRegistry();
+      // @ts-expect-error - testing invalid category
+      const meta = registry.getCategoryMeta("invalid-category");
+      expect(meta).toBeUndefined();
+    });
+
+    it("returns metadata for new categories (platform, gaming)", () => {
+      const registry = createDefaultComponentBlockRegistry();
+
+      const platform = registry.getCategoryMeta("platform");
+      expect(platform).toBeDefined();
+      expect(platform?.name).toBe("Platform");
+
+      const gaming = registry.getCategoryMeta("gaming");
+      expect(gaming).toBeDefined();
+      expect(gaming?.name).toBe("Gaming");
+    });
+  });
+
+  describe("BLOCK_CATEGORIES", () => {
+    it("contains all expected categories", () => {
+      const categoryIds = BLOCK_CATEGORIES.map((c) => c.id);
+      expect(categoryIds).toContain("typography");
+      expect(categoryIds).toContain("media");
+      expect(categoryIds).toContain("layout");
+      expect(categoryIds).toContain("form");
+      expect(categoryIds).toContain("embed");
+      expect(categoryIds).toContain("platform");
+      expect(categoryIds).toContain("gaming");
+      expect(categoryIds).toContain("other");
+    });
+
+    it("categories are sorted by order", () => {
+      const orders = BLOCK_CATEGORIES.map((c) => c.order);
+      expect(orders).toEqual([...orders].sort((a, b) => a - b));
+    });
+
+    it("each category has required properties", () => {
+      for (const category of BLOCK_CATEGORIES) {
+        expect(category.id).toBeDefined();
+        expect(category.name).toBeDefined();
+        expect(category.description).toBeDefined();
+        expect(category.icon).toBeDefined();
+        expect(typeof category.order).toBe("number");
+      }
+    });
+  });
+
+  describe("Dynamic loading", () => {
+    let registry: ComponentBlockRegistry;
+
+    beforeEach(() => {
+      registry = createComponentBlockRegistry();
+    });
+
+    it("registers lazy block with loader", () => {
+      const MockComponent = () => null;
+      const loader: BlockLoader<{ content: string }> = async () => ({
+        component: MockComponent,
+      });
+
+      const lazyBlock: BlockDefinition<{ content: string }> = {
+        id: "lazy-block",
+        name: "Lazy Block",
+        icon: "clock",
+        category: "other",
+        isContainer: false,
+        propsSchema: BaseBlockPropsSchema.extend({ content: z.string() }),
+        defaultProps: { content: "" },
+        loader,
+      };
+
+      const result = registry.register(lazyBlock);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.isLazy).toBe(true);
+        expect(result.value.loadedAt).toBeUndefined();
+      }
+    });
+
+    it("isLoaded returns false for lazy blocks", () => {
+      const loader: BlockLoader<{ content: string }> = async () => ({
+        component: () => null,
+      });
+
+      const lazyBlock: BlockDefinition<{ content: string }> = {
+        id: "lazy-block",
+        name: "Lazy Block",
+        icon: "clock",
+        category: "other",
+        isContainer: false,
+        propsSchema: BaseBlockPropsSchema.extend({ content: z.string() }),
+        defaultProps: { content: "" },
+        loader,
+      };
+
+      registry.register(lazyBlock);
+      expect(registry.isLoaded("lazy-block")).toBe(false);
+    });
+
+    it("isLoaded returns true for blocks with component", () => {
+      registry.register(paragraphComponentBlockDefinition);
+      expect(registry.isLoaded("paragraph")).toBe(true);
+    });
+
+    it("loadBlock loads lazy block component", async () => {
+      const MockComponent = () => null;
+      const loader = vi.fn().mockResolvedValue({
+        component: MockComponent,
+      });
+
+      const lazyBlock: BlockDefinition<{ content: string }> = {
+        id: "lazy-block",
+        name: "Lazy Block",
+        icon: "clock",
+        category: "other",
+        isContainer: false,
+        propsSchema: BaseBlockPropsSchema.extend({ content: z.string() }),
+        defaultProps: { content: "" },
+        loader,
+      };
+
+      registry.register(lazyBlock);
+      expect(registry.isLoaded("lazy-block")).toBe(false);
+
+      const result = await registry.loadBlock("lazy-block");
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.component).toBe(MockComponent);
+      }
+      expect(registry.isLoaded("lazy-block")).toBe(true);
+      expect(loader).toHaveBeenCalledTimes(1);
+    });
+
+    it("loadBlock returns existing definition if already loaded", async () => {
+      const MockComponent = () => null;
+      const loader = vi.fn().mockResolvedValue({
+        component: MockComponent,
+      });
+
+      const lazyBlock: BlockDefinition<{ content: string }> = {
+        id: "lazy-block",
+        name: "Lazy Block",
+        icon: "clock",
+        category: "other",
+        isContainer: false,
+        propsSchema: BaseBlockPropsSchema.extend({ content: z.string() }),
+        defaultProps: { content: "" },
+        loader,
+      };
+
+      registry.register(lazyBlock);
+
+      // Load once
+      await registry.loadBlock("lazy-block");
+      // Load again
+      await registry.loadBlock("lazy-block");
+
+      // Loader should only be called once
+      expect(loader).toHaveBeenCalledTimes(1);
+    });
+
+    it("loadBlock returns error for unknown block", async () => {
+      const result = await registry.loadBlock("nonexistent");
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("INVALID_BLOCK_TYPE");
+      }
+    });
+
+    it("loadBlock handles loader errors", async () => {
+      const loader = vi.fn().mockRejectedValue(new Error("Load failed"));
+
+      const lazyBlock: BlockDefinition<{ content: string }> = {
+        id: "lazy-block",
+        name: "Lazy Block",
+        icon: "clock",
+        category: "other",
+        isContainer: false,
+        propsSchema: BaseBlockPropsSchema.extend({ content: z.string() }),
+        defaultProps: { content: "" },
+        loader,
+      };
+
+      registry.register(lazyBlock);
+
+      const result = await registry.loadBlock("lazy-block");
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("REGISTRY_ERROR");
+        expect(result.error.message).toContain("Load failed");
+      }
+    });
+
+    it("loadBlock deduplicates concurrent loads", async () => {
+      const MockComponent = () => null;
+      const loader = vi.fn().mockImplementation(
+        () =>
+          new Promise((resolve) =>
+            setTimeout(() => resolve({ component: MockComponent }), 10)
+          )
+      );
+
+      const lazyBlock: BlockDefinition<{ content: string }> = {
+        id: "lazy-block",
+        name: "Lazy Block",
+        icon: "clock",
+        category: "other",
+        isContainer: false,
+        propsSchema: BaseBlockPropsSchema.extend({ content: z.string() }),
+        defaultProps: { content: "" },
+        loader,
+      };
+
+      registry.register(lazyBlock);
+
+      // Start multiple loads concurrently
+      const [result1, result2, result3] = await Promise.all([
+        registry.loadBlock("lazy-block"),
+        registry.loadBlock("lazy-block"),
+        registry.loadBlock("lazy-block"),
+      ]);
+
+      // All should succeed
+      expect(result1.ok).toBe(true);
+      expect(result2.ok).toBe(true);
+      expect(result3.ok).toBe(true);
+
+      // Loader should only be called once
+      expect(loader).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects blocks with both component and loader", () => {
+      const blockWithBoth: BlockDefinition<{ content: string }> = {
+        id: "invalid-block",
+        name: "Invalid Block",
+        icon: "x",
+        category: "other",
+        isContainer: false,
+        propsSchema: BaseBlockPropsSchema.extend({ content: z.string() }),
+        defaultProps: { content: "" },
+        component: () => null,
+        loader: async () => ({ component: () => null }),
+      };
+
+      const result = registry.register(blockWithBoth);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("VALIDATION_ERROR");
+        expect(result.error.message).toContain("both component and loader");
+      }
+    });
+  });
+
+  describe("Guild restrictions", () => {
+    it("getForGuild returns all blocks without restrictions", () => {
+      const registry = createDefaultComponentBlockRegistry();
+      const blocks = registry.getForGuild("guild-123");
+
+      // All default blocks have no guild restrictions
+      expect(blocks.length).toBe(defaultComponentBlockDefinitions.length);
+    });
+
+    it("getForGuild filters blocks by guild ID", () => {
+      const registry = createComponentBlockRegistry();
+      registry.register(paragraphComponentBlockDefinition);
+
+      const restrictedBlock: BlockDefinition<{ content: string }> = {
+        id: "guild-specific",
+        name: "Guild Specific",
+        icon: "star",
+        category: "other",
+        isContainer: false,
+        propsSchema: BaseBlockPropsSchema.extend({ content: z.string() }),
+        defaultProps: { content: "" },
+        component: () => null,
+        guildRestrictions: ["guild-123", "guild-456"],
+      };
+      registry.register(restrictedBlock);
+
+      // Guild with access
+      const withAccess = registry.getForGuild("guild-123");
+      expect(withAccess.map((b) => b.id)).toContain("guild-specific");
+      expect(withAccess.map((b) => b.id)).toContain("paragraph");
+
+      // Guild without access
+      const withoutAccess = registry.getForGuild("guild-789");
+      expect(withoutAccess.map((b) => b.id)).not.toContain("guild-specific");
+      expect(withoutAccess.map((b) => b.id)).toContain("paragraph");
+    });
+
+    it("registry with guildId option filters on registration", () => {
+      const registry = createComponentBlockRegistry({ guildId: "guild-123" });
+
+      // Should register successfully - guild is allowed
+      const restrictedAllowed: BlockDefinition<{ content: string }> = {
+        id: "allowed-block",
+        name: "Allowed Block",
+        icon: "check",
+        category: "other",
+        isContainer: false,
+        propsSchema: BaseBlockPropsSchema.extend({ content: z.string() }),
+        defaultProps: { content: "" },
+        component: () => null,
+        guildRestrictions: ["guild-123"],
+      };
+      const allowedResult = registry.register(restrictedAllowed);
+      expect(allowedResult.ok).toBe(true);
+
+      // Should fail - guild is not allowed
+      const restrictedDenied: BlockDefinition<{ content: string }> = {
+        id: "denied-block",
+        name: "Denied Block",
+        icon: "x",
+        category: "other",
+        isContainer: false,
+        propsSchema: BaseBlockPropsSchema.extend({ content: z.string() }),
+        defaultProps: { content: "" },
+        component: () => null,
+        guildRestrictions: ["guild-456"],
+      };
+      const deniedResult = registry.register(restrictedDenied);
+      expect(deniedResult.ok).toBe(false);
+      if (!deniedResult.ok) {
+        expect(deniedResult.error.code).toBe("VALIDATION_ERROR");
+        expect(deniedResult.error.message).toContain("not available for guild");
+      }
+    });
+
+    it("blocks without restrictions pass guild filter", () => {
+      const registry = createComponentBlockRegistry({ guildId: "guild-123" });
+      const result = registry.register(paragraphComponentBlockDefinition);
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  describe("Search functionality", () => {
+    let registry: ComponentBlockRegistry;
+
+    beforeEach(() => {
+      registry = createDefaultComponentBlockRegistry();
+    });
+
+    it("searches by block name", () => {
+      const results = registry.search("heading");
+      expect(results.map((b) => b.id)).toContain("heading");
+    });
+
+    it("searches by block description", () => {
+      const results = registry.search("syntax highlighting");
+      expect(results.map((b) => b.id)).toContain("code");
+    });
+
+    it("searches by keywords", () => {
+      const results = registry.search("h1");
+      expect(results.map((b) => b.id)).toContain("heading");
+    });
+
+    it("searches by type ID", () => {
+      const results = registry.search("paragraph");
+      expect(results.map((b) => b.id)).toContain("paragraph");
+    });
+
+    it("search is case-insensitive", () => {
+      const results = registry.search("HEADING");
+      expect(results.map((b) => b.id)).toContain("heading");
+    });
+
+    it("returns empty array for empty query", () => {
+      const results = registry.search("");
+      expect(results).toHaveLength(0);
+    });
+
+    it("returns empty array for whitespace query", () => {
+      const results = registry.search("   ");
+      expect(results).toHaveLength(0);
+    });
+
+    it("returns empty array for no matches", () => {
+      const results = registry.search("xyznonexistent123");
+      expect(results).toHaveLength(0);
+    });
+
+    it("returns multiple matches", () => {
+      const results = registry.search("text");
+      // Should match paragraph (description contains "text") and others
+      expect(results.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("Premium blocks", () => {
+    it("can register premium blocks", () => {
+      const registry = createComponentBlockRegistry();
+
+      const premiumBlock: BlockDefinition<{ content: string }> = {
+        id: "premium-block",
+        name: "Premium Block",
+        icon: "crown",
+        category: "other",
+        isContainer: false,
+        propsSchema: BaseBlockPropsSchema.extend({ content: z.string() }),
+        defaultProps: { content: "" },
+        component: () => null,
+        isPremium: true,
+      };
+
+      const result = registry.register(premiumBlock);
+      expect(result.ok).toBe(true);
+
+      const retrieved = registry.get("premium-block");
+      expect(retrieved?.isPremium).toBe(true);
+    });
+
+    it("default blocks are not premium", () => {
+      const registry = createDefaultComponentBlockRegistry();
+      for (const def of registry.getAll()) {
+        expect(def.isPremium).toBeFalsy();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements PZ-201 (#42): Registry of available block types with components and schemas.

- BlockDefinition interface with component and category support
- 8 block categories with metadata for sidebar display
- Category grouping methods (getByCategory, getAllCategories)
- Prop schema validation using Zod v4
- Dynamic/lazy loading for guild-specific blocks
- 14 default block definitions with React component stubs

## Technical Details

**Registry Features:**
- `register()`, `get()`, `getAll()`, `has()`, `unregister()`, `clear()`
- `getByCategory()`, `getAllCategories()`, `getCategoryMeta()`
- `validateProps()`, `canContain()`
- `loadBlock()` - Async lazy loading with deduplication
- `getForGuild()` - Guild-based filtering
- `search()` - Keyword search across name, description, keywords

**Design Patterns:**
- Result<T, E> pattern (no thrown exceptions)
- UUIDv7 for identifiers
- TypeScript strict mode

## Test Plan

- [x] Block type registration works correctly
- [x] Category grouping returns correct blocks
- [x] Prop schema validation catches invalid props
- [x] Dynamic loading deduplicates concurrent loads
- [x] Guild-based filtering works correctly
- [x] Keyword search finds matching blocks
- [x] All 269 tests pass (67 new)

Closes #42

:robot: Generated with [Claude Code](https://claude.com/claude-code)