### PR TITLE
feat(edit): implement Block Selection & Focus (PZ-207)

### DIFF
--- a/packages/edit/src/index.ts
+++ b/packages/edit/src/index.ts
@@ -182,6 +182,85 @@ export {
   videoComponentBlockDefinition,
 } from "./registry";
 
+// Block Selection & Focus (PZ-207)
+export {
+  // Types
+  type ClickAction,
+  type FocusDirection,
+  type FocusState,
+  type KeyboardAction,
+  type KeyboardConfig,
+  type MultiSelectionState,
+  type SelectionError,
+  type SelectionErrorCode,
+  type SelectionFocusState,
+  type SelectionMode,
+  type SelectionResult,
+  // Schemas
+  FocusStateSchema,
+  MultiSelectionStateSchema,
+  SelectionFocusStateSchema,
+  // State factories
+  createInitialFocus,
+  createInitialMultiSelection,
+  createInitialSelectionFocus,
+  createSelectionError,
+  // State atoms
+  $focus,
+  $multiSelection,
+  // Computed - Selection
+  $anchorBlock,
+  $hasMultiSelection,
+  $hasSelection,
+  $lastSelectedBlock,
+  $selectedBlocks,
+  $selectedIds,
+  $selectionCount,
+  // Computed - Focus
+  $focusedBlock,
+  $focusedBlockId,
+  $isEditing,
+  // State utilities
+  getBlockAtFlatIndex,
+  getBlockFlatIndex,
+  getBlockRange,
+  getFirstBlockId,
+  getFlatBlockList,
+  getLastBlockId,
+  getNextBlockId,
+  getPrevBlockId,
+  isBlockFocused,
+  isBlockSelected,
+  resetSelectionState,
+  // Selection actions
+  clearSelection,
+  deselectBlock,
+  selectAll,
+  selectBlock as selectBlockMulti,
+  selectRange,
+  toggleSelection,
+  // Focus actions
+  clearFocus,
+  enterEditMode,
+  escape,
+  exitEditMode,
+  extendSelectionDown,
+  extendSelectionUp,
+  focusBlock,
+  focusDirection,
+  focusNext,
+  focusPrev,
+  selectFocused,
+  toggleFocused,
+  // Keyboard handling
+  createKeyboardHandler,
+  defaultKeyboardConfig,
+  executeKeyboardAction,
+  handleKeyboardEvent,
+  parseKeyboardEvent,
+  shouldHandleKeyboardEvent,
+} from "./selection";
+
 // Placeholder - to be implemented in Phase 2
 export function BlockEditor(): never {
   throw new Error("Not implemented - see PZ-200: https://github.com/ezmode-games/phantom-zone/issues/41");

--- a/packages/edit/src/selection/actions.ts
+++ b/packages/edit/src/selection/actions.ts
@@ -1,0 +1,544 @@
+/**
+ * Selection & Focus Actions
+ *
+ * Actions for modifying selection and focus state.
+ * Implements PZ-207: Block Selection & Focus
+ */
+
+import { findBlockById, $document, $selectedBlockId, $selection } from "../model/document";
+import { ok, err } from "../model/types";
+import {
+  $focus,
+  $multiSelection,
+  getBlockRange,
+  getFirstBlockId,
+  getLastBlockId,
+  getNextBlockId,
+  getPrevBlockId,
+  getFlatBlockList,
+} from "./state";
+import {
+  createSelectionError,
+  type FocusDirection,
+  type SelectionResult,
+} from "./types";
+
+/**
+ * Select a single block, clearing any previous selection
+ */
+export function selectBlock(blockId: string): SelectionResult<void> {
+  const doc = $document.get();
+  const block = findBlockById(doc.blocks, blockId);
+
+  if (!block) {
+    return err(
+      createSelectionError("BLOCK_NOT_FOUND", `Block not found: ${blockId}`)
+    );
+  }
+
+  // Update multi-selection state
+  $multiSelection.set({
+    selectedIds: new Set([blockId]),
+    anchorId: blockId,
+    lastSelectedId: blockId,
+  });
+
+  // Also update the legacy single selection for compatibility
+  $selectedBlockId.set(blockId);
+  $selection.set({ blockId });
+
+  // Focus the selected block (but not in edit mode)
+  $focus.set({
+    focusedId: blockId,
+    isEditing: false,
+  });
+
+  return ok(undefined);
+}
+
+/**
+ * Deselect a specific block
+ */
+export function deselectBlock(blockId: string): SelectionResult<void> {
+  const selection = $multiSelection.get();
+
+  if (!selection.selectedIds.has(blockId)) {
+    return ok(undefined); // Already not selected, no error
+  }
+
+  const newSelectedIds = new Set(selection.selectedIds);
+  newSelectedIds.delete(blockId);
+
+  // Update anchor if we're removing it
+  let newAnchorId = selection.anchorId;
+  if (selection.anchorId === blockId) {
+    // Set new anchor to first remaining selected block, or null
+    newAnchorId = newSelectedIds.size > 0 ? [...newSelectedIds][0] ?? null : null;
+  }
+
+  // Update last selected if we're removing it
+  let newLastSelectedId = selection.lastSelectedId;
+  if (selection.lastSelectedId === blockId) {
+    newLastSelectedId = newSelectedIds.size > 0
+      ? [...newSelectedIds][newSelectedIds.size - 1] ?? null
+      : null;
+  }
+
+  $multiSelection.set({
+    selectedIds: newSelectedIds,
+    anchorId: newAnchorId,
+    lastSelectedId: newLastSelectedId,
+  });
+
+  // Update legacy selection
+  if (newLastSelectedId) {
+    $selectedBlockId.set(newLastSelectedId);
+    $selection.set({ blockId: newLastSelectedId });
+  } else {
+    $selectedBlockId.set(null);
+    $selection.set({ blockId: null });
+  }
+
+  return ok(undefined);
+}
+
+/**
+ * Toggle selection of a block (for Cmd/Ctrl+Click)
+ */
+export function toggleSelection(blockId: string): SelectionResult<void> {
+  const doc = $document.get();
+  const block = findBlockById(doc.blocks, blockId);
+
+  if (!block) {
+    return err(
+      createSelectionError("BLOCK_NOT_FOUND", `Block not found: ${blockId}`)
+    );
+  }
+
+  const selection = $multiSelection.get();
+
+  if (selection.selectedIds.has(blockId)) {
+    return deselectBlock(blockId);
+  }
+
+  // Add to selection
+  const newSelectedIds = new Set(selection.selectedIds);
+  newSelectedIds.add(blockId);
+
+  $multiSelection.set({
+    selectedIds: newSelectedIds,
+    anchorId: selection.anchorId ?? blockId,
+    lastSelectedId: blockId,
+  });
+
+  // Update legacy selection to point to the newly added block
+  $selectedBlockId.set(blockId);
+  $selection.set({ blockId });
+
+  // Focus the toggled block
+  $focus.set({
+    focusedId: blockId,
+    isEditing: false,
+  });
+
+  return ok(undefined);
+}
+
+/**
+ * Select a range of blocks (for Shift+Click)
+ * Selects all blocks between the anchor and the target block
+ */
+export function selectRange(blockId: string): SelectionResult<void> {
+  const doc = $document.get();
+  const block = findBlockById(doc.blocks, blockId);
+
+  if (!block) {
+    return err(
+      createSelectionError("BLOCK_NOT_FOUND", `Block not found: ${blockId}`)
+    );
+  }
+
+  const selection = $multiSelection.get();
+
+  // If no anchor, treat as single select
+  if (!selection.anchorId) {
+    return selectBlock(blockId);
+  }
+
+  // Get all blocks in range
+  const rangeIds = getBlockRange(selection.anchorId, blockId);
+
+  if (rangeIds.length === 0) {
+    return err(
+      createSelectionError(
+        "INVALID_RANGE",
+        `Cannot create range between ${selection.anchorId} and ${blockId}`
+      )
+    );
+  }
+
+  $multiSelection.set({
+    selectedIds: new Set(rangeIds),
+    anchorId: selection.anchorId, // Keep the original anchor
+    lastSelectedId: blockId,
+  });
+
+  // Update legacy selection
+  $selectedBlockId.set(blockId);
+  $selection.set({ blockId });
+
+  // Focus the target block
+  $focus.set({
+    focusedId: blockId,
+    isEditing: false,
+  });
+
+  return ok(undefined);
+}
+
+/**
+ * Clear all selection
+ */
+export function clearSelection(): void {
+  $multiSelection.set({
+    selectedIds: new Set(),
+    anchorId: null,
+    lastSelectedId: null,
+  });
+
+  // Update legacy selection
+  $selectedBlockId.set(null);
+  $selection.set({ blockId: null });
+
+  // Exit edit mode but keep focus
+  const focus = $focus.get();
+  if (focus.isEditing) {
+    $focus.set({
+      focusedId: focus.focusedId,
+      isEditing: false,
+    });
+  }
+}
+
+/**
+ * Select all blocks in the document
+ */
+export function selectAll(): SelectionResult<void> {
+  const allIds = getFlatBlockList();
+
+  if (allIds.length === 0) {
+    return err(
+      createSelectionError("NO_BLOCKS_AVAILABLE", "No blocks to select")
+    );
+  }
+
+  const firstId = allIds[0];
+  const lastId = allIds[allIds.length - 1];
+
+  $multiSelection.set({
+    selectedIds: new Set(allIds),
+    anchorId: firstId ?? null,
+    lastSelectedId: lastId ?? null,
+  });
+
+  // Update legacy selection
+  $selectedBlockId.set(lastId ?? null);
+  $selection.set({ blockId: lastId ?? null });
+
+  return ok(undefined);
+}
+
+/**
+ * Focus a specific block without selecting it
+ */
+export function focusBlock(blockId: string): SelectionResult<void> {
+  const doc = $document.get();
+  const block = findBlockById(doc.blocks, blockId);
+
+  if (!block) {
+    return err(
+      createSelectionError("BLOCK_NOT_FOUND", `Block not found: ${blockId}`)
+    );
+  }
+
+  $focus.set({
+    focusedId: blockId,
+    isEditing: false,
+  });
+
+  return ok(undefined);
+}
+
+/**
+ * Focus the next block in document order
+ */
+export function focusNext(): SelectionResult<void> {
+  const focus = $focus.get();
+
+  if (focus.isEditing) {
+    return err(
+      createSelectionError("ALREADY_EDITING", "Cannot navigate while editing")
+    );
+  }
+
+  let nextId: string | null;
+
+  if (focus.focusedId) {
+    nextId = getNextBlockId(focus.focusedId);
+    // If at end, stay on current block
+    if (!nextId) {
+      return ok(undefined);
+    }
+  } else {
+    // No focus, start at first block
+    nextId = getFirstBlockId();
+  }
+
+  if (!nextId) {
+    return err(
+      createSelectionError("NO_BLOCKS_AVAILABLE", "No blocks to focus")
+    );
+  }
+
+  $focus.set({
+    focusedId: nextId,
+    isEditing: false,
+  });
+
+  return ok(undefined);
+}
+
+/**
+ * Focus the previous block in document order
+ */
+export function focusPrev(): SelectionResult<void> {
+  const focus = $focus.get();
+
+  if (focus.isEditing) {
+    return err(
+      createSelectionError("ALREADY_EDITING", "Cannot navigate while editing")
+    );
+  }
+
+  let prevId: string | null;
+
+  if (focus.focusedId) {
+    prevId = getPrevBlockId(focus.focusedId);
+    // If at beginning, stay on current block
+    if (!prevId) {
+      return ok(undefined);
+    }
+  } else {
+    // No focus, start at last block
+    prevId = getLastBlockId();
+  }
+
+  if (!prevId) {
+    return err(
+      createSelectionError("NO_BLOCKS_AVAILABLE", "No blocks to focus")
+    );
+  }
+
+  $focus.set({
+    focusedId: prevId,
+    isEditing: false,
+  });
+
+  return ok(undefined);
+}
+
+/**
+ * Focus a block in a specific direction
+ */
+export function focusDirection(direction: FocusDirection): SelectionResult<void> {
+  switch (direction) {
+    case "up":
+      return focusPrev();
+    case "down":
+      return focusNext();
+    case "first": {
+      const firstId = getFirstBlockId();
+      if (!firstId) {
+        return err(
+          createSelectionError("NO_BLOCKS_AVAILABLE", "No blocks to focus")
+        );
+      }
+      return focusBlock(firstId);
+    }
+    case "last": {
+      const lastId = getLastBlockId();
+      if (!lastId) {
+        return err(
+          createSelectionError("NO_BLOCKS_AVAILABLE", "No blocks to focus")
+        );
+      }
+      return focusBlock(lastId);
+    }
+  }
+}
+
+/**
+ * Select the currently focused block
+ */
+export function selectFocused(): SelectionResult<void> {
+  const focus = $focus.get();
+
+  if (!focus.focusedId) {
+    return err(
+      createSelectionError("NO_BLOCKS_AVAILABLE", "No block is focused")
+    );
+  }
+
+  return selectBlock(focus.focusedId);
+}
+
+/**
+ * Toggle selection of the currently focused block
+ */
+export function toggleFocused(): SelectionResult<void> {
+  const focus = $focus.get();
+
+  if (!focus.focusedId) {
+    return err(
+      createSelectionError("NO_BLOCKS_AVAILABLE", "No block is focused")
+    );
+  }
+
+  return toggleSelection(focus.focusedId);
+}
+
+/**
+ * Extend selection to the next block
+ */
+export function extendSelectionDown(): SelectionResult<void> {
+  const focus = $focus.get();
+  const selection = $multiSelection.get();
+
+  if (focus.isEditing) {
+    return err(
+      createSelectionError("ALREADY_EDITING", "Cannot extend selection while editing")
+    );
+  }
+
+  // If nothing is focused or selected, start from first block
+  const currentId = focus.focusedId ?? selection.lastSelectedId ?? getFirstBlockId();
+
+  if (!currentId) {
+    return err(
+      createSelectionError("NO_BLOCKS_AVAILABLE", "No blocks available")
+    );
+  }
+
+  const nextId = getNextBlockId(currentId);
+
+  if (!nextId) {
+    // Already at the end
+    return ok(undefined);
+  }
+
+  // Extend selection to include the next block
+  return selectRange(nextId);
+}
+
+/**
+ * Extend selection to the previous block
+ */
+export function extendSelectionUp(): SelectionResult<void> {
+  const focus = $focus.get();
+  const selection = $multiSelection.get();
+
+  if (focus.isEditing) {
+    return err(
+      createSelectionError("ALREADY_EDITING", "Cannot extend selection while editing")
+    );
+  }
+
+  // If nothing is focused or selected, start from last block
+  const currentId = focus.focusedId ?? selection.lastSelectedId ?? getLastBlockId();
+
+  if (!currentId) {
+    return err(
+      createSelectionError("NO_BLOCKS_AVAILABLE", "No blocks available")
+    );
+  }
+
+  const prevId = getPrevBlockId(currentId);
+
+  if (!prevId) {
+    // Already at the beginning
+    return ok(undefined);
+  }
+
+  // Extend selection to include the previous block
+  return selectRange(prevId);
+}
+
+/**
+ * Enter edit mode for the focused block
+ */
+export function enterEditMode(): SelectionResult<void> {
+  const focus = $focus.get();
+
+  if (!focus.focusedId) {
+    return err(
+      createSelectionError("NO_BLOCKS_AVAILABLE", "No block is focused")
+    );
+  }
+
+  if (focus.isEditing) {
+    return ok(undefined); // Already in edit mode
+  }
+
+  $focus.set({
+    focusedId: focus.focusedId,
+    isEditing: true,
+  });
+
+  return ok(undefined);
+}
+
+/**
+ * Exit edit mode (but keep focus on the block)
+ */
+export function exitEditMode(): SelectionResult<void> {
+  const focus = $focus.get();
+
+  if (!focus.isEditing) {
+    return ok(undefined); // Already not in edit mode
+  }
+
+  $focus.set({
+    focusedId: focus.focusedId,
+    isEditing: false,
+  });
+
+  return ok(undefined);
+}
+
+/**
+ * Clear focus entirely
+ */
+export function clearFocus(): void {
+  $focus.set({
+    focusedId: null,
+    isEditing: false,
+  });
+}
+
+/**
+ * Deselect all and clear focus (Escape behavior)
+ */
+export function escape(): void {
+  const focus = $focus.get();
+
+  if (focus.isEditing) {
+    // First escape exits edit mode
+    exitEditMode();
+  } else if ($multiSelection.get().selectedIds.size > 0) {
+    // Second escape clears selection
+    clearSelection();
+  } else if (focus.focusedId) {
+    // Third escape clears focus
+    clearFocus();
+  }
+}

--- a/packages/edit/src/selection/index.ts
+++ b/packages/edit/src/selection/index.ts
@@ -1,0 +1,95 @@
+/**
+ * Selection & Focus Module
+ *
+ * Block selection and keyboard focus management for the editor.
+ * Implements PZ-207: Block Selection & Focus
+ */
+
+// Types
+export {
+  type ClickAction,
+  type FocusDirection,
+  type FocusState,
+  type KeyboardAction,
+  type MultiSelectionState,
+  type SelectionError,
+  type SelectionErrorCode,
+  type SelectionFocusState,
+  type SelectionMode,
+  type SelectionResult,
+  // Schemas
+  FocusStateSchema,
+  MultiSelectionStateSchema,
+  SelectionFocusStateSchema,
+  // Utility functions
+  createInitialFocus,
+  createInitialMultiSelection,
+  createInitialSelectionFocus,
+  createSelectionError,
+} from "./types";
+
+// State atoms and computed values
+export {
+  // Atoms
+  $focus,
+  $multiSelection,
+  // Computed - Selection
+  $anchorBlock,
+  $hasMultiSelection,
+  $hasSelection,
+  $lastSelectedBlock,
+  $selectedBlocks,
+  $selectedIds,
+  $selectionCount,
+  // Computed - Focus
+  $focusedBlock,
+  $focusedBlockId,
+  $isEditing,
+  // Utility functions
+  getBlockAtFlatIndex,
+  getBlockFlatIndex,
+  getBlockRange,
+  getFirstBlockId,
+  getFlatBlockList,
+  getLastBlockId,
+  getNextBlockId,
+  getPrevBlockId,
+  isBlockFocused,
+  isBlockSelected,
+  resetSelectionState,
+} from "./state";
+
+// Actions
+export {
+  // Selection actions
+  clearSelection,
+  deselectBlock,
+  selectAll,
+  selectBlock,
+  selectRange,
+  toggleSelection,
+  // Focus actions
+  clearFocus,
+  enterEditMode,
+  escape,
+  exitEditMode,
+  extendSelectionDown,
+  extendSelectionUp,
+  focusBlock,
+  focusDirection,
+  focusNext,
+  focusPrev,
+  selectFocused,
+  toggleFocused,
+} from "./actions";
+
+// Keyboard handling
+export {
+  type KeyboardConfig,
+  createKeyboardHandler,
+  defaultKeyboardConfig,
+  executeKeyboardAction,
+  handleKeyboardEvent,
+  parseKeyboardEvent,
+  shouldHandleKeyboardEvent,
+} from "./keyboard";

--- a/packages/edit/src/selection/keyboard.ts
+++ b/packages/edit/src/selection/keyboard.ts
@@ -1,0 +1,251 @@
+/**
+ * Keyboard Event Handlers for Selection & Focus
+ *
+ * Keyboard navigation and shortcuts for block selection.
+ * Implements PZ-207: Block Selection & Focus
+ */
+
+import {
+  clearSelection,
+  enterEditMode,
+  escape,
+  exitEditMode,
+  extendSelectionDown,
+  extendSelectionUp,
+  focusNext,
+  focusPrev,
+  selectAll,
+  selectFocused,
+} from "./actions";
+import { $focus, $multiSelection } from "./state";
+import type { KeyboardAction, SelectionResult } from "./types";
+
+/**
+ * Keyboard event configuration
+ */
+export interface KeyboardConfig {
+  /** Enable arrow key navigation */
+  enableArrowKeys: boolean;
+  /** Enable Tab/Shift+Tab navigation */
+  enableTabNavigation: boolean;
+  /** Enable Enter to edit */
+  enableEnterToEdit: boolean;
+  /** Enable Escape to deselect */
+  enableEscape: boolean;
+  /** Enable Cmd/Ctrl+A to select all */
+  enableSelectAll: boolean;
+  /** Enable Shift+Arrow for range selection */
+  enableShiftArrows: boolean;
+}
+
+/**
+ * Default keyboard configuration
+ */
+export const defaultKeyboardConfig: KeyboardConfig = {
+  enableArrowKeys: true,
+  enableTabNavigation: true,
+  enableEnterToEdit: true,
+  enableEscape: true,
+  enableSelectAll: true,
+  enableShiftArrows: true,
+};
+
+/**
+ * Parse a keyboard event into a keyboard action
+ */
+export function parseKeyboardEvent(
+  event: KeyboardEvent,
+  config: KeyboardConfig = defaultKeyboardConfig
+): KeyboardAction | null {
+  const { key, shiftKey, metaKey, ctrlKey } = event;
+  const cmdOrCtrl = metaKey || ctrlKey;
+
+  // Escape - clear selection or exit edit mode
+  if (key === "Escape" && config.enableEscape) {
+    const focus = $focus.get();
+    if (focus.isEditing) {
+      return { type: "EXIT_EDIT_MODE" };
+    }
+    return { type: "CLEAR_SELECTION" };
+  }
+
+  // Enter - enter edit mode
+  if (key === "Enter" && config.enableEnterToEdit && !shiftKey) {
+    const focus = $focus.get();
+    if (!focus.isEditing) {
+      return { type: "ENTER_EDIT_MODE" };
+    }
+    return null; // Let the block handle Enter in edit mode
+  }
+
+  // Arrow keys (when not in edit mode)
+  const focus = $focus.get();
+  if (!focus.isEditing && config.enableArrowKeys) {
+    if (key === "ArrowDown" || key === "ArrowRight") {
+      if (shiftKey && config.enableShiftArrows) {
+        return { type: "EXTEND_SELECTION_DOWN" };
+      }
+      return { type: "FOCUS_NEXT" };
+    }
+
+    if (key === "ArrowUp" || key === "ArrowLeft") {
+      if (shiftKey && config.enableShiftArrows) {
+        return { type: "EXTEND_SELECTION_UP" };
+      }
+      return { type: "FOCUS_PREV" };
+    }
+
+    // Home/End for first/last
+    if (key === "Home") {
+      return { type: "FOCUS_FIRST" };
+    }
+
+    if (key === "End") {
+      return { type: "FOCUS_LAST" };
+    }
+  }
+
+  // Tab navigation (when not in edit mode)
+  if (key === "Tab" && config.enableTabNavigation && !focus.isEditing) {
+    if (shiftKey) {
+      return { type: "FOCUS_PREV" };
+    }
+    return { type: "FOCUS_NEXT" };
+  }
+
+  // Cmd/Ctrl+A to select all (when not in edit mode)
+  if (key === "a" && cmdOrCtrl && config.enableSelectAll && !focus.isEditing) {
+    return { type: "SELECT_ALL" };
+  }
+
+  // Space to select/toggle when focused but not editing
+  if (key === " " && !focus.isEditing) {
+    if (shiftKey || cmdOrCtrl) {
+      return { type: "TOGGLE_FOCUSED" };
+    }
+    return { type: "SELECT_FOCUSED" };
+  }
+
+  return null;
+}
+
+/**
+ * Execute a keyboard action
+ */
+export function executeKeyboardAction(action: KeyboardAction): SelectionResult<void> {
+  switch (action.type) {
+    case "FOCUS_NEXT":
+      return focusNext();
+
+    case "FOCUS_PREV":
+      return focusPrev();
+
+    case "FOCUS_FIRST": {
+      const { focusDirection } = require("./actions");
+      return focusDirection("first");
+    }
+
+    case "FOCUS_LAST": {
+      const { focusDirection } = require("./actions");
+      return focusDirection("last");
+    }
+
+    case "SELECT_FOCUSED": {
+      const { selectFocused } = require("./actions");
+      return selectFocused();
+    }
+
+    case "TOGGLE_FOCUSED": {
+      const { toggleFocused } = require("./actions");
+      return toggleFocused();
+    }
+
+    case "EXTEND_SELECTION_UP":
+      return extendSelectionUp();
+
+    case "EXTEND_SELECTION_DOWN":
+      return extendSelectionDown();
+
+    case "ENTER_EDIT_MODE":
+      return enterEditMode();
+
+    case "EXIT_EDIT_MODE":
+      return exitEditMode();
+
+    case "CLEAR_SELECTION": {
+      escape();
+      return { ok: true, value: undefined };
+    }
+
+    case "SELECT_ALL":
+      return selectAll();
+
+    default: {
+      // Exhaustive type check
+      const _exhaustive: never = action;
+      return { ok: true, value: undefined };
+    }
+  }
+}
+
+/**
+ * Handle a keyboard event for selection
+ * Returns true if the event was handled
+ */
+export function handleKeyboardEvent(
+  event: KeyboardEvent,
+  config: KeyboardConfig = defaultKeyboardConfig
+): boolean {
+  const action = parseKeyboardEvent(event, config);
+
+  if (!action) {
+    return false;
+  }
+
+  const result = executeKeyboardAction(action);
+
+  // Only prevent default if the action was handled successfully
+  // or if it's an expected failure (like trying to go past the end)
+  if (result.ok) {
+    event.preventDefault();
+    return true;
+  }
+
+  // For some errors, we still want to prevent default
+  if (!result.ok) {
+    const errorCode = result.error.code;
+    // These are expected failures that still mean we handled the event
+    if (
+      errorCode === "NO_BLOCKS_AVAILABLE" ||
+      errorCode === "ALREADY_EDITING"
+    ) {
+      event.preventDefault();
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Create a keyboard event listener for selection
+ * Use this to attach to a container element
+ */
+export function createKeyboardHandler(
+  config: KeyboardConfig = defaultKeyboardConfig
+): (event: KeyboardEvent) => void {
+  return (event: KeyboardEvent) => {
+    handleKeyboardEvent(event, config);
+  };
+}
+
+/**
+ * Check if a keyboard event should be handled by the selection system
+ * Useful for determining whether to let events bubble
+ */
+export function shouldHandleKeyboardEvent(
+  event: KeyboardEvent,
+  config: KeyboardConfig = defaultKeyboardConfig
+): boolean {
+  return parseKeyboardEvent(event, config) !== null;
+}

--- a/packages/edit/src/selection/state.ts
+++ b/packages/edit/src/selection/state.ts
@@ -1,0 +1,251 @@
+/**
+ * Selection & Focus State Management
+ *
+ * Nanostores atoms and computed values for selection state.
+ * Implements PZ-207: Block Selection & Focus
+ */
+
+import { atom, computed, type ReadableAtom, type WritableAtom } from "nanostores";
+import { $blocks, $document, findBlockById } from "../model/document";
+import type { Block } from "../model/types";
+import {
+  createInitialFocus,
+  createInitialMultiSelection,
+  type FocusState,
+  type MultiSelectionState,
+} from "./types";
+
+// Multi-selection state atom
+export const $multiSelection: WritableAtom<MultiSelectionState> = atom<MultiSelectionState>(
+  createInitialMultiSelection()
+);
+
+// Focus state atom
+export const $focus: WritableAtom<FocusState> = atom<FocusState>(createInitialFocus());
+
+/**
+ * Computed: Set of selected block IDs
+ */
+export const $selectedIds: ReadableAtom<Set<string>> = computed(
+  $multiSelection,
+  (state) => state.selectedIds
+);
+
+/**
+ * Computed: Number of selected blocks
+ */
+export const $selectionCount: ReadableAtom<number> = computed(
+  $multiSelection,
+  (state) => state.selectedIds.size
+);
+
+/**
+ * Computed: Whether any blocks are selected
+ */
+export const $hasSelection: ReadableAtom<boolean> = computed(
+  $multiSelection,
+  (state) => state.selectedIds.size > 0
+);
+
+/**
+ * Computed: Whether multiple blocks are selected
+ */
+export const $hasMultiSelection: ReadableAtom<boolean> = computed(
+  $multiSelection,
+  (state) => state.selectedIds.size > 1
+);
+
+/**
+ * Computed: The anchor block (first selected in range)
+ */
+export const $anchorBlock: ReadableAtom<Block | null> = computed(
+  [$document, $multiSelection],
+  (doc, selection) => {
+    if (!selection.anchorId) return null;
+    return findBlockById(doc.blocks, selection.anchorId);
+  }
+);
+
+/**
+ * Computed: The last selected block
+ */
+export const $lastSelectedBlock: ReadableAtom<Block | null> = computed(
+  [$document, $multiSelection],
+  (doc, selection) => {
+    if (!selection.lastSelectedId) return null;
+    return findBlockById(doc.blocks, selection.lastSelectedId);
+  }
+);
+
+/**
+ * Computed: Array of all selected blocks (in document order)
+ */
+export const $selectedBlocks: ReadableAtom<Block[]> = computed(
+  [$document, $multiSelection],
+  (doc, selection) => {
+    if (selection.selectedIds.size === 0) return [];
+
+    const result: Block[] = [];
+
+    function collectSelected(blocks: Block[]): void {
+      for (const block of blocks) {
+        if (selection.selectedIds.has(block.id)) {
+          result.push(block);
+        }
+        if (block.children) {
+          collectSelected(block.children);
+        }
+      }
+    }
+
+    collectSelected(doc.blocks);
+    return result;
+  }
+);
+
+/**
+ * Computed: Currently focused block ID
+ */
+export const $focusedBlockId: ReadableAtom<string | null> = computed(
+  $focus,
+  (state) => state.focusedId
+);
+
+/**
+ * Computed: Currently focused block
+ */
+export const $focusedBlock: ReadableAtom<Block | null> = computed(
+  [$document, $focus],
+  (doc, focus) => {
+    if (!focus.focusedId) return null;
+    return findBlockById(doc.blocks, focus.focusedId);
+  }
+);
+
+/**
+ * Computed: Whether the focused block is in edit mode
+ */
+export const $isEditing: ReadableAtom<boolean> = computed(
+  $focus,
+  (state) => state.isEditing
+);
+
+/**
+ * Computed: Whether a specific block is selected
+ * Returns a function that checks if a block ID is selected
+ */
+export function isBlockSelected(blockId: string): boolean {
+  return $multiSelection.get().selectedIds.has(blockId);
+}
+
+/**
+ * Computed: Whether a specific block is focused
+ */
+export function isBlockFocused(blockId: string): boolean {
+  return $focus.get().focusedId === blockId;
+}
+
+/**
+ * Get a flattened list of all block IDs in document order
+ * Used for navigation calculations
+ */
+export function getFlatBlockList(): string[] {
+  const blocks = $blocks.get();
+  const result: string[] = [];
+
+  function collectIds(blockList: Block[]): void {
+    for (const block of blockList) {
+      result.push(block.id);
+      if (block.children) {
+        collectIds(block.children);
+      }
+    }
+  }
+
+  collectIds(blocks);
+  return result;
+}
+
+/**
+ * Get the index of a block in the flattened list
+ */
+export function getBlockFlatIndex(blockId: string): number {
+  return getFlatBlockList().indexOf(blockId);
+}
+
+/**
+ * Get block ID at a specific flat index
+ */
+export function getBlockAtFlatIndex(index: number): string | null {
+  const list = getFlatBlockList();
+  if (index < 0 || index >= list.length) {
+    return null;
+  }
+  return list[index] ?? null;
+}
+
+/**
+ * Get the next block ID in document order
+ */
+export function getNextBlockId(currentId: string): string | null {
+  const list = getFlatBlockList();
+  const currentIndex = list.indexOf(currentId);
+  if (currentIndex === -1 || currentIndex >= list.length - 1) {
+    return null;
+  }
+  return list[currentIndex + 1] ?? null;
+}
+
+/**
+ * Get the previous block ID in document order
+ */
+export function getPrevBlockId(currentId: string): string | null {
+  const list = getFlatBlockList();
+  const currentIndex = list.indexOf(currentId);
+  if (currentIndex <= 0) {
+    return null;
+  }
+  return list[currentIndex - 1] ?? null;
+}
+
+/**
+ * Get the first block ID in the document
+ */
+export function getFirstBlockId(): string | null {
+  const list = getFlatBlockList();
+  return list[0] ?? null;
+}
+
+/**
+ * Get the last block ID in the document
+ */
+export function getLastBlockId(): string | null {
+  const list = getFlatBlockList();
+  return list[list.length - 1] ?? null;
+}
+
+/**
+ * Get all block IDs between two blocks (inclusive) in document order
+ */
+export function getBlockRange(startId: string, endId: string): string[] {
+  const list = getFlatBlockList();
+  const startIndex = list.indexOf(startId);
+  const endIndex = list.indexOf(endId);
+
+  if (startIndex === -1 || endIndex === -1) {
+    return [];
+  }
+
+  const minIndex = Math.min(startIndex, endIndex);
+  const maxIndex = Math.max(startIndex, endIndex);
+
+  return list.slice(minIndex, maxIndex + 1);
+}
+
+/**
+ * Reset selection state to initial values
+ */
+export function resetSelectionState(): void {
+  $multiSelection.set(createInitialMultiSelection());
+  $focus.set(createInitialFocus());
+}

--- a/packages/edit/src/selection/types.ts
+++ b/packages/edit/src/selection/types.ts
@@ -1,0 +1,167 @@
+/**
+ * Selection & Focus Types
+ *
+ * Type definitions for block selection and focus management.
+ * Implements PZ-207: Block Selection & Focus
+ */
+
+import { z } from "zod/v4";
+import type { Result } from "../model/types";
+
+/**
+ * Selection mode indicating how selection is being performed
+ */
+export type SelectionMode = "single" | "multi" | "range";
+
+/**
+ * Focus direction for keyboard navigation
+ */
+export type FocusDirection = "up" | "down" | "first" | "last";
+
+/**
+ * Selection error codes
+ */
+export type SelectionErrorCode =
+  | "BLOCK_NOT_FOUND"
+  | "INVALID_RANGE"
+  | "NO_BLOCKS_AVAILABLE"
+  | "ALREADY_EDITING";
+
+/**
+ * Selection error type
+ */
+export interface SelectionError {
+  code: SelectionErrorCode;
+  message: string;
+  cause?: unknown;
+}
+
+/**
+ * Create a selection error
+ */
+export function createSelectionError(
+  code: SelectionErrorCode,
+  message: string,
+  cause?: unknown
+): SelectionError {
+  return { code, message, cause };
+}
+
+/**
+ * Result type for selection operations
+ */
+export type SelectionResult<T> = Result<T, SelectionError>;
+
+/**
+ * Multi-selection state
+ * Tracks which blocks are selected and in what order they were selected
+ */
+export interface MultiSelectionState {
+  /** Set of selected block IDs */
+  selectedIds: Set<string>;
+  /** The anchor block ID for range selection (first selected) */
+  anchorId: string | null;
+  /** The most recently selected block ID */
+  lastSelectedId: string | null;
+}
+
+/**
+ * Focus state for keyboard navigation
+ * Focus is separate from selection - a block can be focused but not selected
+ */
+export interface FocusState {
+  /** Currently focused block ID */
+  focusedId: string | null;
+  /** Whether the focused block is in edit mode (text input active) */
+  isEditing: boolean;
+}
+
+/**
+ * Combined selection and focus state
+ */
+export interface SelectionFocusState {
+  selection: MultiSelectionState;
+  focus: FocusState;
+}
+
+/**
+ * Keyboard navigation action
+ */
+export type KeyboardAction =
+  | { type: "FOCUS_NEXT" }
+  | { type: "FOCUS_PREV" }
+  | { type: "FOCUS_FIRST" }
+  | { type: "FOCUS_LAST" }
+  | { type: "SELECT_FOCUSED" }
+  | { type: "TOGGLE_FOCUSED" }
+  | { type: "EXTEND_SELECTION_UP" }
+  | { type: "EXTEND_SELECTION_DOWN" }
+  | { type: "ENTER_EDIT_MODE" }
+  | { type: "EXIT_EDIT_MODE" }
+  | { type: "CLEAR_SELECTION" }
+  | { type: "SELECT_ALL" };
+
+/**
+ * Click action for mouse interactions
+ */
+export type ClickAction =
+  | { type: "SELECT"; blockId: string }
+  | { type: "TOGGLE"; blockId: string }
+  | { type: "RANGE"; blockId: string }
+  | { type: "DESELECT_ALL" };
+
+/**
+ * Zod schema for multi-selection state (for serialization)
+ */
+export const MultiSelectionStateSchema = z.object({
+  selectedIds: z.array(z.string()).transform((arr) => new Set(arr)),
+  anchorId: z.string().nullable(),
+  lastSelectedId: z.string().nullable(),
+});
+
+/**
+ * Zod schema for focus state
+ */
+export const FocusStateSchema = z.object({
+  focusedId: z.string().nullable(),
+  isEditing: z.boolean(),
+});
+
+/**
+ * Zod schema for combined state
+ */
+export const SelectionFocusStateSchema = z.object({
+  selection: MultiSelectionStateSchema,
+  focus: FocusStateSchema,
+});
+
+/**
+ * Create initial multi-selection state
+ */
+export function createInitialMultiSelection(): MultiSelectionState {
+  return {
+    selectedIds: new Set(),
+    anchorId: null,
+    lastSelectedId: null,
+  };
+}
+
+/**
+ * Create initial focus state
+ */
+export function createInitialFocus(): FocusState {
+  return {
+    focusedId: null,
+    isEditing: false,
+  };
+}
+
+/**
+ * Create initial combined state
+ */
+export function createInitialSelectionFocus(): SelectionFocusState {
+  return {
+    selection: createInitialMultiSelection(),
+    focus: createInitialFocus(),
+  };
+}

--- a/packages/edit/test/selection/actions.test.ts
+++ b/packages/edit/test/selection/actions.test.ts
@@ -1,0 +1,751 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { uuidv7 } from "uuidv7";
+import {
+  initializeDocument,
+  insertBlockAction,
+  $selectedBlockId,
+} from "../../src/model/document";
+import type { Block } from "../../src/model/types";
+import {
+  clearFocus,
+  clearSelection,
+  deselectBlock,
+  enterEditMode,
+  escape,
+  exitEditMode,
+  extendSelectionDown,
+  extendSelectionUp,
+  focusBlock,
+  focusDirection,
+  focusNext,
+  focusPrev,
+  selectAll,
+  selectBlock,
+  selectFocused,
+  selectRange,
+  toggleFocused,
+  toggleSelection,
+} from "../../src/selection/actions";
+import {
+  $focus,
+  $multiSelection,
+  resetSelectionState,
+} from "../../src/selection/state";
+
+// Helper to create a test block
+function createTestBlock(
+  type: string,
+  props: Record<string, unknown> = {},
+  children?: Block[]
+): Block {
+  const block: Block = {
+    id: uuidv7(),
+    type,
+    props,
+  };
+  if (children !== undefined) {
+    block.children = children;
+  }
+  return block;
+}
+
+describe("Selection Actions", () => {
+  beforeEach(() => {
+    initializeDocument();
+    resetSelectionState();
+  });
+
+  afterEach(() => {
+    initializeDocument();
+    resetSelectionState();
+  });
+
+  describe("selectBlock", () => {
+    it("selects a single block", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+
+      const result = selectBlock(block.id);
+
+      expect(result.ok).toBe(true);
+      const state = $multiSelection.get();
+      expect(state.selectedIds.size).toBe(1);
+      expect(state.selectedIds.has(block.id)).toBe(true);
+    });
+
+    it("clears previous selection", () => {
+      const block1 = createTestBlock("paragraph");
+      const block2 = createTestBlock("paragraph");
+      insertBlockAction(block1);
+      insertBlockAction(block2);
+
+      selectBlock(block1.id);
+      selectBlock(block2.id);
+
+      const state = $multiSelection.get();
+      expect(state.selectedIds.size).toBe(1);
+      expect(state.selectedIds.has(block2.id)).toBe(true);
+      expect(state.selectedIds.has(block1.id)).toBe(false);
+    });
+
+    it("sets anchor and last selected", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+
+      selectBlock(block.id);
+
+      const state = $multiSelection.get();
+      expect(state.anchorId).toBe(block.id);
+      expect(state.lastSelectedId).toBe(block.id);
+    });
+
+    it("updates legacy selection state", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+
+      selectBlock(block.id);
+
+      expect($selectedBlockId.get()).toBe(block.id);
+    });
+
+    it("focuses the selected block", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+
+      selectBlock(block.id);
+
+      expect($focus.get().focusedId).toBe(block.id);
+      expect($focus.get().isEditing).toBe(false);
+    });
+
+    it("returns error for non-existent block", () => {
+      const result = selectBlock("nonexistent");
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("BLOCK_NOT_FOUND");
+      }
+    });
+  });
+
+  describe("deselectBlock", () => {
+    it("removes block from selection", () => {
+      const block1 = createTestBlock("paragraph");
+      const block2 = createTestBlock("paragraph");
+      insertBlockAction(block1);
+      insertBlockAction(block2);
+
+      selectBlock(block1.id);
+      toggleSelection(block2.id);
+      deselectBlock(block1.id);
+
+      const state = $multiSelection.get();
+      expect(state.selectedIds.size).toBe(1);
+      expect(state.selectedIds.has(block2.id)).toBe(true);
+    });
+
+    it("updates anchor if deselecting anchor", () => {
+      const block1 = createTestBlock("paragraph");
+      const block2 = createTestBlock("paragraph");
+      insertBlockAction(block1);
+      insertBlockAction(block2);
+
+      selectBlock(block1.id);
+      toggleSelection(block2.id);
+      deselectBlock(block1.id);
+
+      const state = $multiSelection.get();
+      expect(state.anchorId).toBe(block2.id);
+    });
+
+    it("succeeds silently for unselected block", () => {
+      const result = deselectBlock("nonexistent");
+      expect(result.ok).toBe(true);
+    });
+
+    it("clears legacy selection when empty", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+
+      selectBlock(block.id);
+      deselectBlock(block.id);
+
+      expect($selectedBlockId.get()).toBeNull();
+    });
+  });
+
+  describe("toggleSelection", () => {
+    it("adds unselected block to selection", () => {
+      const block1 = createTestBlock("paragraph");
+      const block2 = createTestBlock("paragraph");
+      insertBlockAction(block1);
+      insertBlockAction(block2);
+
+      selectBlock(block1.id);
+      toggleSelection(block2.id);
+
+      const state = $multiSelection.get();
+      expect(state.selectedIds.size).toBe(2);
+      expect(state.selectedIds.has(block1.id)).toBe(true);
+      expect(state.selectedIds.has(block2.id)).toBe(true);
+    });
+
+    it("removes selected block from selection", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+
+      selectBlock(block.id);
+      toggleSelection(block.id);
+
+      const state = $multiSelection.get();
+      expect(state.selectedIds.size).toBe(0);
+    });
+
+    it("updates last selected on toggle add", () => {
+      const block1 = createTestBlock("paragraph");
+      const block2 = createTestBlock("paragraph");
+      insertBlockAction(block1);
+      insertBlockAction(block2);
+
+      selectBlock(block1.id);
+      toggleSelection(block2.id);
+
+      expect($multiSelection.get().lastSelectedId).toBe(block2.id);
+    });
+
+    it("returns error for non-existent block", () => {
+      const result = toggleSelection("nonexistent");
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("BLOCK_NOT_FOUND");
+      }
+    });
+  });
+
+  describe("selectRange", () => {
+    it("selects all blocks between anchor and target", () => {
+      const block1 = createTestBlock("paragraph");
+      const block2 = createTestBlock("paragraph");
+      const block3 = createTestBlock("paragraph");
+      insertBlockAction(block1);
+      insertBlockAction(block2);
+      insertBlockAction(block3);
+
+      selectBlock(block1.id);
+      selectRange(block3.id);
+
+      const state = $multiSelection.get();
+      expect(state.selectedIds.size).toBe(3);
+      expect(state.selectedIds.has(block1.id)).toBe(true);
+      expect(state.selectedIds.has(block2.id)).toBe(true);
+      expect(state.selectedIds.has(block3.id)).toBe(true);
+    });
+
+    it("keeps original anchor", () => {
+      const block1 = createTestBlock("paragraph");
+      const block2 = createTestBlock("paragraph");
+      insertBlockAction(block1);
+      insertBlockAction(block2);
+
+      selectBlock(block1.id);
+      selectRange(block2.id);
+
+      expect($multiSelection.get().anchorId).toBe(block1.id);
+    });
+
+    it("updates last selected to target", () => {
+      const block1 = createTestBlock("paragraph");
+      const block2 = createTestBlock("paragraph");
+      insertBlockAction(block1);
+      insertBlockAction(block2);
+
+      selectBlock(block1.id);
+      selectRange(block2.id);
+
+      expect($multiSelection.get().lastSelectedId).toBe(block2.id);
+    });
+
+    it("works when target is before anchor", () => {
+      const block1 = createTestBlock("paragraph");
+      const block2 = createTestBlock("paragraph");
+      const block3 = createTestBlock("paragraph");
+      insertBlockAction(block1);
+      insertBlockAction(block2);
+      insertBlockAction(block3);
+
+      selectBlock(block3.id);
+      selectRange(block1.id);
+
+      const state = $multiSelection.get();
+      expect(state.selectedIds.size).toBe(3);
+    });
+
+    it("falls back to single select when no anchor", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+
+      const result = selectRange(block.id);
+
+      expect(result.ok).toBe(true);
+      expect($multiSelection.get().selectedIds.size).toBe(1);
+    });
+
+    it("returns error for non-existent block", () => {
+      const result = selectRange("nonexistent");
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("BLOCK_NOT_FOUND");
+      }
+    });
+  });
+
+  describe("clearSelection", () => {
+    it("clears all selection", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+
+      selectBlock(block.id);
+      clearSelection();
+
+      const state = $multiSelection.get();
+      expect(state.selectedIds.size).toBe(0);
+      expect(state.anchorId).toBeNull();
+      expect(state.lastSelectedId).toBeNull();
+    });
+
+    it("updates legacy selection", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+
+      selectBlock(block.id);
+      clearSelection();
+
+      expect($selectedBlockId.get()).toBeNull();
+    });
+
+    it("exits edit mode but keeps focus", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+
+      selectBlock(block.id);
+      enterEditMode();
+      clearSelection();
+
+      expect($focus.get().isEditing).toBe(false);
+      expect($focus.get().focusedId).toBe(block.id);
+    });
+  });
+
+  describe("selectAll", () => {
+    it("selects all blocks in document", () => {
+      const block1 = createTestBlock("paragraph");
+      const block2 = createTestBlock("paragraph");
+      const block3 = createTestBlock("paragraph");
+      insertBlockAction(block1);
+      insertBlockAction(block2);
+      insertBlockAction(block3);
+
+      const result = selectAll();
+
+      expect(result.ok).toBe(true);
+      expect($multiSelection.get().selectedIds.size).toBe(3);
+    });
+
+    it("includes nested blocks", () => {
+      const child = createTestBlock("paragraph");
+      const parent = createTestBlock("section", {}, [child]);
+      insertBlockAction(parent);
+
+      selectAll();
+
+      const state = $multiSelection.get();
+      expect(state.selectedIds.size).toBe(2);
+      expect(state.selectedIds.has(parent.id)).toBe(true);
+      expect(state.selectedIds.has(child.id)).toBe(true);
+    });
+
+    it("returns error for empty document", () => {
+      const result = selectAll();
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("NO_BLOCKS_AVAILABLE");
+      }
+    });
+  });
+
+  describe("focusBlock", () => {
+    it("focuses a block without selecting", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+
+      const result = focusBlock(block.id);
+
+      expect(result.ok).toBe(true);
+      expect($focus.get().focusedId).toBe(block.id);
+      expect($multiSelection.get().selectedIds.size).toBe(0);
+    });
+
+    it("does not enter edit mode", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+
+      focusBlock(block.id);
+
+      expect($focus.get().isEditing).toBe(false);
+    });
+
+    it("returns error for non-existent block", () => {
+      const result = focusBlock("nonexistent");
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("BLOCK_NOT_FOUND");
+      }
+    });
+  });
+
+  describe("focusNext", () => {
+    it("moves focus to next block", () => {
+      const block1 = createTestBlock("paragraph");
+      const block2 = createTestBlock("paragraph");
+      insertBlockAction(block1);
+      insertBlockAction(block2);
+
+      focusBlock(block1.id);
+      focusNext();
+
+      expect($focus.get().focusedId).toBe(block2.id);
+    });
+
+    it("starts at first block when no focus", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+
+      focusNext();
+
+      expect($focus.get().focusedId).toBe(block.id);
+    });
+
+    it("stays at end when already at last block", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+
+      focusBlock(block.id);
+      const result = focusNext();
+
+      expect(result.ok).toBe(true);
+      expect($focus.get().focusedId).toBe(block.id);
+    });
+
+    it("returns error when in edit mode", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+
+      focusBlock(block.id);
+      enterEditMode();
+      const result = focusNext();
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("ALREADY_EDITING");
+      }
+    });
+
+    it("returns error for empty document", () => {
+      const result = focusNext();
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("NO_BLOCKS_AVAILABLE");
+      }
+    });
+  });
+
+  describe("focusPrev", () => {
+    it("moves focus to previous block", () => {
+      const block1 = createTestBlock("paragraph");
+      const block2 = createTestBlock("paragraph");
+      insertBlockAction(block1);
+      insertBlockAction(block2);
+
+      focusBlock(block2.id);
+      focusPrev();
+
+      expect($focus.get().focusedId).toBe(block1.id);
+    });
+
+    it("starts at last block when no focus", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+
+      focusPrev();
+
+      expect($focus.get().focusedId).toBe(block.id);
+    });
+
+    it("stays at beginning when already at first block", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+
+      focusBlock(block.id);
+      const result = focusPrev();
+
+      expect(result.ok).toBe(true);
+      expect($focus.get().focusedId).toBe(block.id);
+    });
+  });
+
+  describe("focusDirection", () => {
+    it("handles up direction", () => {
+      const block1 = createTestBlock("paragraph");
+      const block2 = createTestBlock("paragraph");
+      insertBlockAction(block1);
+      insertBlockAction(block2);
+
+      focusBlock(block2.id);
+      focusDirection("up");
+
+      expect($focus.get().focusedId).toBe(block1.id);
+    });
+
+    it("handles down direction", () => {
+      const block1 = createTestBlock("paragraph");
+      const block2 = createTestBlock("paragraph");
+      insertBlockAction(block1);
+      insertBlockAction(block2);
+
+      focusBlock(block1.id);
+      focusDirection("down");
+
+      expect($focus.get().focusedId).toBe(block2.id);
+    });
+
+    it("handles first direction", () => {
+      const block1 = createTestBlock("paragraph");
+      const block2 = createTestBlock("paragraph");
+      insertBlockAction(block1);
+      insertBlockAction(block2);
+
+      focusBlock(block2.id);
+      focusDirection("first");
+
+      expect($focus.get().focusedId).toBe(block1.id);
+    });
+
+    it("handles last direction", () => {
+      const block1 = createTestBlock("paragraph");
+      const block2 = createTestBlock("paragraph");
+      insertBlockAction(block1);
+      insertBlockAction(block2);
+
+      focusBlock(block1.id);
+      focusDirection("last");
+
+      expect($focus.get().focusedId).toBe(block2.id);
+    });
+  });
+
+  describe("selectFocused", () => {
+    it("selects the focused block", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+
+      focusBlock(block.id);
+      selectFocused();
+
+      expect($multiSelection.get().selectedIds.has(block.id)).toBe(true);
+    });
+
+    it("returns error when no focus", () => {
+      const result = selectFocused();
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("NO_BLOCKS_AVAILABLE");
+      }
+    });
+  });
+
+  describe("toggleFocused", () => {
+    it("toggles selection of focused block", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+
+      focusBlock(block.id);
+      toggleFocused();
+
+      expect($multiSelection.get().selectedIds.has(block.id)).toBe(true);
+
+      toggleFocused();
+
+      expect($multiSelection.get().selectedIds.size).toBe(0);
+    });
+
+    it("returns error when no focus", () => {
+      const result = toggleFocused();
+
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  describe("extendSelectionDown", () => {
+    it("extends selection to next block", () => {
+      const block1 = createTestBlock("paragraph");
+      const block2 = createTestBlock("paragraph");
+      insertBlockAction(block1);
+      insertBlockAction(block2);
+
+      selectBlock(block1.id);
+      extendSelectionDown();
+
+      const state = $multiSelection.get();
+      expect(state.selectedIds.size).toBe(2);
+      expect(state.selectedIds.has(block1.id)).toBe(true);
+      expect(state.selectedIds.has(block2.id)).toBe(true);
+    });
+
+    it("does nothing when at end", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+
+      selectBlock(block.id);
+      const result = extendSelectionDown();
+
+      expect(result.ok).toBe(true);
+      expect($multiSelection.get().selectedIds.size).toBe(1);
+    });
+  });
+
+  describe("extendSelectionUp", () => {
+    it("extends selection to previous block", () => {
+      const block1 = createTestBlock("paragraph");
+      const block2 = createTestBlock("paragraph");
+      insertBlockAction(block1);
+      insertBlockAction(block2);
+
+      selectBlock(block2.id);
+      extendSelectionUp();
+
+      const state = $multiSelection.get();
+      expect(state.selectedIds.size).toBe(2);
+    });
+
+    it("does nothing when at beginning", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+
+      selectBlock(block.id);
+      const result = extendSelectionUp();
+
+      expect(result.ok).toBe(true);
+      expect($multiSelection.get().selectedIds.size).toBe(1);
+    });
+  });
+
+  describe("enterEditMode", () => {
+    it("enters edit mode for focused block", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+
+      focusBlock(block.id);
+      const result = enterEditMode();
+
+      expect(result.ok).toBe(true);
+      expect($focus.get().isEditing).toBe(true);
+    });
+
+    it("returns error when no focus", () => {
+      const result = enterEditMode();
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("NO_BLOCKS_AVAILABLE");
+      }
+    });
+
+    it("succeeds silently when already editing", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+
+      focusBlock(block.id);
+      enterEditMode();
+      const result = enterEditMode();
+
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  describe("exitEditMode", () => {
+    it("exits edit mode", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+
+      focusBlock(block.id);
+      enterEditMode();
+      exitEditMode();
+
+      expect($focus.get().isEditing).toBe(false);
+      expect($focus.get().focusedId).toBe(block.id); // Focus maintained
+    });
+
+    it("succeeds silently when not editing", () => {
+      const result = exitEditMode();
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  describe("clearFocus", () => {
+    it("clears focus entirely", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+
+      focusBlock(block.id);
+      clearFocus();
+
+      expect($focus.get().focusedId).toBeNull();
+      expect($focus.get().isEditing).toBe(false);
+    });
+  });
+
+  describe("escape", () => {
+    it("exits edit mode first", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+
+      selectBlock(block.id);
+      enterEditMode();
+      escape();
+
+      expect($focus.get().isEditing).toBe(false);
+      expect($multiSelection.get().selectedIds.size).toBe(1); // Still selected
+    });
+
+    it("clears selection second", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+
+      selectBlock(block.id);
+      escape();
+
+      expect($multiSelection.get().selectedIds.size).toBe(0);
+      expect($focus.get().focusedId).toBe(block.id); // Still focused
+    });
+
+    it("clears focus third", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+
+      focusBlock(block.id);
+      escape();
+
+      expect($focus.get().focusedId).toBeNull();
+    });
+
+    it("does nothing when nothing to clear", () => {
+      escape(); // Should not throw
+    });
+  });
+});

--- a/packages/edit/test/selection/keyboard.test.ts
+++ b/packages/edit/test/selection/keyboard.test.ts
@@ -1,0 +1,554 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { uuidv7 } from "uuidv7";
+import { initializeDocument, insertBlockAction } from "../../src/model/document";
+import type { Block } from "../../src/model/types";
+import { focusBlock, enterEditMode, selectBlock } from "../../src/selection/actions";
+import {
+  createKeyboardHandler,
+  defaultKeyboardConfig,
+  executeKeyboardAction,
+  handleKeyboardEvent,
+  parseKeyboardEvent,
+  shouldHandleKeyboardEvent,
+  type KeyboardConfig,
+} from "../../src/selection/keyboard";
+import { $focus, $multiSelection, resetSelectionState } from "../../src/selection/state";
+
+// Helper to create a test block
+function createTestBlock(
+  type: string,
+  props: Record<string, unknown> = {},
+  children?: Block[]
+): Block {
+  const block: Block = {
+    id: uuidv7(),
+    type,
+    props,
+  };
+  if (children !== undefined) {
+    block.children = children;
+  }
+  return block;
+}
+
+// Mock keyboard event interface for testing in Node environment
+interface MockKeyboardEvent {
+  key: string;
+  shiftKey: boolean;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  preventDefault: () => void;
+}
+
+// Helper to create a mock keyboard event
+// Cast to KeyboardEvent for compatibility with the keyboard module functions
+function createKeyboardEvent(
+  key: string,
+  options: {
+    shiftKey?: boolean;
+    metaKey?: boolean;
+    ctrlKey?: boolean;
+  } = {}
+): KeyboardEvent {
+  const mock: MockKeyboardEvent = {
+    key,
+    shiftKey: options.shiftKey ?? false,
+    metaKey: options.metaKey ?? false,
+    ctrlKey: options.ctrlKey ?? false,
+    preventDefault: vi.fn(),
+  };
+  // Cast to KeyboardEvent - the keyboard module only uses these properties
+  return mock as unknown as KeyboardEvent;
+}
+
+describe("Keyboard Handling", () => {
+  beforeEach(() => {
+    initializeDocument();
+    resetSelectionState();
+  });
+
+  afterEach(() => {
+    initializeDocument();
+    resetSelectionState();
+  });
+
+  describe("parseKeyboardEvent", () => {
+    describe("Escape key", () => {
+      it("returns EXIT_EDIT_MODE when editing", () => {
+        const block = createTestBlock("paragraph");
+        insertBlockAction(block);
+        focusBlock(block.id);
+        enterEditMode();
+
+        const event = createKeyboardEvent("Escape");
+        const action = parseKeyboardEvent(event);
+
+        expect(action).toEqual({ type: "EXIT_EDIT_MODE" });
+      });
+
+      it("returns CLEAR_SELECTION when not editing", () => {
+        const event = createKeyboardEvent("Escape");
+        const action = parseKeyboardEvent(event);
+
+        expect(action).toEqual({ type: "CLEAR_SELECTION" });
+      });
+
+      it("returns null when escape is disabled", () => {
+        const config: KeyboardConfig = {
+          ...defaultKeyboardConfig,
+          enableEscape: false,
+        };
+        const event = createKeyboardEvent("Escape");
+        const action = parseKeyboardEvent(event, config);
+
+        expect(action).toBeNull();
+      });
+    });
+
+    describe("Enter key", () => {
+      it("returns ENTER_EDIT_MODE when not editing", () => {
+        const block = createTestBlock("paragraph");
+        insertBlockAction(block);
+        focusBlock(block.id);
+
+        const event = createKeyboardEvent("Enter");
+        const action = parseKeyboardEvent(event);
+
+        expect(action).toEqual({ type: "ENTER_EDIT_MODE" });
+      });
+
+      it("returns null when editing (let block handle it)", () => {
+        const block = createTestBlock("paragraph");
+        insertBlockAction(block);
+        focusBlock(block.id);
+        enterEditMode();
+
+        const event = createKeyboardEvent("Enter");
+        const action = parseKeyboardEvent(event);
+
+        expect(action).toBeNull();
+      });
+
+      it("returns null for Shift+Enter", () => {
+        const event = createKeyboardEvent("Enter", { shiftKey: true });
+        const action = parseKeyboardEvent(event);
+
+        expect(action).toBeNull();
+      });
+
+      it("returns null when disabled", () => {
+        const config: KeyboardConfig = {
+          ...defaultKeyboardConfig,
+          enableEnterToEdit: false,
+        };
+        const event = createKeyboardEvent("Enter");
+        const action = parseKeyboardEvent(event, config);
+
+        expect(action).toBeNull();
+      });
+    });
+
+    describe("Arrow keys", () => {
+      it("returns FOCUS_NEXT for ArrowDown", () => {
+        const event = createKeyboardEvent("ArrowDown");
+        const action = parseKeyboardEvent(event);
+
+        expect(action).toEqual({ type: "FOCUS_NEXT" });
+      });
+
+      it("returns FOCUS_NEXT for ArrowRight", () => {
+        const event = createKeyboardEvent("ArrowRight");
+        const action = parseKeyboardEvent(event);
+
+        expect(action).toEqual({ type: "FOCUS_NEXT" });
+      });
+
+      it("returns FOCUS_PREV for ArrowUp", () => {
+        const event = createKeyboardEvent("ArrowUp");
+        const action = parseKeyboardEvent(event);
+
+        expect(action).toEqual({ type: "FOCUS_PREV" });
+      });
+
+      it("returns FOCUS_PREV for ArrowLeft", () => {
+        const event = createKeyboardEvent("ArrowLeft");
+        const action = parseKeyboardEvent(event);
+
+        expect(action).toEqual({ type: "FOCUS_PREV" });
+      });
+
+      it("returns EXTEND_SELECTION_DOWN for Shift+ArrowDown", () => {
+        const event = createKeyboardEvent("ArrowDown", { shiftKey: true });
+        const action = parseKeyboardEvent(event);
+
+        expect(action).toEqual({ type: "EXTEND_SELECTION_DOWN" });
+      });
+
+      it("returns EXTEND_SELECTION_UP for Shift+ArrowUp", () => {
+        const event = createKeyboardEvent("ArrowUp", { shiftKey: true });
+        const action = parseKeyboardEvent(event);
+
+        expect(action).toEqual({ type: "EXTEND_SELECTION_UP" });
+      });
+
+      it("returns null for arrow keys when editing", () => {
+        const block = createTestBlock("paragraph");
+        insertBlockAction(block);
+        focusBlock(block.id);
+        enterEditMode();
+
+        const event = createKeyboardEvent("ArrowDown");
+        const action = parseKeyboardEvent(event);
+
+        expect(action).toBeNull();
+      });
+
+      it("returns null when arrow keys disabled", () => {
+        const config: KeyboardConfig = {
+          ...defaultKeyboardConfig,
+          enableArrowKeys: false,
+        };
+        const event = createKeyboardEvent("ArrowDown");
+        const action = parseKeyboardEvent(event, config);
+
+        expect(action).toBeNull();
+      });
+    });
+
+    describe("Home/End keys", () => {
+      it("returns FOCUS_FIRST for Home", () => {
+        const event = createKeyboardEvent("Home");
+        const action = parseKeyboardEvent(event);
+
+        expect(action).toEqual({ type: "FOCUS_FIRST" });
+      });
+
+      it("returns FOCUS_LAST for End", () => {
+        const event = createKeyboardEvent("End");
+        const action = parseKeyboardEvent(event);
+
+        expect(action).toEqual({ type: "FOCUS_LAST" });
+      });
+    });
+
+    describe("Tab key", () => {
+      it("returns FOCUS_NEXT for Tab", () => {
+        const event = createKeyboardEvent("Tab");
+        const action = parseKeyboardEvent(event);
+
+        expect(action).toEqual({ type: "FOCUS_NEXT" });
+      });
+
+      it("returns FOCUS_PREV for Shift+Tab", () => {
+        const event = createKeyboardEvent("Tab", { shiftKey: true });
+        const action = parseKeyboardEvent(event);
+
+        expect(action).toEqual({ type: "FOCUS_PREV" });
+      });
+
+      it("returns null for Tab when editing", () => {
+        const block = createTestBlock("paragraph");
+        insertBlockAction(block);
+        focusBlock(block.id);
+        enterEditMode();
+
+        const event = createKeyboardEvent("Tab");
+        const action = parseKeyboardEvent(event);
+
+        expect(action).toBeNull();
+      });
+
+      it("returns null when tab navigation disabled", () => {
+        const config: KeyboardConfig = {
+          ...defaultKeyboardConfig,
+          enableTabNavigation: false,
+        };
+        const event = createKeyboardEvent("Tab");
+        const action = parseKeyboardEvent(event, config);
+
+        expect(action).toBeNull();
+      });
+    });
+
+    describe("Cmd/Ctrl+A", () => {
+      it("returns SELECT_ALL for Cmd+A", () => {
+        const event = createKeyboardEvent("a", { metaKey: true });
+        const action = parseKeyboardEvent(event);
+
+        expect(action).toEqual({ type: "SELECT_ALL" });
+      });
+
+      it("returns SELECT_ALL for Ctrl+A", () => {
+        const event = createKeyboardEvent("a", { ctrlKey: true });
+        const action = parseKeyboardEvent(event);
+
+        expect(action).toEqual({ type: "SELECT_ALL" });
+      });
+
+      it("returns null when editing", () => {
+        const block = createTestBlock("paragraph");
+        insertBlockAction(block);
+        focusBlock(block.id);
+        enterEditMode();
+
+        const event = createKeyboardEvent("a", { metaKey: true });
+        const action = parseKeyboardEvent(event);
+
+        expect(action).toBeNull();
+      });
+
+      it("returns null when disabled", () => {
+        const config: KeyboardConfig = {
+          ...defaultKeyboardConfig,
+          enableSelectAll: false,
+        };
+        const event = createKeyboardEvent("a", { metaKey: true });
+        const action = parseKeyboardEvent(event, config);
+
+        expect(action).toBeNull();
+      });
+    });
+
+    describe("Space key", () => {
+      it("returns SELECT_FOCUSED for Space", () => {
+        const event = createKeyboardEvent(" ");
+        const action = parseKeyboardEvent(event);
+
+        expect(action).toEqual({ type: "SELECT_FOCUSED" });
+      });
+
+      it("returns TOGGLE_FOCUSED for Shift+Space", () => {
+        const event = createKeyboardEvent(" ", { shiftKey: true });
+        const action = parseKeyboardEvent(event);
+
+        expect(action).toEqual({ type: "TOGGLE_FOCUSED" });
+      });
+
+      it("returns TOGGLE_FOCUSED for Cmd+Space", () => {
+        const event = createKeyboardEvent(" ", { metaKey: true });
+        const action = parseKeyboardEvent(event);
+
+        expect(action).toEqual({ type: "TOGGLE_FOCUSED" });
+      });
+
+      it("returns null when editing", () => {
+        const block = createTestBlock("paragraph");
+        insertBlockAction(block);
+        focusBlock(block.id);
+        enterEditMode();
+
+        const event = createKeyboardEvent(" ");
+        const action = parseKeyboardEvent(event);
+
+        expect(action).toBeNull();
+      });
+    });
+
+    describe("unhandled keys", () => {
+      it("returns null for regular letters", () => {
+        const event = createKeyboardEvent("x");
+        const action = parseKeyboardEvent(event);
+
+        expect(action).toBeNull();
+      });
+
+      it("returns null for numbers", () => {
+        const event = createKeyboardEvent("5");
+        const action = parseKeyboardEvent(event);
+
+        expect(action).toBeNull();
+      });
+    });
+  });
+
+  describe("executeKeyboardAction", () => {
+    it("executes FOCUS_NEXT action", () => {
+      const block1 = createTestBlock("paragraph");
+      const block2 = createTestBlock("paragraph");
+      insertBlockAction(block1);
+      insertBlockAction(block2);
+      focusBlock(block1.id);
+
+      const result = executeKeyboardAction({ type: "FOCUS_NEXT" });
+
+      expect(result.ok).toBe(true);
+      expect($focus.get().focusedId).toBe(block2.id);
+    });
+
+    it("executes FOCUS_PREV action", () => {
+      const block1 = createTestBlock("paragraph");
+      const block2 = createTestBlock("paragraph");
+      insertBlockAction(block1);
+      insertBlockAction(block2);
+      focusBlock(block2.id);
+
+      const result = executeKeyboardAction({ type: "FOCUS_PREV" });
+
+      expect(result.ok).toBe(true);
+      expect($focus.get().focusedId).toBe(block1.id);
+    });
+
+    it("executes ENTER_EDIT_MODE action", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+      focusBlock(block.id);
+
+      const result = executeKeyboardAction({ type: "ENTER_EDIT_MODE" });
+
+      expect(result.ok).toBe(true);
+      expect($focus.get().isEditing).toBe(true);
+    });
+
+    it("executes EXIT_EDIT_MODE action", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+      focusBlock(block.id);
+      enterEditMode();
+
+      const result = executeKeyboardAction({ type: "EXIT_EDIT_MODE" });
+
+      expect(result.ok).toBe(true);
+      expect($focus.get().isEditing).toBe(false);
+    });
+
+    it("executes CLEAR_SELECTION action", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+      selectBlock(block.id);
+
+      const result = executeKeyboardAction({ type: "CLEAR_SELECTION" });
+
+      expect(result.ok).toBe(true);
+      expect($multiSelection.get().selectedIds.size).toBe(0);
+    });
+
+    it("executes SELECT_ALL action", () => {
+      const block1 = createTestBlock("paragraph");
+      const block2 = createTestBlock("paragraph");
+      insertBlockAction(block1);
+      insertBlockAction(block2);
+
+      const result = executeKeyboardAction({ type: "SELECT_ALL" });
+
+      expect(result.ok).toBe(true);
+      expect($multiSelection.get().selectedIds.size).toBe(2);
+    });
+
+    it("executes EXTEND_SELECTION_DOWN action", () => {
+      const block1 = createTestBlock("paragraph");
+      const block2 = createTestBlock("paragraph");
+      insertBlockAction(block1);
+      insertBlockAction(block2);
+      selectBlock(block1.id);
+
+      const result = executeKeyboardAction({ type: "EXTEND_SELECTION_DOWN" });
+
+      expect(result.ok).toBe(true);
+      expect($multiSelection.get().selectedIds.size).toBe(2);
+    });
+
+    it("executes EXTEND_SELECTION_UP action", () => {
+      const block1 = createTestBlock("paragraph");
+      const block2 = createTestBlock("paragraph");
+      insertBlockAction(block1);
+      insertBlockAction(block2);
+      selectBlock(block2.id);
+
+      const result = executeKeyboardAction({ type: "EXTEND_SELECTION_UP" });
+
+      expect(result.ok).toBe(true);
+      expect($multiSelection.get().selectedIds.size).toBe(2);
+    });
+  });
+
+  describe("handleKeyboardEvent", () => {
+    it("returns true and prevents default for handled events", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+      focusBlock(block.id);
+
+      const event = createKeyboardEvent("ArrowDown");
+      const handled = handleKeyboardEvent(event);
+
+      expect(handled).toBe(true);
+      // Access the mock function through the cast event
+      expect((event as unknown as MockKeyboardEvent).preventDefault).toHaveBeenCalled();
+    });
+
+    it("returns false for unhandled events", () => {
+      const event = createKeyboardEvent("x");
+      const handled = handleKeyboardEvent(event);
+
+      expect(handled).toBe(false);
+    });
+
+    it("prevents default for expected failures", () => {
+      // Empty document, no blocks to focus
+      const event = createKeyboardEvent("ArrowDown");
+      const handled = handleKeyboardEvent(event);
+
+      // Returns true because we handled it (even though there are no blocks)
+      expect(handled).toBe(true);
+      expect((event as unknown as MockKeyboardEvent).preventDefault).toHaveBeenCalled();
+    });
+  });
+
+  describe("shouldHandleKeyboardEvent", () => {
+    it("returns true for handled keys", () => {
+      expect(shouldHandleKeyboardEvent(createKeyboardEvent("ArrowDown"))).toBe(true);
+      expect(shouldHandleKeyboardEvent(createKeyboardEvent("ArrowUp"))).toBe(true);
+      expect(shouldHandleKeyboardEvent(createKeyboardEvent("Tab"))).toBe(true);
+      expect(shouldHandleKeyboardEvent(createKeyboardEvent("Escape"))).toBe(true);
+      expect(shouldHandleKeyboardEvent(createKeyboardEvent("Enter"))).toBe(true);
+    });
+
+    it("returns false for unhandled keys", () => {
+      expect(shouldHandleKeyboardEvent(createKeyboardEvent("x"))).toBe(false);
+      expect(shouldHandleKeyboardEvent(createKeyboardEvent("5"))).toBe(false);
+    });
+  });
+
+  describe("createKeyboardHandler", () => {
+    it("creates a handler function", () => {
+      const handler = createKeyboardHandler();
+      expect(typeof handler).toBe("function");
+    });
+
+    it("handler processes keyboard events", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+      focusBlock(block.id);
+
+      const handler = createKeyboardHandler();
+      const event = createKeyboardEvent("ArrowDown");
+
+      // Should not throw
+      handler(event);
+    });
+
+    it("handler respects custom config", () => {
+      const config: KeyboardConfig = {
+        ...defaultKeyboardConfig,
+        enableArrowKeys: false,
+      };
+
+      const handler = createKeyboardHandler(config);
+      const event = createKeyboardEvent("ArrowDown");
+
+      // With arrows disabled, handler should not process the event
+      // (no state change expected)
+      handler(event);
+    });
+  });
+
+  describe("defaultKeyboardConfig", () => {
+    it("has all options enabled by default", () => {
+      expect(defaultKeyboardConfig.enableArrowKeys).toBe(true);
+      expect(defaultKeyboardConfig.enableTabNavigation).toBe(true);
+      expect(defaultKeyboardConfig.enableEnterToEdit).toBe(true);
+      expect(defaultKeyboardConfig.enableEscape).toBe(true);
+      expect(defaultKeyboardConfig.enableSelectAll).toBe(true);
+      expect(defaultKeyboardConfig.enableShiftArrows).toBe(true);
+    });
+  });
+});

--- a/packages/edit/test/selection/state.test.ts
+++ b/packages/edit/test/selection/state.test.ts
@@ -1,0 +1,513 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { uuidv7 } from "uuidv7";
+import { initializeDocument, insertBlockAction } from "../../src/model/document";
+import type { Block } from "../../src/model/types";
+import {
+  $anchorBlock,
+  $focus,
+  $focusedBlock,
+  $focusedBlockId,
+  $hasMultiSelection,
+  $hasSelection,
+  $isEditing,
+  $lastSelectedBlock,
+  $multiSelection,
+  $selectedBlocks,
+  $selectedIds,
+  $selectionCount,
+  getBlockAtFlatIndex,
+  getBlockFlatIndex,
+  getBlockRange,
+  getFirstBlockId,
+  getFlatBlockList,
+  getLastBlockId,
+  getNextBlockId,
+  getPrevBlockId,
+  isBlockFocused,
+  isBlockSelected,
+  resetSelectionState,
+} from "../../src/selection/state";
+import { createInitialFocus, createInitialMultiSelection } from "../../src/selection/types";
+
+// Helper to create a test block
+function createTestBlock(
+  type: string,
+  props: Record<string, unknown> = {},
+  children?: Block[]
+): Block {
+  const block: Block = {
+    id: uuidv7(),
+    type,
+    props,
+  };
+  if (children !== undefined) {
+    block.children = children;
+  }
+  return block;
+}
+
+describe("Selection State", () => {
+  beforeEach(() => {
+    initializeDocument();
+    resetSelectionState();
+  });
+
+  afterEach(() => {
+    initializeDocument();
+    resetSelectionState();
+  });
+
+  describe("$multiSelection atom", () => {
+    it("starts with empty selection", () => {
+      const state = $multiSelection.get();
+      expect(state.selectedIds.size).toBe(0);
+      expect(state.anchorId).toBeNull();
+      expect(state.lastSelectedId).toBeNull();
+    });
+
+    it("can be updated with new selection", () => {
+      $multiSelection.set({
+        selectedIds: new Set(["id1", "id2"]),
+        anchorId: "id1",
+        lastSelectedId: "id2",
+      });
+
+      const state = $multiSelection.get();
+      expect(state.selectedIds.size).toBe(2);
+      expect(state.anchorId).toBe("id1");
+      expect(state.lastSelectedId).toBe("id2");
+    });
+  });
+
+  describe("$focus atom", () => {
+    it("starts with no focus", () => {
+      const state = $focus.get();
+      expect(state.focusedId).toBeNull();
+      expect(state.isEditing).toBe(false);
+    });
+
+    it("can be updated with focus", () => {
+      $focus.set({
+        focusedId: "block-123",
+        isEditing: true,
+      });
+
+      const state = $focus.get();
+      expect(state.focusedId).toBe("block-123");
+      expect(state.isEditing).toBe(true);
+    });
+  });
+
+  describe("computed selection atoms", () => {
+    beforeEach(() => {
+      $multiSelection.set({
+        selectedIds: new Set(["id1", "id2", "id3"]),
+        anchorId: "id1",
+        lastSelectedId: "id3",
+      });
+    });
+
+    it("$selectedIds returns the set of selected IDs", () => {
+      const ids = $selectedIds.get();
+      expect(ids.size).toBe(3);
+      expect(ids.has("id1")).toBe(true);
+      expect(ids.has("id2")).toBe(true);
+      expect(ids.has("id3")).toBe(true);
+    });
+
+    it("$selectionCount returns the count", () => {
+      expect($selectionCount.get()).toBe(3);
+    });
+
+    it("$hasSelection returns true when blocks are selected", () => {
+      expect($hasSelection.get()).toBe(true);
+    });
+
+    it("$hasSelection returns false when no blocks are selected", () => {
+      $multiSelection.set(createInitialMultiSelection());
+      expect($hasSelection.get()).toBe(false);
+    });
+
+    it("$hasMultiSelection returns true when multiple blocks are selected", () => {
+      expect($hasMultiSelection.get()).toBe(true);
+    });
+
+    it("$hasMultiSelection returns false for single selection", () => {
+      $multiSelection.set({
+        selectedIds: new Set(["id1"]),
+        anchorId: "id1",
+        lastSelectedId: "id1",
+      });
+      expect($hasMultiSelection.get()).toBe(false);
+    });
+  });
+
+  describe("computed focus atoms", () => {
+    it("$focusedBlockId returns the focused block ID", () => {
+      $focus.set({ focusedId: "block-abc", isEditing: false });
+      expect($focusedBlockId.get()).toBe("block-abc");
+    });
+
+    it("$isEditing returns editing state", () => {
+      $focus.set({ focusedId: "block-abc", isEditing: true });
+      expect($isEditing.get()).toBe(true);
+    });
+  });
+
+  describe("$anchorBlock", () => {
+    it("returns null when no anchor", () => {
+      expect($anchorBlock.get()).toBeNull();
+    });
+
+    it("returns the anchor block when set", () => {
+      const block = createTestBlock("paragraph", { content: "Anchor" });
+      insertBlockAction(block);
+
+      $multiSelection.set({
+        selectedIds: new Set([block.id]),
+        anchorId: block.id,
+        lastSelectedId: block.id,
+      });
+
+      const anchor = $anchorBlock.get();
+      expect(anchor).not.toBeNull();
+      expect(anchor?.id).toBe(block.id);
+    });
+  });
+
+  describe("$lastSelectedBlock", () => {
+    it("returns null when no last selected", () => {
+      expect($lastSelectedBlock.get()).toBeNull();
+    });
+
+    it("returns the last selected block when set", () => {
+      const block = createTestBlock("paragraph", { content: "Last" });
+      insertBlockAction(block);
+
+      $multiSelection.set({
+        selectedIds: new Set([block.id]),
+        anchorId: block.id,
+        lastSelectedId: block.id,
+      });
+
+      const last = $lastSelectedBlock.get();
+      expect(last).not.toBeNull();
+      expect(last?.id).toBe(block.id);
+    });
+  });
+
+  describe("$selectedBlocks", () => {
+    it("returns empty array when no selection", () => {
+      expect($selectedBlocks.get()).toEqual([]);
+    });
+
+    it("returns selected blocks in document order", () => {
+      const block1 = createTestBlock("paragraph", { content: "First" });
+      const block2 = createTestBlock("paragraph", { content: "Second" });
+      const block3 = createTestBlock("paragraph", { content: "Third" });
+
+      insertBlockAction(block1);
+      insertBlockAction(block2);
+      insertBlockAction(block3);
+
+      // Select in reverse order
+      $multiSelection.set({
+        selectedIds: new Set([block3.id, block1.id]),
+        anchorId: block3.id,
+        lastSelectedId: block1.id,
+      });
+
+      const selected = $selectedBlocks.get();
+      expect(selected).toHaveLength(2);
+      // Should be in document order, not selection order
+      expect(selected[0]?.id).toBe(block1.id);
+      expect(selected[1]?.id).toBe(block3.id);
+    });
+
+    it("includes nested blocks", () => {
+      const child = createTestBlock("paragraph", { content: "Child" });
+      const parent = createTestBlock("section", {}, [child]);
+      insertBlockAction(parent);
+
+      $multiSelection.set({
+        selectedIds: new Set([child.id]),
+        anchorId: child.id,
+        lastSelectedId: child.id,
+      });
+
+      const selected = $selectedBlocks.get();
+      expect(selected).toHaveLength(1);
+      expect(selected[0]?.id).toBe(child.id);
+    });
+  });
+
+  describe("$focusedBlock", () => {
+    it("returns null when no focus", () => {
+      expect($focusedBlock.get()).toBeNull();
+    });
+
+    it("returns the focused block", () => {
+      const block = createTestBlock("paragraph", { content: "Focused" });
+      insertBlockAction(block);
+
+      $focus.set({ focusedId: block.id, isEditing: false });
+
+      const focused = $focusedBlock.get();
+      expect(focused).not.toBeNull();
+      expect(focused?.id).toBe(block.id);
+    });
+  });
+
+  describe("isBlockSelected", () => {
+    it("returns true for selected block", () => {
+      $multiSelection.set({
+        selectedIds: new Set(["block-1"]),
+        anchorId: "block-1",
+        lastSelectedId: "block-1",
+      });
+      expect(isBlockSelected("block-1")).toBe(true);
+    });
+
+    it("returns false for unselected block", () => {
+      $multiSelection.set({
+        selectedIds: new Set(["block-1"]),
+        anchorId: "block-1",
+        lastSelectedId: "block-1",
+      });
+      expect(isBlockSelected("block-2")).toBe(false);
+    });
+  });
+
+  describe("isBlockFocused", () => {
+    it("returns true for focused block", () => {
+      $focus.set({ focusedId: "block-1", isEditing: false });
+      expect(isBlockFocused("block-1")).toBe(true);
+    });
+
+    it("returns false for unfocused block", () => {
+      $focus.set({ focusedId: "block-1", isEditing: false });
+      expect(isBlockFocused("block-2")).toBe(false);
+    });
+  });
+
+  describe("getFlatBlockList", () => {
+    it("returns empty array for empty document", () => {
+      expect(getFlatBlockList()).toEqual([]);
+    });
+
+    it("returns block IDs in order", () => {
+      const block1 = createTestBlock("paragraph");
+      const block2 = createTestBlock("paragraph");
+      insertBlockAction(block1);
+      insertBlockAction(block2);
+
+      const list = getFlatBlockList();
+      expect(list).toEqual([block1.id, block2.id]);
+    });
+
+    it("includes nested block IDs", () => {
+      const child1 = createTestBlock("paragraph");
+      const child2 = createTestBlock("paragraph");
+      const parent = createTestBlock("section", {}, [child1, child2]);
+      const sibling = createTestBlock("paragraph");
+
+      insertBlockAction(parent);
+      insertBlockAction(sibling);
+
+      const list = getFlatBlockList();
+      expect(list).toEqual([parent.id, child1.id, child2.id, sibling.id]);
+    });
+  });
+
+  describe("getBlockFlatIndex", () => {
+    it("returns -1 for non-existent block", () => {
+      expect(getBlockFlatIndex("nonexistent")).toBe(-1);
+    });
+
+    it("returns correct index for block", () => {
+      const block1 = createTestBlock("paragraph");
+      const block2 = createTestBlock("paragraph");
+      insertBlockAction(block1);
+      insertBlockAction(block2);
+
+      expect(getBlockFlatIndex(block1.id)).toBe(0);
+      expect(getBlockFlatIndex(block2.id)).toBe(1);
+    });
+  });
+
+  describe("getBlockAtFlatIndex", () => {
+    it("returns null for negative index", () => {
+      expect(getBlockAtFlatIndex(-1)).toBeNull();
+    });
+
+    it("returns null for out of bounds index", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+      expect(getBlockAtFlatIndex(5)).toBeNull();
+    });
+
+    it("returns block ID at index", () => {
+      const block1 = createTestBlock("paragraph");
+      const block2 = createTestBlock("paragraph");
+      insertBlockAction(block1);
+      insertBlockAction(block2);
+
+      expect(getBlockAtFlatIndex(0)).toBe(block1.id);
+      expect(getBlockAtFlatIndex(1)).toBe(block2.id);
+    });
+  });
+
+  describe("getNextBlockId", () => {
+    it("returns null when at end", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+      expect(getNextBlockId(block.id)).toBeNull();
+    });
+
+    it("returns null for non-existent block", () => {
+      expect(getNextBlockId("nonexistent")).toBeNull();
+    });
+
+    it("returns next block ID", () => {
+      const block1 = createTestBlock("paragraph");
+      const block2 = createTestBlock("paragraph");
+      insertBlockAction(block1);
+      insertBlockAction(block2);
+
+      expect(getNextBlockId(block1.id)).toBe(block2.id);
+    });
+  });
+
+  describe("getPrevBlockId", () => {
+    it("returns null when at beginning", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+      expect(getPrevBlockId(block.id)).toBeNull();
+    });
+
+    it("returns null for non-existent block", () => {
+      expect(getPrevBlockId("nonexistent")).toBeNull();
+    });
+
+    it("returns previous block ID", () => {
+      const block1 = createTestBlock("paragraph");
+      const block2 = createTestBlock("paragraph");
+      insertBlockAction(block1);
+      insertBlockAction(block2);
+
+      expect(getPrevBlockId(block2.id)).toBe(block1.id);
+    });
+  });
+
+  describe("getFirstBlockId", () => {
+    it("returns null for empty document", () => {
+      expect(getFirstBlockId()).toBeNull();
+    });
+
+    it("returns first block ID", () => {
+      const block1 = createTestBlock("paragraph");
+      const block2 = createTestBlock("paragraph");
+      insertBlockAction(block1);
+      insertBlockAction(block2);
+
+      expect(getFirstBlockId()).toBe(block1.id);
+    });
+  });
+
+  describe("getLastBlockId", () => {
+    it("returns null for empty document", () => {
+      expect(getLastBlockId()).toBeNull();
+    });
+
+    it("returns last block ID", () => {
+      const block1 = createTestBlock("paragraph");
+      const block2 = createTestBlock("paragraph");
+      insertBlockAction(block1);
+      insertBlockAction(block2);
+
+      expect(getLastBlockId()).toBe(block2.id);
+    });
+
+    it("returns deepest last block for nested", () => {
+      const child = createTestBlock("paragraph");
+      const parent = createTestBlock("section", {}, [child]);
+      insertBlockAction(parent);
+
+      // Last in flat list is the child
+      expect(getLastBlockId()).toBe(child.id);
+    });
+  });
+
+  describe("getBlockRange", () => {
+    it("returns empty array for non-existent start", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+      expect(getBlockRange("nonexistent", block.id)).toEqual([]);
+    });
+
+    it("returns empty array for non-existent end", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+      expect(getBlockRange(block.id, "nonexistent")).toEqual([]);
+    });
+
+    it("returns single block when start equals end", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+
+      const range = getBlockRange(block.id, block.id);
+      expect(range).toEqual([block.id]);
+    });
+
+    it("returns range in document order (start before end)", () => {
+      const block1 = createTestBlock("paragraph");
+      const block2 = createTestBlock("paragraph");
+      const block3 = createTestBlock("paragraph");
+      insertBlockAction(block1);
+      insertBlockAction(block2);
+      insertBlockAction(block3);
+
+      const range = getBlockRange(block1.id, block3.id);
+      expect(range).toEqual([block1.id, block2.id, block3.id]);
+    });
+
+    it("returns range in document order (end before start)", () => {
+      const block1 = createTestBlock("paragraph");
+      const block2 = createTestBlock("paragraph");
+      const block3 = createTestBlock("paragraph");
+      insertBlockAction(block1);
+      insertBlockAction(block2);
+      insertBlockAction(block3);
+
+      // Reversed order
+      const range = getBlockRange(block3.id, block1.id);
+      expect(range).toEqual([block1.id, block2.id, block3.id]);
+    });
+  });
+
+  describe("resetSelectionState", () => {
+    it("resets selection to initial state", () => {
+      $multiSelection.set({
+        selectedIds: new Set(["id1"]),
+        anchorId: "id1",
+        lastSelectedId: "id1",
+      });
+
+      resetSelectionState();
+
+      const state = $multiSelection.get();
+      expect(state.selectedIds.size).toBe(0);
+      expect(state.anchorId).toBeNull();
+    });
+
+    it("resets focus to initial state", () => {
+      $focus.set({ focusedId: "block-1", isEditing: true });
+
+      resetSelectionState();
+
+      const state = $focus.get();
+      expect(state.focusedId).toBeNull();
+      expect(state.isEditing).toBe(false);
+    });
+  });
+});

--- a/packages/edit/test/selection/types.test.ts
+++ b/packages/edit/test/selection/types.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import {
+  createInitialFocus,
+  createInitialMultiSelection,
+  createInitialSelectionFocus,
+  createSelectionError,
+  FocusStateSchema,
+  MultiSelectionStateSchema,
+  SelectionFocusStateSchema,
+} from "../../src/selection/types";
+
+describe("Selection Types", () => {
+  describe("createInitialMultiSelection", () => {
+    it("creates state with empty selected ids", () => {
+      const state = createInitialMultiSelection();
+      expect(state.selectedIds.size).toBe(0);
+    });
+
+    it("creates state with null anchor", () => {
+      const state = createInitialMultiSelection();
+      expect(state.anchorId).toBeNull();
+    });
+
+    it("creates state with null last selected", () => {
+      const state = createInitialMultiSelection();
+      expect(state.lastSelectedId).toBeNull();
+    });
+  });
+
+  describe("createInitialFocus", () => {
+    it("creates state with null focused id", () => {
+      const state = createInitialFocus();
+      expect(state.focusedId).toBeNull();
+    });
+
+    it("creates state with isEditing false", () => {
+      const state = createInitialFocus();
+      expect(state.isEditing).toBe(false);
+    });
+  });
+
+  describe("createInitialSelectionFocus", () => {
+    it("creates combined state with initial selection", () => {
+      const state = createInitialSelectionFocus();
+      expect(state.selection.selectedIds.size).toBe(0);
+      expect(state.selection.anchorId).toBeNull();
+    });
+
+    it("creates combined state with initial focus", () => {
+      const state = createInitialSelectionFocus();
+      expect(state.focus.focusedId).toBeNull();
+      expect(state.focus.isEditing).toBe(false);
+    });
+  });
+
+  describe("createSelectionError", () => {
+    it("creates error with code and message", () => {
+      const error = createSelectionError(
+        "BLOCK_NOT_FOUND",
+        "Block not found: abc123"
+      );
+      expect(error.code).toBe("BLOCK_NOT_FOUND");
+      expect(error.message).toBe("Block not found: abc123");
+    });
+
+    it("creates error with optional cause", () => {
+      const cause = new Error("underlying error");
+      const error = createSelectionError(
+        "INVALID_RANGE",
+        "Invalid range",
+        cause
+      );
+      expect(error.cause).toBe(cause);
+    });
+  });
+
+  describe("FocusStateSchema", () => {
+    it("validates valid focus state", () => {
+      const result = FocusStateSchema.safeParse({
+        focusedId: "block-123",
+        isEditing: true,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("validates null focused id", () => {
+      const result = FocusStateSchema.safeParse({
+        focusedId: null,
+        isEditing: false,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects invalid focus state", () => {
+      const result = FocusStateSchema.safeParse({
+        focusedId: 123, // Should be string or null
+        isEditing: false,
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("MultiSelectionStateSchema", () => {
+    it("validates valid multi-selection state", () => {
+      const result = MultiSelectionStateSchema.safeParse({
+        selectedIds: ["id1", "id2"],
+        anchorId: "id1",
+        lastSelectedId: "id2",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.selectedIds).toBeInstanceOf(Set);
+        expect(result.data.selectedIds.size).toBe(2);
+      }
+    });
+
+    it("transforms array to Set", () => {
+      const result = MultiSelectionStateSchema.safeParse({
+        selectedIds: ["a", "b", "c"],
+        anchorId: null,
+        lastSelectedId: null,
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.selectedIds.has("a")).toBe(true);
+        expect(result.data.selectedIds.has("b")).toBe(true);
+        expect(result.data.selectedIds.has("c")).toBe(true);
+      }
+    });
+  });
+
+  describe("SelectionFocusStateSchema", () => {
+    it("validates valid combined state", () => {
+      const result = SelectionFocusStateSchema.safeParse({
+        selection: {
+          selectedIds: ["id1"],
+          anchorId: "id1",
+          lastSelectedId: "id1",
+        },
+        focus: {
+          focusedId: "id1",
+          isEditing: false,
+        },
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements PZ-207 (#43): Selection and focus system for blocks in the editor.

- Click to select with selection ring
- Arrow keys navigate between blocks
- Tab/Shift+Tab navigation
- Enter to edit selected block
- Escape to deselect (multi-stage: edit -> selection -> focus)
- Multi-select with Shift+Click range selection
- Cmd/Ctrl+Click for toggle selection
- Selection state in Nanostores atoms

## Technical Details

**State atoms:**
- `$multiSelection` - Selection state with anchor and range support
- `$focus` - Focus state with editing mode
- Computed atoms for derived values

**Actions:**
- Selection: selectBlock, deselectBlock, toggleSelection, selectRange, clearSelection, selectAll
- Focus: focusBlock, focusNext, focusPrev, focusDirection
- Edit: enterEditMode, exitEditMode, escape

**Keyboard:**
- Configurable keyboard handler factory
- Arrow, Tab, Enter, Escape key support
- Shift+Arrow for extend selection

## Test Plan

- [x] Click to select works
- [x] Arrow keys navigate blocks
- [x] Tab navigation works
- [x] Enter enters edit mode
- [x] Escape deselects (multi-stage)
- [x] Shift+Click selects range
- [x] All 442 tests pass (173 new)

Closes #43

:robot: Generated with [Claude Code](https://claude.com/claude-code)