### PR TITLE
feat(ui): implement Conditional Logic Builder (PZ-103)

### DIFF
--- a/packages/ui/src/designer/ConditionalLogic.tsx
+++ b/packages/ui/src/designer/ConditionalLogic.tsx
@@ -1,0 +1,1333 @@
+/**
+ * Conditional Logic Builder (PZ-103)
+ *
+ * A UI component for creating conditional field visibility rules.
+ * Features:
+ * - "Show this field when..." dropdown
+ * - Select trigger field from other fields in form
+ * - Select condition (equals, notEquals, contains, isEmpty, etc.)
+ * - Value input based on trigger field type
+ * - Multiple conditions with AND/OR operators
+ * - Visual indicator on conditional fields
+ */
+
+import {
+  type ReactNode,
+  useState,
+  useCallback,
+  useMemo,
+  createContext,
+  useContext,
+} from "react";
+import type {
+  ComparisonOperator,
+  VisibilityCondition,
+  LogicalOperator,
+  ConditionGroup,
+  VisibilityRules,
+} from "@phantom-zone/core";
+
+import type { CanvasField } from "./types";
+import { generateUUIDv7 } from "./types";
+
+// -----------------------------------------------------------------------------
+// Types
+// -----------------------------------------------------------------------------
+
+/**
+ * Represents a single condition in the UI (with unique ID for React keys).
+ */
+export interface UICondition {
+  id: string;
+  fieldId: string;
+  operator: ComparisonOperator;
+  value: string | number | boolean | null;
+}
+
+/**
+ * Represents a condition group in the UI (with unique ID for React keys).
+ */
+export interface UIConditionGroup {
+  id: string;
+  operator: LogicalOperator;
+  conditions: Array<UICondition | UIConditionGroup>;
+}
+
+/**
+ * Event emitted when visibility rules change.
+ */
+export interface VisibilityRulesChangeEvent {
+  fieldId: string;
+  rules: VisibilityRules | null;
+}
+
+/**
+ * Event emitted when a condition is added.
+ */
+export interface ConditionAddEvent {
+  fieldId: string;
+  condition: UICondition;
+  parentGroupId?: string;
+}
+
+/**
+ * Event emitted when a condition is removed.
+ */
+export interface ConditionRemoveEvent {
+  fieldId: string;
+  conditionId: string;
+}
+
+/**
+ * Event emitted when a condition is updated.
+ */
+export interface ConditionUpdateEvent {
+  fieldId: string;
+  conditionId: string;
+  updates: Partial<Omit<UICondition, "id">>;
+}
+
+/**
+ * Event emitted when a group operator changes.
+ */
+export interface GroupOperatorChangeEvent {
+  fieldId: string;
+  groupId: string;
+  operator: LogicalOperator;
+}
+
+/**
+ * Maps comparison operators to human-readable labels.
+ */
+export const OPERATOR_LABELS: Record<ComparisonOperator, string> = {
+  equals: "equals",
+  notEquals: "does not equal",
+  contains: "contains",
+  notContains: "does not contain",
+  greaterThan: "is greater than",
+  lessThan: "is less than",
+  greaterThanOrEquals: "is at least",
+  lessThanOrEquals: "is at most",
+  isEmpty: "is empty",
+  isNotEmpty: "is not empty",
+  matches: "matches pattern",
+};
+
+/**
+ * Operators that don't require a value input.
+ */
+export const VALUE_FREE_OPERATORS: ComparisonOperator[] = ["isEmpty", "isNotEmpty"];
+
+/**
+ * Get operators compatible with a field type.
+ */
+export function getCompatibleOperators(fieldType: string): ComparisonOperator[] {
+  switch (fieldType) {
+    case "number":
+      return [
+        "equals",
+        "notEquals",
+        "greaterThan",
+        "lessThan",
+        "greaterThanOrEquals",
+        "lessThanOrEquals",
+        "isEmpty",
+        "isNotEmpty",
+      ];
+    case "checkbox":
+      return ["equals", "notEquals"];
+    case "select":
+    case "multiselect":
+      return [
+        "equals",
+        "notEquals",
+        "contains",
+        "notContains",
+        "isEmpty",
+        "isNotEmpty",
+      ];
+    case "date":
+      return [
+        "equals",
+        "notEquals",
+        "greaterThan",
+        "lessThan",
+        "greaterThanOrEquals",
+        "lessThanOrEquals",
+        "isEmpty",
+        "isNotEmpty",
+      ];
+    case "text":
+    case "textarea":
+    default:
+      return [
+        "equals",
+        "notEquals",
+        "contains",
+        "notContains",
+        "isEmpty",
+        "isNotEmpty",
+        "matches",
+      ];
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Context
+// -----------------------------------------------------------------------------
+
+interface ConditionalLogicContextValue {
+  /** The field being configured */
+  field: CanvasField | null;
+  /** All available fields that can be used as triggers (excludes current field) */
+  availableFields: CanvasField[];
+  /** Current UI condition group */
+  conditionGroup: UIConditionGroup | null;
+  /** Add a new condition */
+  addCondition: (parentGroupId?: string) => void;
+  /** Remove a condition */
+  removeCondition: (conditionId: string) => void;
+  /** Update a condition */
+  updateCondition: (conditionId: string, updates: Partial<Omit<UICondition, "id">>) => void;
+  /** Change group operator */
+  setGroupOperator: (groupId: string, operator: LogicalOperator) => void;
+  /** Add a nested condition group */
+  addNestedGroup: (parentGroupId: string) => void;
+  /** Clear all conditions */
+  clearConditions: () => void;
+  /** Get a field by ID */
+  getFieldById: (fieldId: string) => CanvasField | undefined;
+}
+
+const ConditionalLogicContext = createContext<ConditionalLogicContextValue | null>(null);
+
+/**
+ * Hook to access the ConditionalLogic context.
+ * Must be used within a ConditionalLogic component.
+ */
+export function useConditionalLogic(): ConditionalLogicContextValue {
+  const context = useContext(ConditionalLogicContext);
+  if (!context) {
+    throw new Error("useConditionalLogic must be used within a ConditionalLogic component");
+  }
+  return context;
+}
+
+// -----------------------------------------------------------------------------
+// Conversion Utilities
+// -----------------------------------------------------------------------------
+
+/**
+ * Convert UI condition to visibility condition.
+ */
+export function uiConditionToVisibility(condition: UICondition): VisibilityCondition {
+  const result: VisibilityCondition = {
+    fieldId: condition.fieldId,
+    operator: condition.operator,
+  };
+
+  // Only include value if operator requires it
+  if (!VALUE_FREE_OPERATORS.includes(condition.operator)) {
+    result.value = condition.value;
+  }
+
+  return result;
+}
+
+/**
+ * Convert UI condition group to visibility rules.
+ */
+export function uiGroupToVisibilityRules(group: UIConditionGroup): VisibilityRules {
+  // Single condition - return as single VisibilityCondition
+  if (group.conditions.length === 1) {
+    const first = group.conditions[0];
+    if (first && !isUIConditionGroup(first)) {
+      return uiConditionToVisibility(first);
+    }
+  }
+
+  // Multiple conditions - return as ConditionGroup
+  const conditions: Array<VisibilityCondition | ConditionGroup> = group.conditions.map((c) => {
+    if (isUIConditionGroup(c)) {
+      return uiGroupToVisibilityRules(c) as ConditionGroup;
+    }
+    return uiConditionToVisibility(c);
+  });
+
+  return {
+    operator: group.operator,
+    conditions,
+  };
+}
+
+/**
+ * Convert visibility rules to UI condition group.
+ */
+export function visibilityRulesToUIGroup(rules: VisibilityRules): UIConditionGroup {
+  if (isConditionGroup(rules)) {
+    return {
+      id: generateUUIDv7(),
+      operator: rules.operator,
+      conditions: rules.conditions.map((c) => {
+        if (isConditionGroup(c)) {
+          return visibilityRulesToUIGroup(c);
+        }
+        return {
+          id: generateUUIDv7(),
+          fieldId: c.fieldId,
+          operator: c.operator,
+          value: c.value ?? null,
+        };
+      }),
+    };
+  }
+
+  // Single condition - wrap in a group
+  return {
+    id: generateUUIDv7(),
+    operator: "and",
+    conditions: [
+      {
+        id: generateUUIDv7(),
+        fieldId: rules.fieldId,
+        operator: rules.operator,
+        value: rules.value ?? null,
+      },
+    ],
+  };
+}
+
+/**
+ * Type guard for ConditionGroup.
+ */
+function isConditionGroup(rule: VisibilityRules): rule is ConditionGroup {
+  return "operator" in rule && "conditions" in rule;
+}
+
+/**
+ * Type guard for UIConditionGroup.
+ */
+function isUIConditionGroup(item: UICondition | UIConditionGroup): item is UIConditionGroup {
+  return "conditions" in item;
+}
+
+/**
+ * Create an empty condition with defaults.
+ */
+export function createEmptyCondition(defaultFieldId?: string): UICondition {
+  return {
+    id: generateUUIDv7(),
+    fieldId: defaultFieldId ?? "",
+    operator: "equals",
+    value: null,
+  };
+}
+
+/**
+ * Create an empty condition group.
+ */
+export function createEmptyConditionGroup(): UIConditionGroup {
+  return {
+    id: generateUUIDv7(),
+    operator: "and",
+    conditions: [],
+  };
+}
+
+// -----------------------------------------------------------------------------
+// ConditionRow Component
+// -----------------------------------------------------------------------------
+
+export interface ConditionRowProps {
+  /** The condition to render */
+  condition: UICondition;
+  /** Index for display (e.g., "and" separator) */
+  index: number;
+  /** Parent group operator (for display) */
+  groupOperator: LogicalOperator;
+  /** Whether to show the operator label before this row */
+  showOperatorLabel: boolean;
+  /** Available trigger fields */
+  availableFields: CanvasField[];
+  /** Callback when condition changes */
+  onChange: (conditionId: string, updates: Partial<Omit<UICondition, "id">>) => void;
+  /** Callback when condition is removed */
+  onRemove: (conditionId: string) => void;
+  /** Custom field option renderer */
+  renderFieldOption?: (field: CanvasField) => ReactNode;
+  /** Custom value input renderer */
+  renderValueInput?: (
+    condition: UICondition,
+    triggerField: CanvasField | undefined,
+    onChange: (value: string | number | boolean | null) => void
+  ) => ReactNode;
+}
+
+/**
+ * Renders a single condition row with field selector, operator selector, and value input.
+ */
+export function ConditionRow({
+  condition,
+  index,
+  groupOperator,
+  showOperatorLabel,
+  availableFields,
+  onChange,
+  onRemove,
+  renderFieldOption,
+  renderValueInput,
+}: ConditionRowProps) {
+  const triggerField = availableFields.find((f) => f.id === condition.fieldId);
+  const compatibleOperators = triggerField
+    ? getCompatibleOperators(triggerField.inputType)
+    : getCompatibleOperators("text");
+  const showValueInput = !VALUE_FREE_OPERATORS.includes(condition.operator);
+
+  const handleFieldChange = useCallback(
+    (fieldId: string) => {
+      const newField = availableFields.find((f) => f.id === fieldId);
+      const newOperators = newField
+        ? getCompatibleOperators(newField.inputType)
+        : getCompatibleOperators("text");
+
+      // Reset operator if current one is not compatible
+      const newOperator = newOperators.includes(condition.operator)
+        ? condition.operator
+        : newOperators[0] ?? "equals";
+
+      onChange(condition.id, {
+        fieldId,
+        operator: newOperator,
+        value: null, // Reset value when field changes
+      });
+    },
+    [availableFields, condition.id, condition.operator, onChange]
+  );
+
+  const handleOperatorChange = useCallback(
+    (operator: ComparisonOperator) => {
+      const updates: Partial<Omit<UICondition, "id">> = { operator };
+
+      // Clear value if operator doesn't need it
+      if (VALUE_FREE_OPERATORS.includes(operator)) {
+        updates.value = null;
+      }
+
+      onChange(condition.id, updates);
+    },
+    [condition.id, onChange]
+  );
+
+  const handleValueChange = useCallback(
+    (value: string | number | boolean | null) => {
+      onChange(condition.id, { value });
+    },
+    [condition.id, onChange]
+  );
+
+  return (
+    <div
+      data-testid={`condition-row-${condition.id}`}
+      data-index={index}
+      role="group"
+      aria-label={`Condition ${index + 1}`}
+    >
+      {/* Operator label (AND/OR) */}
+      {showOperatorLabel && (
+        <span
+          data-testid={`condition-operator-label-${condition.id}`}
+          aria-hidden="true"
+        >
+          {groupOperator.toUpperCase()}
+        </span>
+      )}
+
+      {/* Field Selector */}
+      <div data-testid={`condition-field-wrapper-${condition.id}`}>
+        <label
+          htmlFor={`condition-field-${condition.id}`}
+          data-testid={`condition-field-label-${condition.id}`}
+        >
+          When
+        </label>
+        <select
+          id={`condition-field-${condition.id}`}
+          data-testid={`condition-field-select-${condition.id}`}
+          value={condition.fieldId}
+          onChange={(e) => handleFieldChange(e.target.value)}
+          aria-label="Select trigger field"
+        >
+          <option value="">Select a field...</option>
+          {availableFields.map((field) => (
+            <option key={field.id} value={field.id}>
+              {renderFieldOption ? renderFieldOption(field) : field.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Operator Selector */}
+      <div data-testid={`condition-operator-wrapper-${condition.id}`}>
+        <label
+          htmlFor={`condition-operator-${condition.id}`}
+          data-testid={`condition-operator-label-input-${condition.id}`}
+        >
+          Condition
+        </label>
+        <select
+          id={`condition-operator-${condition.id}`}
+          data-testid={`condition-operator-select-${condition.id}`}
+          value={condition.operator}
+          onChange={(e) => handleOperatorChange(e.target.value as ComparisonOperator)}
+          aria-label="Select condition type"
+          disabled={!condition.fieldId}
+        >
+          {compatibleOperators.map((op) => (
+            <option key={op} value={op}>
+              {OPERATOR_LABELS[op]}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Value Input */}
+      {showValueInput && (
+        <div data-testid={`condition-value-wrapper-${condition.id}`}>
+          <label
+            htmlFor={`condition-value-${condition.id}`}
+            data-testid={`condition-value-label-${condition.id}`}
+          >
+            Value
+          </label>
+          {renderValueInput ? (
+            renderValueInput(condition, triggerField, handleValueChange)
+          ) : (
+            <DefaultValueInput
+              condition={condition}
+              triggerField={triggerField}
+              onChange={handleValueChange}
+            />
+          )}
+        </div>
+      )}
+
+      {/* Remove Button */}
+      <button
+        type="button"
+        data-testid={`condition-remove-${condition.id}`}
+        onClick={() => onRemove(condition.id)}
+        aria-label="Remove this condition"
+      >
+        <RemoveIcon />
+      </button>
+    </div>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// Default Value Input
+// -----------------------------------------------------------------------------
+
+interface DefaultValueInputProps {
+  condition: UICondition;
+  triggerField: CanvasField | undefined;
+  onChange: (value: string | number | boolean | null) => void;
+}
+
+function DefaultValueInput({
+  condition,
+  triggerField,
+  onChange,
+}: DefaultValueInputProps) {
+  const inputId = `condition-value-${condition.id}`;
+
+  // Checkbox field - show boolean select
+  if (triggerField?.inputType === "checkbox") {
+    return (
+      <select
+        id={inputId}
+        data-testid={`condition-value-input-${condition.id}`}
+        value={condition.value === true ? "true" : "false"}
+        onChange={(e) => onChange(e.target.value === "true")}
+        aria-label="Value to compare"
+      >
+        <option value="true">Checked</option>
+        <option value="false">Unchecked</option>
+      </select>
+    );
+  }
+
+  // Select field - show options dropdown
+  if (triggerField?.inputType === "select" && triggerField.options) {
+    return (
+      <select
+        id={inputId}
+        data-testid={`condition-value-input-${condition.id}`}
+        value={condition.value?.toString() ?? ""}
+        onChange={(e) => onChange(e.target.value || null)}
+        aria-label="Value to compare"
+      >
+        <option value="">Select a value...</option>
+        {triggerField.options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    );
+  }
+
+  // Number field - show number input
+  if (triggerField?.inputType === "number") {
+    return (
+      <input
+        id={inputId}
+        type="number"
+        data-testid={`condition-value-input-${condition.id}`}
+        value={condition.value?.toString() ?? ""}
+        onChange={(e) => {
+          const val = e.target.value;
+          onChange(val === "" ? null : Number(val));
+        }}
+        aria-label="Value to compare"
+        placeholder="Enter a number"
+      />
+    );
+  }
+
+  // Date field - show date input
+  if (triggerField?.inputType === "date") {
+    return (
+      <input
+        id={inputId}
+        type="date"
+        data-testid={`condition-value-input-${condition.id}`}
+        value={condition.value?.toString() ?? ""}
+        onChange={(e) => onChange(e.target.value || null)}
+        aria-label="Value to compare"
+      />
+    );
+  }
+
+  // Default - text input
+  return (
+    <input
+      id={inputId}
+      type="text"
+      data-testid={`condition-value-input-${condition.id}`}
+      value={condition.value?.toString() ?? ""}
+      onChange={(e) => onChange(e.target.value || null)}
+      aria-label="Value to compare"
+      placeholder="Enter a value"
+    />
+  );
+}
+
+// -----------------------------------------------------------------------------
+// ConditionGroupComponent
+// -----------------------------------------------------------------------------
+
+export interface ConditionGroupComponentProps {
+  /** The condition group to render */
+  group: UIConditionGroup;
+  /** Depth level for nested groups */
+  depth: number;
+  /** Available trigger fields */
+  availableFields: CanvasField[];
+  /** Callback when a condition changes */
+  onConditionChange: (conditionId: string, updates: Partial<Omit<UICondition, "id">>) => void;
+  /** Callback when a condition is removed */
+  onConditionRemove: (conditionId: string) => void;
+  /** Callback when group operator changes */
+  onOperatorChange: (groupId: string, operator: LogicalOperator) => void;
+  /** Callback to add a condition */
+  onAddCondition: (parentGroupId: string) => void;
+  /** Callback to add a nested group */
+  onAddNestedGroup: (parentGroupId: string) => void;
+  /** Custom field option renderer */
+  renderFieldOption?: (field: CanvasField) => ReactNode;
+  /** Custom value input renderer */
+  renderValueInput?: (
+    condition: UICondition,
+    triggerField: CanvasField | undefined,
+    onChange: (value: string | number | boolean | null) => void
+  ) => ReactNode;
+}
+
+/**
+ * Renders a condition group with AND/OR toggle and nested conditions.
+ */
+export function ConditionGroupComponent({
+  group,
+  depth,
+  availableFields,
+  onConditionChange,
+  onConditionRemove,
+  onOperatorChange,
+  onAddCondition,
+  onAddNestedGroup,
+  renderFieldOption,
+  renderValueInput,
+}: ConditionGroupComponentProps) {
+  const handleOperatorToggle = useCallback(() => {
+    const newOperator: LogicalOperator = group.operator === "and" ? "or" : "and";
+    onOperatorChange(group.id, newOperator);
+  }, [group.id, group.operator, onOperatorChange]);
+
+  return (
+    <div
+      data-testid={`condition-group-${group.id}`}
+      data-depth={depth}
+      role="group"
+      aria-label={`Condition group with ${group.operator.toUpperCase()} logic`}
+    >
+      {/* Group Header with Operator Toggle */}
+      {group.conditions.length > 1 && (
+        <div data-testid={`group-header-${group.id}`}>
+          <span data-testid={`group-logic-label-${group.id}`}>
+            Match
+          </span>
+          <button
+            type="button"
+            data-testid={`group-operator-toggle-${group.id}`}
+            onClick={handleOperatorToggle}
+            aria-pressed={group.operator === "and"}
+            aria-label={`Toggle between AND and OR logic. Currently: ${group.operator.toUpperCase()}`}
+          >
+            {group.operator === "and" ? "ALL" : "ANY"}
+          </button>
+          <span data-testid={`group-conditions-label-${group.id}`}>
+            of these conditions
+          </span>
+        </div>
+      )}
+
+      {/* Conditions List */}
+      <div data-testid={`group-conditions-${group.id}`} role="list">
+        {group.conditions.map((item, index) => {
+          if (isUIConditionGroup(item)) {
+            return (
+              <ConditionGroupComponent
+                key={item.id}
+                group={item}
+                depth={depth + 1}
+                availableFields={availableFields}
+                onConditionChange={onConditionChange}
+                onConditionRemove={onConditionRemove}
+                onOperatorChange={onOperatorChange}
+                onAddCondition={onAddCondition}
+                onAddNestedGroup={onAddNestedGroup}
+                renderFieldOption={renderFieldOption}
+                renderValueInput={renderValueInput}
+              />
+            );
+          }
+
+          return (
+            <ConditionRow
+              key={item.id}
+              condition={item}
+              index={index}
+              groupOperator={group.operator}
+              showOperatorLabel={index > 0}
+              availableFields={availableFields}
+              onChange={onConditionChange}
+              onRemove={onConditionRemove}
+              renderFieldOption={renderFieldOption}
+              renderValueInput={renderValueInput}
+            />
+          );
+        })}
+      </div>
+
+      {/* Add Condition Button */}
+      <div data-testid={`group-actions-${group.id}`}>
+        <button
+          type="button"
+          data-testid={`add-condition-${group.id}`}
+          onClick={() => onAddCondition(group.id)}
+          aria-label="Add another condition"
+        >
+          <PlusIcon />
+          Add Condition
+        </button>
+
+        {/* Add Nested Group (only for root level, max depth of 1) */}
+        {depth === 0 && (
+          <button
+            type="button"
+            data-testid={`add-nested-group-${group.id}`}
+            onClick={() => onAddNestedGroup(group.id)}
+            aria-label="Add nested condition group"
+          >
+            <PlusIcon />
+            Add Group
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// VisibilityIndicator Component
+// -----------------------------------------------------------------------------
+
+export interface VisibilityIndicatorProps {
+  /** Whether the field has visibility conditions */
+  hasConditions: boolean;
+  /** Number of conditions applied */
+  conditionCount: number;
+  /** Callback when clicked */
+  onClick?: () => void;
+  /** Additional class name */
+  className?: string;
+}
+
+/**
+ * Visual indicator shown on fields that have conditional visibility rules.
+ */
+export function VisibilityIndicator({
+  hasConditions,
+  conditionCount,
+  onClick,
+  className,
+}: VisibilityIndicatorProps) {
+  if (!hasConditions) {
+    return null;
+  }
+
+  return (
+    <button
+      type="button"
+      data-testid="visibility-indicator"
+      data-has-conditions={hasConditions}
+      data-condition-count={conditionCount}
+      onClick={onClick}
+      className={className}
+      aria-label={`This field has ${conditionCount} visibility condition${conditionCount !== 1 ? "s" : ""}. Click to edit.`}
+    >
+      <ConditionalIcon />
+      <span data-testid="condition-count">{conditionCount}</span>
+    </button>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// Empty State
+// -----------------------------------------------------------------------------
+
+function EmptyState() {
+  return (
+    <div
+      data-testid="conditional-logic-empty"
+      role="status"
+      aria-label="No field selected"
+    >
+      <div data-testid="empty-icon">
+        <ConditionalIcon />
+      </div>
+      <h3 data-testid="empty-title">No Field Selected</h3>
+      <p data-testid="empty-description">
+        Select a field on the canvas to configure its visibility conditions.
+      </p>
+    </div>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// No Conditions State
+// -----------------------------------------------------------------------------
+
+interface NoConditionsStateProps {
+  onAddCondition: () => void;
+}
+
+function NoConditionsState({ onAddCondition }: NoConditionsStateProps) {
+  return (
+    <div
+      data-testid="no-conditions-state"
+      role="status"
+      aria-label="No visibility conditions"
+    >
+      <p data-testid="no-conditions-description">
+        This field is always visible. Add conditions to show or hide it based on other field values.
+      </p>
+      <button
+        type="button"
+        data-testid="add-first-condition-button"
+        onClick={onAddCondition}
+        aria-label="Add first visibility condition"
+      >
+        <PlusIcon />
+        Show this field when...
+      </button>
+    </div>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// Icons
+// -----------------------------------------------------------------------------
+
+function RemoveIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      aria-hidden="true"
+    >
+      <path d="M4 4l8 8M12 4l-8 8" />
+    </svg>
+  );
+}
+
+function PlusIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      aria-hidden="true"
+    >
+      <path d="M8 2v12M2 8h12" />
+    </svg>
+  );
+}
+
+function ConditionalIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      aria-hidden="true"
+    >
+      {/* Branch/fork icon representing conditional logic */}
+      <path d="M4 2v4M4 10v4M4 6c4 0 4 4 8 4M4 10c4 0 4-4 8-4" />
+      <circle cx="12" cy="6" r="2" />
+      <circle cx="12" cy="10" r="2" />
+    </svg>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// ConditionalLogic Component
+// -----------------------------------------------------------------------------
+
+export interface ConditionalLogicProps {
+  /** The field to configure visibility for (null if no field selected) */
+  field: CanvasField | null;
+  /** All fields in the form (for selecting trigger fields) */
+  allFields: CanvasField[];
+  /** Current visibility rules for the field */
+  visibilityRules?: VisibilityRules | null;
+  /** Callback when visibility rules change */
+  onRulesChange?: (event: VisibilityRulesChangeEvent) => void;
+  /** Custom field option renderer for dropdowns */
+  renderFieldOption?: (field: CanvasField) => ReactNode;
+  /** Custom value input renderer */
+  renderValueInput?: (
+    condition: UICondition,
+    triggerField: CanvasField | undefined,
+    onChange: (value: string | number | boolean | null) => void
+  ) => ReactNode;
+  /** Additional class name */
+  className?: string;
+  /** Children to render (e.g., custom header) */
+  children?: ReactNode;
+}
+
+/**
+ * ConditionalLogic is a panel for configuring field visibility conditions.
+ *
+ * Features:
+ * - "Show this field when..." interface
+ * - Trigger field selector (other fields in the form)
+ * - Condition type selector (equals, notEquals, contains, isEmpty, etc.)
+ * - Value input appropriate for the trigger field type
+ * - Multiple conditions with AND/OR logic
+ */
+export function ConditionalLogic({
+  field,
+  allFields,
+  visibilityRules,
+  onRulesChange,
+  renderFieldOption,
+  renderValueInput,
+  className,
+  children,
+}: ConditionalLogicProps) {
+  // State for the condition group
+  const [conditionGroup, setConditionGroup] = useState<UIConditionGroup | null>(() => {
+    if (visibilityRules) {
+      return visibilityRulesToUIGroup(visibilityRules);
+    }
+    return null;
+  });
+
+  // Available fields (exclude current field)
+  const availableFields = useMemo(() => {
+    if (!field) return [];
+    return allFields.filter((f) => f.id !== field.id);
+  }, [allFields, field]);
+
+  // Notify parent when conditions change
+  const notifyChange = useCallback(
+    (newGroup: UIConditionGroup | null) => {
+      if (!field) return;
+
+      let rules: VisibilityRules | null = null;
+      if (newGroup && newGroup.conditions.length > 0) {
+        rules = uiGroupToVisibilityRules(newGroup);
+      }
+
+      onRulesChange?.({
+        fieldId: field.id,
+        rules,
+      });
+    },
+    [field, onRulesChange]
+  );
+
+  // Add a condition
+  const addCondition = useCallback(
+    (parentGroupId?: string) => {
+      const newCondition = createEmptyCondition(availableFields[0]?.id);
+
+      setConditionGroup((prev) => {
+        if (!prev) {
+          // Create new root group with the condition
+          const newGroup: UIConditionGroup = {
+            id: generateUUIDv7(),
+            operator: "and",
+            conditions: [newCondition],
+          };
+          notifyChange(newGroup);
+          return newGroup;
+        }
+
+        // Add to existing group
+        const newGroup = addConditionToGroup(prev, newCondition, parentGroupId);
+        notifyChange(newGroup);
+        return newGroup;
+      });
+    },
+    [availableFields, notifyChange]
+  );
+
+  // Remove a condition
+  const removeCondition = useCallback(
+    (conditionId: string) => {
+      setConditionGroup((prev) => {
+        if (!prev) return null;
+
+        const newGroup = removeConditionFromGroup(prev, conditionId);
+        if (newGroup.conditions.length === 0) {
+          notifyChange(null);
+          return null;
+        }
+        notifyChange(newGroup);
+        return newGroup;
+      });
+    },
+    [notifyChange]
+  );
+
+  // Update a condition
+  const updateCondition = useCallback(
+    (conditionId: string, updates: Partial<Omit<UICondition, "id">>) => {
+      setConditionGroup((prev) => {
+        if (!prev) return null;
+
+        const newGroup = updateConditionInGroup(prev, conditionId, updates);
+        notifyChange(newGroup);
+        return newGroup;
+      });
+    },
+    [notifyChange]
+  );
+
+  // Change group operator
+  const setGroupOperator = useCallback(
+    (groupId: string, operator: LogicalOperator) => {
+      setConditionGroup((prev) => {
+        if (!prev) return null;
+
+        const newGroup = updateGroupOperator(prev, groupId, operator);
+        notifyChange(newGroup);
+        return newGroup;
+      });
+    },
+    [notifyChange]
+  );
+
+  // Add nested group
+  const addNestedGroup = useCallback(
+    (parentGroupId: string) => {
+      const newGroup = createEmptyConditionGroup();
+      newGroup.conditions = [createEmptyCondition(availableFields[0]?.id)];
+
+      setConditionGroup((prev) => {
+        if (!prev) return null;
+
+        const updated = addNestedGroupToParent(prev, parentGroupId, newGroup);
+        notifyChange(updated);
+        return updated;
+      });
+    },
+    [availableFields, notifyChange]
+  );
+
+  // Clear all conditions
+  const clearConditions = useCallback(() => {
+    setConditionGroup(null);
+    notifyChange(null);
+  }, [notifyChange]);
+
+  // Get field by ID
+  const getFieldById = useCallback(
+    (fieldId: string) => {
+      return allFields.find((f) => f.id === fieldId);
+    },
+    [allFields]
+  );
+
+  // Context value
+  const contextValue = useMemo<ConditionalLogicContextValue>(
+    () => ({
+      field,
+      availableFields,
+      conditionGroup,
+      addCondition,
+      removeCondition,
+      updateCondition,
+      setGroupOperator,
+      addNestedGroup,
+      clearConditions,
+      getFieldById,
+    }),
+    [
+      field,
+      availableFields,
+      conditionGroup,
+      addCondition,
+      removeCondition,
+      updateCondition,
+      setGroupOperator,
+      addNestedGroup,
+      clearConditions,
+      getFieldById,
+    ]
+  );
+
+  // Sync state when prop changes
+  useMemo(() => {
+    if (visibilityRules) {
+      setConditionGroup(visibilityRulesToUIGroup(visibilityRules));
+    } else {
+      setConditionGroup(null);
+    }
+  }, [visibilityRules]);
+
+  const hasConditions = conditionGroup !== null && conditionGroup.conditions.length > 0;
+
+  return (
+    <ConditionalLogicContext.Provider value={contextValue}>
+      <aside
+        data-testid="conditional-logic"
+        className={className}
+        role="complementary"
+        aria-label="Conditional visibility editor"
+      >
+        {children && (
+          <div data-testid="conditional-logic-header">{children}</div>
+        )}
+
+        {!field ? (
+          <EmptyState />
+        ) : (
+          <div data-testid="conditional-logic-content">
+            {/* Field indicator */}
+            <div data-testid="field-indicator">
+              <span data-testid="field-indicator-label">Configuring:</span>
+              <span data-testid="field-indicator-value">{field.label}</span>
+            </div>
+
+            {!hasConditions ? (
+              <NoConditionsState onAddCondition={() => addCondition()} />
+            ) : (
+              <>
+                {/* Conditions header */}
+                <div data-testid="conditions-header">
+                  <h3 data-testid="conditions-title">Show this field when:</h3>
+                  <button
+                    type="button"
+                    data-testid="clear-conditions-button"
+                    onClick={clearConditions}
+                    aria-label="Remove all conditions"
+                  >
+                    Clear All
+                  </button>
+                </div>
+
+                {/* Condition Group */}
+                {conditionGroup && (
+                  <ConditionGroupComponent
+                    group={conditionGroup}
+                    depth={0}
+                    availableFields={availableFields}
+                    onConditionChange={updateCondition}
+                    onConditionRemove={removeCondition}
+                    onOperatorChange={setGroupOperator}
+                    onAddCondition={addCondition}
+                    onAddNestedGroup={addNestedGroup}
+                    renderFieldOption={renderFieldOption}
+                    renderValueInput={renderValueInput}
+                  />
+                )}
+              </>
+            )}
+          </div>
+        )}
+      </aside>
+    </ConditionalLogicContext.Provider>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// Helper Functions for Immutable Updates
+// -----------------------------------------------------------------------------
+
+function addConditionToGroup(
+  group: UIConditionGroup,
+  condition: UICondition,
+  targetGroupId?: string
+): UIConditionGroup {
+  if (!targetGroupId || group.id === targetGroupId) {
+    return {
+      ...group,
+      conditions: [...group.conditions, condition],
+    };
+  }
+
+  return {
+    ...group,
+    conditions: group.conditions.map((c) => {
+      if (isUIConditionGroup(c)) {
+        return addConditionToGroup(c, condition, targetGroupId);
+      }
+      return c;
+    }),
+  };
+}
+
+function removeConditionFromGroup(
+  group: UIConditionGroup,
+  conditionId: string
+): UIConditionGroup {
+  return {
+    ...group,
+    conditions: group.conditions
+      .filter((c) => {
+        if (!isUIConditionGroup(c)) {
+          return c.id !== conditionId;
+        }
+        return true;
+      })
+      .map((c) => {
+        if (isUIConditionGroup(c)) {
+          const updated = removeConditionFromGroup(c, conditionId);
+          // Remove empty nested groups
+          if (updated.conditions.length === 0) {
+            return null;
+          }
+          return updated;
+        }
+        return c;
+      })
+      .filter((c): c is UICondition | UIConditionGroup => c !== null),
+  };
+}
+
+function updateConditionInGroup(
+  group: UIConditionGroup,
+  conditionId: string,
+  updates: Partial<Omit<UICondition, "id">>
+): UIConditionGroup {
+  return {
+    ...group,
+    conditions: group.conditions.map((c) => {
+      if (isUIConditionGroup(c)) {
+        return updateConditionInGroup(c, conditionId, updates);
+      }
+      if (c.id === conditionId) {
+        return { ...c, ...updates };
+      }
+      return c;
+    }),
+  };
+}
+
+function updateGroupOperator(
+  group: UIConditionGroup,
+  groupId: string,
+  operator: LogicalOperator
+): UIConditionGroup {
+  if (group.id === groupId) {
+    return { ...group, operator };
+  }
+
+  return {
+    ...group,
+    conditions: group.conditions.map((c) => {
+      if (isUIConditionGroup(c)) {
+        return updateGroupOperator(c, groupId, operator);
+      }
+      return c;
+    }),
+  };
+}
+
+function addNestedGroupToParent(
+  parent: UIConditionGroup,
+  parentGroupId: string,
+  newGroup: UIConditionGroup
+): UIConditionGroup {
+  if (parent.id === parentGroupId) {
+    return {
+      ...parent,
+      conditions: [...parent.conditions, newGroup],
+    };
+  }
+
+  return {
+    ...parent,
+    conditions: parent.conditions.map((c) => {
+      if (isUIConditionGroup(c)) {
+        return addNestedGroupToParent(c, parentGroupId, newGroup);
+      }
+      return c;
+    }),
+  };
+}
+
+// Export sub-components for flexibility
+ConditionalLogic.EmptyState = EmptyState;
+ConditionalLogic.NoConditionsState = NoConditionsState;
+ConditionalLogic.ConditionRow = ConditionRow;
+ConditionalLogic.ConditionGroupComponent = ConditionGroupComponent;
+ConditionalLogic.VisibilityIndicator = VisibilityIndicator;
+ConditionalLogic.RemoveIcon = RemoveIcon;
+ConditionalLogic.PlusIcon = PlusIcon;
+ConditionalLogic.ConditionalIcon = ConditionalIcon;

--- a/packages/ui/src/designer/index.ts
+++ b/packages/ui/src/designer/index.ts
@@ -31,6 +31,38 @@ export type {
   RuleReorderEvent,
 } from "./PropertyEditor";
 
+// Conditional Logic component and hook (PZ-103)
+export {
+  ConditionalLogic,
+  useConditionalLogic,
+  ConditionRow,
+  ConditionGroupComponent,
+  VisibilityIndicator,
+  // Utilities
+  getCompatibleOperators,
+  uiConditionToVisibility,
+  uiGroupToVisibilityRules,
+  visibilityRulesToUIGroup,
+  createEmptyCondition,
+  createEmptyConditionGroup,
+  // Constants
+  OPERATOR_LABELS,
+  VALUE_FREE_OPERATORS,
+} from "./ConditionalLogic";
+export type {
+  ConditionalLogicProps,
+  UICondition,
+  UIConditionGroup,
+  VisibilityRulesChangeEvent,
+  ConditionAddEvent,
+  ConditionRemoveEvent,
+  ConditionUpdateEvent,
+  GroupOperatorChangeEvent,
+  ConditionRowProps,
+  ConditionGroupComponentProps,
+  VisibilityIndicatorProps,
+} from "./ConditionalLogic";
+
 // Types and utilities
 export {
   // Schemas for runtime validation

--- a/packages/ui/test/designer/ConditionalLogic.test.ts
+++ b/packages/ui/test/designer/ConditionalLogic.test.ts
@@ -1,0 +1,1336 @@
+/**
+ * ConditionalLogic Tests (PZ-103)
+ *
+ * Note: These tests are limited since we use node environment.
+ * Full component testing would require jsdom environment and @testing-library/react.
+ * These tests verify types, exports, and basic functionality.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  ConditionalLogic,
+  useConditionalLogic,
+  ConditionRow,
+  ConditionGroupComponent,
+  VisibilityIndicator,
+  getCompatibleOperators,
+  uiConditionToVisibility,
+  uiGroupToVisibilityRules,
+  visibilityRulesToUIGroup,
+  createEmptyCondition,
+  createEmptyConditionGroup,
+  OPERATOR_LABELS,
+  VALUE_FREE_OPERATORS,
+  createField,
+  generateUUIDv7,
+} from "../../src/designer";
+import type {
+  ConditionalLogicProps,
+  UICondition,
+  UIConditionGroup,
+  VisibilityRulesChangeEvent,
+  ConditionAddEvent,
+  ConditionRemoveEvent,
+  ConditionUpdateEvent,
+  GroupOperatorChangeEvent,
+  ConditionRowProps,
+  ConditionGroupComponentProps,
+  VisibilityIndicatorProps,
+  CanvasField,
+} from "../../src/designer";
+import type {
+  VisibilityCondition,
+  ConditionGroup,
+  VisibilityRules,
+  ComparisonOperator,
+  LogicalOperator,
+} from "@phantom-zone/core";
+
+describe("ConditionalLogic", () => {
+  describe("exports", () => {
+    it("ConditionalLogic is exported as a function", () => {
+      expect(typeof ConditionalLogic).toBe("function");
+    });
+
+    it("useConditionalLogic is exported as a function", () => {
+      expect(typeof useConditionalLogic).toBe("function");
+    });
+
+    it("ConditionRow is exported as a function", () => {
+      expect(typeof ConditionRow).toBe("function");
+    });
+
+    it("ConditionGroupComponent is exported as a function", () => {
+      expect(typeof ConditionGroupComponent).toBe("function");
+    });
+
+    it("VisibilityIndicator is exported as a function", () => {
+      expect(typeof VisibilityIndicator).toBe("function");
+    });
+
+    it("getCompatibleOperators is exported as a function", () => {
+      expect(typeof getCompatibleOperators).toBe("function");
+    });
+
+    it("uiConditionToVisibility is exported as a function", () => {
+      expect(typeof uiConditionToVisibility).toBe("function");
+    });
+
+    it("uiGroupToVisibilityRules is exported as a function", () => {
+      expect(typeof uiGroupToVisibilityRules).toBe("function");
+    });
+
+    it("visibilityRulesToUIGroup is exported as a function", () => {
+      expect(typeof visibilityRulesToUIGroup).toBe("function");
+    });
+
+    it("createEmptyCondition is exported as a function", () => {
+      expect(typeof createEmptyCondition).toBe("function");
+    });
+
+    it("createEmptyConditionGroup is exported as a function", () => {
+      expect(typeof createEmptyConditionGroup).toBe("function");
+    });
+
+    it("OPERATOR_LABELS is exported", () => {
+      expect(OPERATOR_LABELS).toBeDefined();
+      expect(typeof OPERATOR_LABELS).toBe("object");
+    });
+
+    it("VALUE_FREE_OPERATORS is exported", () => {
+      expect(VALUE_FREE_OPERATORS).toBeDefined();
+      expect(Array.isArray(VALUE_FREE_OPERATORS)).toBe(true);
+    });
+  });
+
+  describe("ConditionalLogic component", () => {
+    it("is a valid React component function", () => {
+      expect(ConditionalLogic.length).toBeGreaterThanOrEqual(0);
+    });
+
+    it("has sub-components attached", () => {
+      expect(ConditionalLogic.EmptyState).toBeDefined();
+      expect(ConditionalLogic.NoConditionsState).toBeDefined();
+      expect(ConditionalLogic.ConditionRow).toBeDefined();
+      expect(ConditionalLogic.ConditionGroupComponent).toBeDefined();
+      expect(ConditionalLogic.VisibilityIndicator).toBeDefined();
+      expect(ConditionalLogic.RemoveIcon).toBeDefined();
+      expect(ConditionalLogic.PlusIcon).toBeDefined();
+      expect(ConditionalLogic.ConditionalIcon).toBeDefined();
+    });
+  });
+
+  describe("useConditionalLogic hook", () => {
+    it("is exported as a function", () => {
+      // Note: We cannot test the actual hook behavior in node environment
+      // since React hooks require a React component context.
+      expect(typeof useConditionalLogic).toBe("function");
+    });
+  });
+});
+
+describe("OPERATOR_LABELS", () => {
+  it("has labels for all comparison operators", () => {
+    const operators: ComparisonOperator[] = [
+      "equals",
+      "notEquals",
+      "contains",
+      "notContains",
+      "greaterThan",
+      "lessThan",
+      "greaterThanOrEquals",
+      "lessThanOrEquals",
+      "isEmpty",
+      "isNotEmpty",
+      "matches",
+    ];
+
+    for (const op of operators) {
+      expect(OPERATOR_LABELS[op]).toBeDefined();
+      expect(typeof OPERATOR_LABELS[op]).toBe("string");
+      expect(OPERATOR_LABELS[op].length).toBeGreaterThan(0);
+    }
+  });
+
+  it("has human-readable labels", () => {
+    expect(OPERATOR_LABELS.equals).toBe("equals");
+    expect(OPERATOR_LABELS.notEquals).toBe("does not equal");
+    expect(OPERATOR_LABELS.contains).toBe("contains");
+    expect(OPERATOR_LABELS.isEmpty).toBe("is empty");
+    expect(OPERATOR_LABELS.isNotEmpty).toBe("is not empty");
+    expect(OPERATOR_LABELS.greaterThan).toBe("is greater than");
+    expect(OPERATOR_LABELS.lessThan).toBe("is less than");
+    expect(OPERATOR_LABELS.matches).toBe("matches pattern");
+  });
+});
+
+describe("VALUE_FREE_OPERATORS", () => {
+  it("contains isEmpty and isNotEmpty", () => {
+    expect(VALUE_FREE_OPERATORS).toContain("isEmpty");
+    expect(VALUE_FREE_OPERATORS).toContain("isNotEmpty");
+  });
+
+  it("does not contain operators that require values", () => {
+    expect(VALUE_FREE_OPERATORS).not.toContain("equals");
+    expect(VALUE_FREE_OPERATORS).not.toContain("notEquals");
+    expect(VALUE_FREE_OPERATORS).not.toContain("contains");
+    expect(VALUE_FREE_OPERATORS).not.toContain("greaterThan");
+  });
+});
+
+describe("getCompatibleOperators", () => {
+  it("returns operators for text fields", () => {
+    const operators = getCompatibleOperators("text");
+
+    expect(operators).toContain("equals");
+    expect(operators).toContain("notEquals");
+    expect(operators).toContain("contains");
+    expect(operators).toContain("notContains");
+    expect(operators).toContain("isEmpty");
+    expect(operators).toContain("isNotEmpty");
+    expect(operators).toContain("matches");
+
+    // Should not include numeric operators
+    expect(operators).not.toContain("greaterThan");
+    expect(operators).not.toContain("lessThan");
+  });
+
+  it("returns operators for textarea fields", () => {
+    const operators = getCompatibleOperators("textarea");
+
+    expect(operators).toContain("equals");
+    expect(operators).toContain("contains");
+    expect(operators).toContain("matches");
+  });
+
+  it("returns operators for number fields", () => {
+    const operators = getCompatibleOperators("number");
+
+    expect(operators).toContain("equals");
+    expect(operators).toContain("notEquals");
+    expect(operators).toContain("greaterThan");
+    expect(operators).toContain("lessThan");
+    expect(operators).toContain("greaterThanOrEquals");
+    expect(operators).toContain("lessThanOrEquals");
+    expect(operators).toContain("isEmpty");
+    expect(operators).toContain("isNotEmpty");
+
+    // Should not include string operators
+    expect(operators).not.toContain("contains");
+    expect(operators).not.toContain("matches");
+  });
+
+  it("returns operators for checkbox fields", () => {
+    const operators = getCompatibleOperators("checkbox");
+
+    expect(operators).toContain("equals");
+    expect(operators).toContain("notEquals");
+
+    // Checkbox only needs equals/notEquals for true/false
+    expect(operators).toHaveLength(2);
+  });
+
+  it("returns operators for select fields", () => {
+    const operators = getCompatibleOperators("select");
+
+    expect(operators).toContain("equals");
+    expect(operators).toContain("notEquals");
+    expect(operators).toContain("contains");
+    expect(operators).toContain("notContains");
+    expect(operators).toContain("isEmpty");
+    expect(operators).toContain("isNotEmpty");
+  });
+
+  it("returns operators for multiselect fields", () => {
+    const operators = getCompatibleOperators("multiselect");
+
+    expect(operators).toContain("contains");
+    expect(operators).toContain("notContains");
+    expect(operators).toContain("isEmpty");
+    expect(operators).toContain("isNotEmpty");
+  });
+
+  it("returns operators for date fields", () => {
+    const operators = getCompatibleOperators("date");
+
+    expect(operators).toContain("equals");
+    expect(operators).toContain("notEquals");
+    expect(operators).toContain("greaterThan");
+    expect(operators).toContain("lessThan");
+    expect(operators).toContain("greaterThanOrEquals");
+    expect(operators).toContain("lessThanOrEquals");
+    expect(operators).toContain("isEmpty");
+    expect(operators).toContain("isNotEmpty");
+  });
+
+  it("returns default operators for unknown field types", () => {
+    const operators = getCompatibleOperators("custom-type");
+
+    // Should default to text-like operators
+    expect(operators).toContain("equals");
+    expect(operators).toContain("contains");
+    expect(operators).toContain("isEmpty");
+  });
+});
+
+describe("createEmptyCondition", () => {
+  it("creates a condition with unique ID", () => {
+    const condition1 = createEmptyCondition();
+    const condition2 = createEmptyCondition();
+
+    expect(condition1.id).toBeTruthy();
+    expect(condition2.id).toBeTruthy();
+    expect(condition1.id).not.toBe(condition2.id);
+  });
+
+  it("creates a condition with default values", () => {
+    const condition = createEmptyCondition();
+
+    expect(condition.fieldId).toBe("");
+    expect(condition.operator).toBe("equals");
+    expect(condition.value).toBeNull();
+  });
+
+  it("accepts optional default field ID", () => {
+    const condition = createEmptyCondition("field-123");
+
+    expect(condition.fieldId).toBe("field-123");
+    expect(condition.operator).toBe("equals");
+  });
+});
+
+describe("createEmptyConditionGroup", () => {
+  it("creates a group with unique ID", () => {
+    const group1 = createEmptyConditionGroup();
+    const group2 = createEmptyConditionGroup();
+
+    expect(group1.id).toBeTruthy();
+    expect(group2.id).toBeTruthy();
+    expect(group1.id).not.toBe(group2.id);
+  });
+
+  it("creates a group with AND operator by default", () => {
+    const group = createEmptyConditionGroup();
+
+    expect(group.operator).toBe("and");
+  });
+
+  it("creates a group with empty conditions array", () => {
+    const group = createEmptyConditionGroup();
+
+    expect(group.conditions).toEqual([]);
+  });
+});
+
+describe("uiConditionToVisibility", () => {
+  it("converts a basic UI condition to VisibilityCondition", () => {
+    const uiCondition: UICondition = {
+      id: "ui-123",
+      fieldId: "field-456",
+      operator: "equals",
+      value: "test",
+    };
+
+    const result = uiConditionToVisibility(uiCondition);
+
+    expect(result.fieldId).toBe("field-456");
+    expect(result.operator).toBe("equals");
+    expect(result.value).toBe("test");
+  });
+
+  it("excludes value for isEmpty operator", () => {
+    const uiCondition: UICondition = {
+      id: "ui-123",
+      fieldId: "field-456",
+      operator: "isEmpty",
+      value: "ignored",
+    };
+
+    const result = uiConditionToVisibility(uiCondition);
+
+    expect(result.fieldId).toBe("field-456");
+    expect(result.operator).toBe("isEmpty");
+    expect(result.value).toBeUndefined();
+  });
+
+  it("excludes value for isNotEmpty operator", () => {
+    const uiCondition: UICondition = {
+      id: "ui-123",
+      fieldId: "field-456",
+      operator: "isNotEmpty",
+      value: "ignored",
+    };
+
+    const result = uiConditionToVisibility(uiCondition);
+
+    expect(result.value).toBeUndefined();
+  });
+
+  it("handles number values", () => {
+    const uiCondition: UICondition = {
+      id: "ui-123",
+      fieldId: "field-456",
+      operator: "greaterThan",
+      value: 42,
+    };
+
+    const result = uiConditionToVisibility(uiCondition);
+
+    expect(result.value).toBe(42);
+  });
+
+  it("handles boolean values", () => {
+    const uiCondition: UICondition = {
+      id: "ui-123",
+      fieldId: "field-456",
+      operator: "equals",
+      value: true,
+    };
+
+    const result = uiConditionToVisibility(uiCondition);
+
+    expect(result.value).toBe(true);
+  });
+
+  it("handles null values", () => {
+    const uiCondition: UICondition = {
+      id: "ui-123",
+      fieldId: "field-456",
+      operator: "equals",
+      value: null,
+    };
+
+    const result = uiConditionToVisibility(uiCondition);
+
+    expect(result.value).toBeNull();
+  });
+});
+
+describe("uiGroupToVisibilityRules", () => {
+  it("converts single condition to VisibilityCondition", () => {
+    const uiGroup: UIConditionGroup = {
+      id: "group-1",
+      operator: "and",
+      conditions: [
+        {
+          id: "cond-1",
+          fieldId: "experience",
+          operator: "equals",
+          value: "Hardcore",
+        },
+      ],
+    };
+
+    const result = uiGroupToVisibilityRules(uiGroup);
+
+    // Single condition should be returned as VisibilityCondition, not ConditionGroup
+    expect("conditions" in result).toBe(false);
+    expect((result as VisibilityCondition).fieldId).toBe("experience");
+    expect((result as VisibilityCondition).operator).toBe("equals");
+    expect((result as VisibilityCondition).value).toBe("Hardcore");
+  });
+
+  it("converts multiple conditions to ConditionGroup", () => {
+    const uiGroup: UIConditionGroup = {
+      id: "group-1",
+      operator: "and",
+      conditions: [
+        {
+          id: "cond-1",
+          fieldId: "experience",
+          operator: "equals",
+          value: "Hardcore",
+        },
+        {
+          id: "cond-2",
+          fieldId: "level",
+          operator: "greaterThan",
+          value: 60,
+        },
+      ],
+    };
+
+    const result = uiGroupToVisibilityRules(uiGroup) as ConditionGroup;
+
+    expect("conditions" in result).toBe(true);
+    expect(result.operator).toBe("and");
+    expect(result.conditions).toHaveLength(2);
+    expect((result.conditions[0] as VisibilityCondition).fieldId).toBe("experience");
+    expect((result.conditions[1] as VisibilityCondition).fieldId).toBe("level");
+  });
+
+  it("converts OR group correctly", () => {
+    const uiGroup: UIConditionGroup = {
+      id: "group-1",
+      operator: "or",
+      conditions: [
+        {
+          id: "cond-1",
+          fieldId: "role",
+          operator: "equals",
+          value: "admin",
+        },
+        {
+          id: "cond-2",
+          fieldId: "role",
+          operator: "equals",
+          value: "moderator",
+        },
+      ],
+    };
+
+    const result = uiGroupToVisibilityRules(uiGroup) as ConditionGroup;
+
+    expect(result.operator).toBe("or");
+    expect(result.conditions).toHaveLength(2);
+  });
+
+  it("handles nested groups", () => {
+    const uiGroup: UIConditionGroup = {
+      id: "group-1",
+      operator: "and",
+      conditions: [
+        {
+          id: "cond-1",
+          fieldId: "experience",
+          operator: "equals",
+          value: "Hardcore",
+        },
+        {
+          id: "nested-group",
+          operator: "or",
+          conditions: [
+            {
+              id: "cond-2",
+              fieldId: "class",
+              operator: "equals",
+              value: "Warrior",
+            },
+            {
+              id: "cond-3",
+              fieldId: "class",
+              operator: "equals",
+              value: "Paladin",
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = uiGroupToVisibilityRules(uiGroup) as ConditionGroup;
+
+    expect(result.operator).toBe("and");
+    expect(result.conditions).toHaveLength(2);
+
+    const nestedGroup = result.conditions[1] as ConditionGroup;
+    expect("conditions" in nestedGroup).toBe(true);
+    expect(nestedGroup.operator).toBe("or");
+    expect(nestedGroup.conditions).toHaveLength(2);
+  });
+});
+
+describe("visibilityRulesToUIGroup", () => {
+  it("converts single VisibilityCondition to UIConditionGroup", () => {
+    const visibility: VisibilityCondition = {
+      fieldId: "experience",
+      operator: "equals",
+      value: "Hardcore",
+    };
+
+    const result = visibilityRulesToUIGroup(visibility);
+
+    expect(result.id).toBeTruthy();
+    expect(result.operator).toBe("and"); // Default operator for single condition
+    expect(result.conditions).toHaveLength(1);
+
+    const condition = result.conditions[0] as UICondition;
+    expect(condition.id).toBeTruthy();
+    expect(condition.fieldId).toBe("experience");
+    expect(condition.operator).toBe("equals");
+    expect(condition.value).toBe("Hardcore");
+  });
+
+  it("converts ConditionGroup to UIConditionGroup", () => {
+    const visibility: ConditionGroup = {
+      operator: "or",
+      conditions: [
+        { fieldId: "role", operator: "equals", value: "admin" },
+        { fieldId: "role", operator: "equals", value: "moderator" },
+      ],
+    };
+
+    const result = visibilityRulesToUIGroup(visibility);
+
+    expect(result.operator).toBe("or");
+    expect(result.conditions).toHaveLength(2);
+
+    const cond1 = result.conditions[0] as UICondition;
+    const cond2 = result.conditions[1] as UICondition;
+
+    expect(cond1.fieldId).toBe("role");
+    expect(cond1.value).toBe("admin");
+    expect(cond2.fieldId).toBe("role");
+    expect(cond2.value).toBe("moderator");
+  });
+
+  it("generates unique IDs for all items", () => {
+    const visibility: ConditionGroup = {
+      operator: "and",
+      conditions: [
+        { fieldId: "a", operator: "equals", value: "1" },
+        { fieldId: "b", operator: "equals", value: "2" },
+        { fieldId: "c", operator: "equals", value: "3" },
+      ],
+    };
+
+    const result = visibilityRulesToUIGroup(visibility);
+
+    const ids = new Set<string>();
+    ids.add(result.id);
+    for (const cond of result.conditions) {
+      ids.add((cond as UICondition).id);
+    }
+
+    // All IDs should be unique
+    expect(ids.size).toBe(4); // 1 group + 3 conditions
+  });
+
+  it("handles nested ConditionGroups", () => {
+    const visibility: ConditionGroup = {
+      operator: "and",
+      conditions: [
+        { fieldId: "experience", operator: "equals", value: "Hardcore" },
+        {
+          operator: "or",
+          conditions: [
+            { fieldId: "class", operator: "equals", value: "Warrior" },
+            { fieldId: "class", operator: "equals", value: "Paladin" },
+          ],
+        },
+      ],
+    };
+
+    const result = visibilityRulesToUIGroup(visibility);
+
+    expect(result.operator).toBe("and");
+    expect(result.conditions).toHaveLength(2);
+
+    const nestedGroup = result.conditions[1] as UIConditionGroup;
+    expect("conditions" in nestedGroup).toBe(true);
+    expect(nestedGroup.operator).toBe("or");
+    expect(nestedGroup.conditions).toHaveLength(2);
+  });
+
+  it("handles null/undefined values", () => {
+    const visibility: VisibilityCondition = {
+      fieldId: "field",
+      operator: "isEmpty",
+      // value is undefined
+    };
+
+    const result = visibilityRulesToUIGroup(visibility);
+    const condition = result.conditions[0] as UICondition;
+
+    expect(condition.value).toBeNull(); // Should be converted to null
+  });
+});
+
+describe("Round-trip conversion", () => {
+  it("preserves single condition through round-trip", () => {
+    const original: UIConditionGroup = {
+      id: generateUUIDv7(),
+      operator: "and",
+      conditions: [
+        {
+          id: generateUUIDv7(),
+          fieldId: "experience",
+          operator: "equals",
+          value: "Hardcore",
+        },
+      ],
+    };
+
+    const visibility = uiGroupToVisibilityRules(original);
+    const result = visibilityRulesToUIGroup(visibility);
+
+    // IDs will be different, but structure should match
+    expect(result.conditions).toHaveLength(1);
+    const condition = result.conditions[0] as UICondition;
+    expect(condition.fieldId).toBe("experience");
+    expect(condition.operator).toBe("equals");
+    expect(condition.value).toBe("Hardcore");
+  });
+
+  it("preserves multiple conditions through round-trip", () => {
+    const original: UIConditionGroup = {
+      id: generateUUIDv7(),
+      operator: "or",
+      conditions: [
+        {
+          id: generateUUIDv7(),
+          fieldId: "role",
+          operator: "equals",
+          value: "admin",
+        },
+        {
+          id: generateUUIDv7(),
+          fieldId: "level",
+          operator: "greaterThan",
+          value: 50,
+        },
+      ],
+    };
+
+    const visibility = uiGroupToVisibilityRules(original);
+    const result = visibilityRulesToUIGroup(visibility as VisibilityRules);
+
+    expect(result.operator).toBe("or");
+    expect(result.conditions).toHaveLength(2);
+
+    const cond1 = result.conditions[0] as UICondition;
+    const cond2 = result.conditions[1] as UICondition;
+
+    expect(cond1.value).toBe("admin");
+    expect(cond2.value).toBe(50);
+  });
+
+  it("preserves nested groups through round-trip", () => {
+    const original: UIConditionGroup = {
+      id: generateUUIDv7(),
+      operator: "and",
+      conditions: [
+        {
+          id: generateUUIDv7(),
+          fieldId: "experience",
+          operator: "equals",
+          value: "Hardcore",
+        },
+        {
+          id: generateUUIDv7(),
+          operator: "or",
+          conditions: [
+            {
+              id: generateUUIDv7(),
+              fieldId: "class",
+              operator: "equals",
+              value: "Warrior",
+            },
+            {
+              id: generateUUIDv7(),
+              fieldId: "class",
+              operator: "equals",
+              value: "Paladin",
+            },
+          ],
+        },
+      ],
+    };
+
+    const visibility = uiGroupToVisibilityRules(original);
+    const result = visibilityRulesToUIGroup(visibility as VisibilityRules);
+
+    expect(result.operator).toBe("and");
+    expect(result.conditions).toHaveLength(2);
+
+    const nested = result.conditions[1] as UIConditionGroup;
+    expect("conditions" in nested).toBe(true);
+    expect(nested.operator).toBe("or");
+    expect(nested.conditions).toHaveLength(2);
+  });
+});
+
+describe("ConditionalLogicProps Type Tests", () => {
+  it("ConditionalLogicProps interface is correct", () => {
+    const field = createField("text", "Test Field");
+    const allFields = [field, createField("select", "Experience Level")];
+
+    const props: ConditionalLogicProps = {
+      field,
+      allFields,
+      visibilityRules: null,
+      onRulesChange: (event: VisibilityRulesChangeEvent) => {
+        void event;
+      },
+      renderFieldOption: (f: CanvasField) => f.label,
+      renderValueInput: (condition, triggerField, onChange) => {
+        void condition;
+        void triggerField;
+        void onChange;
+        return null;
+      },
+      className: "test-class",
+      children: null,
+    };
+
+    expect(props.field).toBeDefined();
+    expect(props.allFields).toHaveLength(2);
+    expect(typeof props.onRulesChange).toBe("function");
+    expect(typeof props.renderFieldOption).toBe("function");
+    expect(typeof props.renderValueInput).toBe("function");
+    expect(props.className).toBe("test-class");
+  });
+
+  it("ConditionalLogicProps supports null field", () => {
+    const props: ConditionalLogicProps = {
+      field: null,
+      allFields: [],
+    };
+
+    expect(props.field).toBeNull();
+  });
+
+  it("ConditionalLogicProps supports visibility rules", () => {
+    const field = createField("number", "Mythic+ Score");
+    const visibilityRules: VisibilityCondition = {
+      fieldId: "experience",
+      operator: "equals",
+      value: "Hardcore",
+    };
+
+    const props: ConditionalLogicProps = {
+      field,
+      allFields: [field],
+      visibilityRules,
+    };
+
+    expect(props.visibilityRules).toBeDefined();
+    expect((props.visibilityRules as VisibilityCondition).fieldId).toBe("experience");
+  });
+});
+
+describe("UICondition Type Tests", () => {
+  it("UICondition has correct structure", () => {
+    const condition: UICondition = {
+      id: generateUUIDv7(),
+      fieldId: "field-123",
+      operator: "equals",
+      value: "test",
+    };
+
+    expect(condition.id).toBeTruthy();
+    expect(condition.fieldId).toBe("field-123");
+    expect(condition.operator).toBe("equals");
+    expect(condition.value).toBe("test");
+  });
+
+  it("UICondition supports all value types", () => {
+    const stringCondition: UICondition = {
+      id: generateUUIDv7(),
+      fieldId: "f1",
+      operator: "equals",
+      value: "string",
+    };
+
+    const numberCondition: UICondition = {
+      id: generateUUIDv7(),
+      fieldId: "f2",
+      operator: "greaterThan",
+      value: 42,
+    };
+
+    const booleanCondition: UICondition = {
+      id: generateUUIDv7(),
+      fieldId: "f3",
+      operator: "equals",
+      value: true,
+    };
+
+    const nullCondition: UICondition = {
+      id: generateUUIDv7(),
+      fieldId: "f4",
+      operator: "isEmpty",
+      value: null,
+    };
+
+    expect(stringCondition.value).toBe("string");
+    expect(numberCondition.value).toBe(42);
+    expect(booleanCondition.value).toBe(true);
+    expect(nullCondition.value).toBeNull();
+  });
+});
+
+describe("UIConditionGroup Type Tests", () => {
+  it("UIConditionGroup has correct structure", () => {
+    const group: UIConditionGroup = {
+      id: generateUUIDv7(),
+      operator: "and",
+      conditions: [],
+    };
+
+    expect(group.id).toBeTruthy();
+    expect(group.operator).toBe("and");
+    expect(group.conditions).toEqual([]);
+  });
+
+  it("UIConditionGroup supports OR operator", () => {
+    const group: UIConditionGroup = {
+      id: generateUUIDv7(),
+      operator: "or",
+      conditions: [],
+    };
+
+    expect(group.operator).toBe("or");
+  });
+
+  it("UIConditionGroup supports nested conditions", () => {
+    const nestedGroup: UIConditionGroup = {
+      id: generateUUIDv7(),
+      operator: "or",
+      conditions: [
+        {
+          id: generateUUIDv7(),
+          fieldId: "class",
+          operator: "equals",
+          value: "Warrior",
+        },
+      ],
+    };
+
+    const group: UIConditionGroup = {
+      id: generateUUIDv7(),
+      operator: "and",
+      conditions: [
+        {
+          id: generateUUIDv7(),
+          fieldId: "experience",
+          operator: "equals",
+          value: "Hardcore",
+        },
+        nestedGroup,
+      ],
+    };
+
+    expect(group.conditions).toHaveLength(2);
+    expect("conditions" in group.conditions[1]!).toBe(true);
+  });
+});
+
+describe("Event Type Tests", () => {
+  it("VisibilityRulesChangeEvent has correct structure", () => {
+    const event: VisibilityRulesChangeEvent = {
+      fieldId: "field-123",
+      rules: {
+        fieldId: "trigger",
+        operator: "equals",
+        value: "test",
+      },
+    };
+
+    expect(event.fieldId).toBe("field-123");
+    expect(event.rules).toBeDefined();
+  });
+
+  it("VisibilityRulesChangeEvent supports null rules", () => {
+    const event: VisibilityRulesChangeEvent = {
+      fieldId: "field-123",
+      rules: null,
+    };
+
+    expect(event.rules).toBeNull();
+  });
+
+  it("ConditionAddEvent has correct structure", () => {
+    const event: ConditionAddEvent = {
+      fieldId: "field-123",
+      condition: {
+        id: generateUUIDv7(),
+        fieldId: "trigger",
+        operator: "equals",
+        value: "test",
+      },
+      parentGroupId: "group-456",
+    };
+
+    expect(event.fieldId).toBe("field-123");
+    expect(event.condition.fieldId).toBe("trigger");
+    expect(event.parentGroupId).toBe("group-456");
+  });
+
+  it("ConditionRemoveEvent has correct structure", () => {
+    const event: ConditionRemoveEvent = {
+      fieldId: "field-123",
+      conditionId: "cond-456",
+    };
+
+    expect(event.fieldId).toBe("field-123");
+    expect(event.conditionId).toBe("cond-456");
+  });
+
+  it("ConditionUpdateEvent has correct structure", () => {
+    const event: ConditionUpdateEvent = {
+      fieldId: "field-123",
+      conditionId: "cond-456",
+      updates: {
+        operator: "notEquals",
+        value: "new-value",
+      },
+    };
+
+    expect(event.fieldId).toBe("field-123");
+    expect(event.conditionId).toBe("cond-456");
+    expect(event.updates.operator).toBe("notEquals");
+    expect(event.updates.value).toBe("new-value");
+  });
+
+  it("GroupOperatorChangeEvent has correct structure", () => {
+    const event: GroupOperatorChangeEvent = {
+      fieldId: "field-123",
+      groupId: "group-456",
+      operator: "or",
+    };
+
+    expect(event.fieldId).toBe("field-123");
+    expect(event.groupId).toBe("group-456");
+    expect(event.operator).toBe("or");
+  });
+});
+
+describe("ConditionRowProps Type Tests", () => {
+  it("ConditionRowProps has correct structure", () => {
+    const condition: UICondition = {
+      id: generateUUIDv7(),
+      fieldId: "trigger",
+      operator: "equals",
+      value: "test",
+    };
+
+    const props: ConditionRowProps = {
+      condition,
+      index: 0,
+      groupOperator: "and",
+      showOperatorLabel: false,
+      availableFields: [],
+      onChange: (conditionId, updates) => {
+        void conditionId;
+        void updates;
+      },
+      onRemove: (conditionId) => {
+        void conditionId;
+      },
+    };
+
+    expect(props.condition).toBeDefined();
+    expect(props.index).toBe(0);
+    expect(props.groupOperator).toBe("and");
+    expect(typeof props.onChange).toBe("function");
+    expect(typeof props.onRemove).toBe("function");
+  });
+});
+
+describe("ConditionGroupComponentProps Type Tests", () => {
+  it("ConditionGroupComponentProps has correct structure", () => {
+    const group: UIConditionGroup = {
+      id: generateUUIDv7(),
+      operator: "and",
+      conditions: [],
+    };
+
+    const props: ConditionGroupComponentProps = {
+      group,
+      depth: 0,
+      availableFields: [],
+      onConditionChange: (conditionId, updates) => {
+        void conditionId;
+        void updates;
+      },
+      onConditionRemove: (conditionId) => {
+        void conditionId;
+      },
+      onOperatorChange: (groupId, operator) => {
+        void groupId;
+        void operator;
+      },
+      onAddCondition: (parentGroupId) => {
+        void parentGroupId;
+      },
+      onAddNestedGroup: (parentGroupId) => {
+        void parentGroupId;
+      },
+    };
+
+    expect(props.group).toBeDefined();
+    expect(props.depth).toBe(0);
+    expect(typeof props.onConditionChange).toBe("function");
+    expect(typeof props.onConditionRemove).toBe("function");
+    expect(typeof props.onOperatorChange).toBe("function");
+    expect(typeof props.onAddCondition).toBe("function");
+    expect(typeof props.onAddNestedGroup).toBe("function");
+  });
+});
+
+describe("VisibilityIndicatorProps Type Tests", () => {
+  it("VisibilityIndicatorProps has correct structure", () => {
+    const props: VisibilityIndicatorProps = {
+      hasConditions: true,
+      conditionCount: 3,
+      onClick: () => {},
+      className: "indicator-class",
+    };
+
+    expect(props.hasConditions).toBe(true);
+    expect(props.conditionCount).toBe(3);
+    expect(typeof props.onClick).toBe("function");
+    expect(props.className).toBe("indicator-class");
+  });
+
+  it("VisibilityIndicatorProps supports no conditions", () => {
+    const props: VisibilityIndicatorProps = {
+      hasConditions: false,
+      conditionCount: 0,
+    };
+
+    expect(props.hasConditions).toBe(false);
+    expect(props.conditionCount).toBe(0);
+  });
+});
+
+describe("Integration with CanvasField", () => {
+  it("works with a basic field", () => {
+    const field = createField("text", "Name");
+
+    expect(field.id).toBeTruthy();
+    expect(field.inputType).toBe("text");
+    expect(field.label).toBe("Name");
+  });
+
+  it("works with a select field with options", () => {
+    const field = createField("select", "Experience Level", {
+      options: [
+        { value: "casual", label: "Casual" },
+        { value: "normal", label: "Normal" },
+        { value: "hardcore", label: "Hardcore" },
+      ],
+    });
+
+    expect(field.inputType).toBe("select");
+    expect(field.options).toHaveLength(3);
+    expect(field.options?.[2]?.value).toBe("hardcore");
+  });
+
+  it("can create conditional visibility scenario", () => {
+    // Example: Show "Mythic+ Score" when "Experience Level" = "Hardcore"
+    const experienceField = createField("select", "Experience Level", {
+      options: [
+        { value: "casual", label: "Casual" },
+        { value: "normal", label: "Normal" },
+        { value: "hardcore", label: "Hardcore" },
+      ],
+    });
+
+    const mythicScoreField = createField("number", "Mythic+ Score");
+
+    // Create visibility condition
+    const visibilityRules: VisibilityCondition = {
+      fieldId: experienceField.id,
+      operator: "equals",
+      value: "hardcore",
+    };
+
+    // Convert to UI representation
+    const uiGroup = visibilityRulesToUIGroup(visibilityRules);
+
+    expect(uiGroup.conditions).toHaveLength(1);
+    const condition = uiGroup.conditions[0] as UICondition;
+    expect(condition.fieldId).toBe(experienceField.id);
+    expect(condition.operator).toBe("equals");
+    expect(condition.value).toBe("hardcore");
+
+    // Convert back to visibility rules
+    const converted = uiGroupToVisibilityRules(uiGroup);
+
+    expect((converted as VisibilityCondition).fieldId).toBe(experienceField.id);
+    expect((converted as VisibilityCondition).value).toBe("hardcore");
+  });
+
+  it("can create complex conditional visibility scenario", () => {
+    // Example: Show "Raid Schedule" when:
+    // - Experience Level = "Hardcore" AND
+    // - (Guild Role = "Raid Leader" OR Guild Role = "Officer")
+
+    const experienceField = createField("select", "Experience Level");
+    const guildRoleField = createField("select", "Guild Role");
+
+    // Create UI condition group
+    const uiGroup: UIConditionGroup = {
+      id: generateUUIDv7(),
+      operator: "and",
+      conditions: [
+        {
+          id: generateUUIDv7(),
+          fieldId: experienceField.id,
+          operator: "equals",
+          value: "Hardcore",
+        },
+        {
+          id: generateUUIDv7(),
+          operator: "or",
+          conditions: [
+            {
+              id: generateUUIDv7(),
+              fieldId: guildRoleField.id,
+              operator: "equals",
+              value: "Raid Leader",
+            },
+            {
+              id: generateUUIDv7(),
+              fieldId: guildRoleField.id,
+              operator: "equals",
+              value: "Officer",
+            },
+          ],
+        },
+      ],
+    };
+
+    // Convert to visibility rules
+    const visibilityRules = uiGroupToVisibilityRules(uiGroup);
+
+    // Verify structure
+    const group = visibilityRules as ConditionGroup;
+    expect(group.operator).toBe("and");
+    expect(group.conditions).toHaveLength(2);
+
+    const nestedGroup = group.conditions[1] as ConditionGroup;
+    expect(nestedGroup.operator).toBe("or");
+    expect(nestedGroup.conditions).toHaveLength(2);
+  });
+});
+
+describe("Edge Cases", () => {
+  it("handles empty field ID", () => {
+    const condition = createEmptyCondition("");
+    expect(condition.fieldId).toBe("");
+  });
+
+  it("handles condition with all operator types", () => {
+    const operators: ComparisonOperator[] = [
+      "equals",
+      "notEquals",
+      "contains",
+      "notContains",
+      "greaterThan",
+      "lessThan",
+      "greaterThanOrEquals",
+      "lessThanOrEquals",
+      "isEmpty",
+      "isNotEmpty",
+      "matches",
+    ];
+
+    for (const op of operators) {
+      const condition: UICondition = {
+        id: generateUUIDv7(),
+        fieldId: "field",
+        operator: op,
+        value: "test",
+      };
+
+      const visibility = uiConditionToVisibility(condition);
+      expect(visibility.operator).toBe(op);
+    }
+  });
+
+  it("handles deeply nested groups", () => {
+    // Create a 3-level deep structure with multiple conditions to avoid flattening
+    const uiGroup: UIConditionGroup = {
+      id: generateUUIDv7(),
+      operator: "and",
+      conditions: [
+        {
+          id: generateUUIDv7(),
+          fieldId: "top-level",
+          operator: "equals",
+          value: "top",
+        },
+        {
+          id: generateUUIDv7(),
+          operator: "or",
+          conditions: [
+            {
+              id: generateUUIDv7(),
+              fieldId: "mid-level",
+              operator: "equals",
+              value: "mid",
+            },
+            {
+              id: generateUUIDv7(),
+              operator: "and",
+              conditions: [
+                {
+                  id: generateUUIDv7(),
+                  fieldId: "deep",
+                  operator: "equals",
+                  value: "value",
+                },
+                {
+                  id: generateUUIDv7(),
+                  fieldId: "deep2",
+                  operator: "notEquals",
+                  value: "other",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const visibility = uiGroupToVisibilityRules(uiGroup);
+    const result = visibilityRulesToUIGroup(visibility);
+
+    // Verify structure
+    expect(result.operator).toBe("and");
+    expect(result.conditions).toHaveLength(2);
+
+    // Navigate to the deepest condition
+    const topCondition = result.conditions[0] as UICondition;
+    expect(topCondition.fieldId).toBe("top-level");
+
+    const level1 = result.conditions[1] as UIConditionGroup;
+    expect(level1.operator).toBe("or");
+    expect(level1.conditions).toHaveLength(2);
+
+    const level2 = level1.conditions[1] as UIConditionGroup;
+    expect(level2.operator).toBe("and");
+    expect(level2.conditions).toHaveLength(2);
+
+    const deepCondition = level2.conditions[0] as UICondition;
+    expect(deepCondition.fieldId).toBe("deep");
+    expect(deepCondition.value).toBe("value");
+  });
+
+  it("generates unique IDs for many conditions", () => {
+    const ids = new Set<string>();
+
+    for (let i = 0; i < 100; i++) {
+      const condition = createEmptyCondition();
+      ids.add(condition.id);
+    }
+
+    expect(ids.size).toBe(100);
+  });
+
+  it("handles special characters in values", () => {
+    const condition: UICondition = {
+      id: generateUUIDv7(),
+      fieldId: "field",
+      operator: "equals",
+      value: "test <script>alert('xss')</script>",
+    };
+
+    const visibility = uiConditionToVisibility(condition);
+    expect(visibility.value).toBe("test <script>alert('xss')</script>");
+  });
+
+  it("handles unicode characters in values", () => {
+    const condition: UICondition = {
+      id: generateUUIDv7(),
+      fieldId: "field",
+      operator: "contains",
+      value: "Hier sollten wir Umlaute haben",
+    };
+
+    const visibility = uiConditionToVisibility(condition);
+    expect(visibility.value).toBe("Hier sollten wir Umlaute haben");
+  });
+});


### PR DESCRIPTION
## Summary
Implements PZ-103 (#71): UI for conditional field visibility rules.

- Show this field when... dropdown interface
- Trigger field and condition selectors
- Multiple conditions with AND/OR logic
- Visual indicator on conditional fields

Closes #71

:robot: Generated with [Claude Code](https://claude.com/claude-code)