### PR TITLE
feat(edit): implement Undo/Redo History (PZ-210)

### DIFF
--- a/packages/edit/src/history/actions.ts
+++ b/packages/edit/src/history/actions.ts
@@ -1,0 +1,393 @@
+/**
+ * History Actions
+ *
+ * Actions for manipulating undo/redo history.
+ * Implements PZ-210: Undo/Redo History
+ *
+ * The history model works as follows:
+ * - baseSnapshot: stores the document state before any history entries
+ * - entries[i].snapshot: stores the document state AFTER change i was made
+ * - currentIndex: points to the last applied change (-1 means at base state)
+ *
+ * When undoing: restore the previous entry's snapshot (or base if at index 0)
+ * When redoing: restore the next entry's snapshot
+ */
+
+import { createSnapshot, restoreSnapshot } from "../model/document";
+import type { DocumentSnapshot } from "../model/types";
+import { $history, resetHistoryState } from "./state";
+import {
+  canRedo,
+  canUndo,
+  createHistoryError,
+  HISTORY_LIMIT,
+  type HistoryEntry,
+  type HistoryResult,
+} from "./types";
+
+/**
+ * Push a new entry onto the history stack
+ *
+ * This should be called AFTER making a change. The current state (post-change)
+ * will be stored in the entry. If this is the first entry, the pre-change state
+ * is inferred from the base snapshot.
+ *
+ * If we are not at the end of the history stack, truncates future entries.
+ * Enforces the history limit by removing oldest entries when necessary.
+ */
+export function pushHistory(description: string): HistoryResult<void> {
+  const state = $history.get();
+
+  // If batching is active, do not push individual entries
+  if (state.isBatching) {
+    return { ok: true, value: undefined };
+  }
+
+  const currentSnapshot = createSnapshot();
+
+  // Keep the existing base snapshot - it should have been set by initializeHistory()
+  // If no base exists, we won't be able to undo back to initial state
+  const baseSnapshot = state.baseSnapshot;
+
+  const entry: HistoryEntry = {
+    snapshot: currentSnapshot,
+    description,
+    timestamp: new Date(),
+  };
+
+  // Create new entries array
+  let newEntries: HistoryEntry[];
+
+  if (state.currentIndex < state.entries.length - 1) {
+    // We are in the middle of history - truncate future entries
+    newEntries = [...state.entries.slice(0, state.currentIndex + 1), entry];
+  } else {
+    // We are at the end - just append
+    newEntries = [...state.entries, entry];
+  }
+
+  // Enforce history limit by removing oldest entries
+  if (newEntries.length > HISTORY_LIMIT) {
+    newEntries = newEntries.slice(newEntries.length - HISTORY_LIMIT);
+  }
+
+  $history.set({
+    ...state,
+    baseSnapshot,
+    entries: newEntries,
+    currentIndex: newEntries.length - 1,
+  });
+
+  return { ok: true, value: undefined };
+}
+
+/**
+ * Initialize history with a base snapshot
+ *
+ * This should be called at the start of editing, before any changes are made.
+ * The current document state will be stored as the base snapshot, which is
+ * the state that will be restored when all changes are undone.
+ */
+export function initializeHistory(): void {
+  const baseSnapshot = createSnapshot();
+  $history.set({
+    baseSnapshot,
+    entries: [],
+    currentIndex: -1,
+    isBatching: false,
+    batchDescription: null,
+    batchStartSnapshot: null,
+  });
+}
+
+/**
+ * Undo the last change
+ *
+ * Restores the document to the state before the current history entry.
+ */
+export function undo(): HistoryResult<void> {
+  const state = $history.get();
+
+  if (!canUndo(state)) {
+    return {
+      ok: false,
+      error: createHistoryError("NOTHING_TO_UNDO", "No changes to undo"),
+    };
+  }
+
+  // Determine which snapshot to restore
+  let snapshotToRestore: DocumentSnapshot | null;
+
+  if (state.currentIndex === 0) {
+    // Undoing the first entry - restore to base snapshot
+    snapshotToRestore = state.baseSnapshot;
+    if (!snapshotToRestore) {
+      // If no base snapshot, we cannot undo properly
+      // This happens if initializeHistory() was not called
+      // Fall back to creating an empty document state
+      return {
+        ok: false,
+        error: createHistoryError(
+          "NOTHING_TO_UNDO",
+          "No base snapshot available - call initializeHistory() before making changes"
+        ),
+      };
+    }
+  } else {
+    // Undoing entry N (N > 0) - restore to entry N-1's snapshot
+    snapshotToRestore = state.entries[state.currentIndex - 1]?.snapshot ?? null;
+    if (!snapshotToRestore) {
+      return {
+        ok: false,
+        error: createHistoryError("NOTHING_TO_UNDO", "Previous history entry not found"),
+      };
+    }
+  }
+
+  restoreSnapshot(snapshotToRestore);
+
+  $history.set({
+    ...state,
+    currentIndex: state.currentIndex - 1,
+  });
+
+  return { ok: true, value: undefined };
+}
+
+/**
+ * Redo the last undone change
+ *
+ * Restores the document to the state after the next history entry.
+ */
+export function redo(): HistoryResult<void> {
+  const state = $history.get();
+
+  if (!canRedo(state)) {
+    return {
+      ok: false,
+      error: createHistoryError("NOTHING_TO_REDO", "No changes to redo"),
+    };
+  }
+
+  const nextIndex = state.currentIndex + 1;
+  const entryToRedo = state.entries[nextIndex];
+  if (!entryToRedo) {
+    return {
+      ok: false,
+      error: createHistoryError("NOTHING_TO_REDO", "History entry not found"),
+    };
+  }
+
+  // Restore the snapshot from the next entry
+  restoreSnapshot(entryToRedo.snapshot);
+
+  $history.set({
+    ...state,
+    currentIndex: nextIndex,
+  });
+
+  return { ok: true, value: undefined };
+}
+
+/**
+ * Clear all history entries
+ */
+export function clearHistory(): void {
+  resetHistoryState();
+}
+
+/**
+ * Start a batch operation
+ *
+ * All changes within a batch will be grouped into a single undo step.
+ * Call commitBatch() to finalize or rollbackBatch() to cancel.
+ */
+export function startBatch(description: string): HistoryResult<void> {
+  const state = $history.get();
+
+  if (state.isBatching) {
+    return {
+      ok: false,
+      error: createHistoryError(
+        "BATCH_ALREADY_ACTIVE",
+        "A batch operation is already in progress"
+      ),
+    };
+  }
+
+  const snapshot = createSnapshot();
+
+  // If no base snapshot exists, set it now
+  const baseSnapshot = state.baseSnapshot ?? snapshot;
+
+  $history.set({
+    ...state,
+    baseSnapshot,
+    isBatching: true,
+    batchDescription: description,
+    batchStartSnapshot: snapshot,
+  });
+
+  return { ok: true, value: undefined };
+}
+
+/**
+ * Commit a batch operation
+ *
+ * Creates a single history entry for all changes made since startBatch().
+ */
+export function commitBatch(): HistoryResult<void> {
+  const state = $history.get();
+
+  if (!state.isBatching) {
+    return {
+      ok: false,
+      error: createHistoryError(
+        "NO_BATCH_ACTIVE",
+        "No batch operation is in progress"
+      ),
+    };
+  }
+
+  if (!state.batchStartSnapshot || !state.batchDescription) {
+    return {
+      ok: false,
+      error: createHistoryError(
+        "NO_BATCH_ACTIVE",
+        "Batch state is incomplete"
+      ),
+    };
+  }
+
+  // Create entry with the CURRENT state (after all batch changes)
+  const currentSnapshot = createSnapshot();
+  const entry: HistoryEntry = {
+    snapshot: currentSnapshot,
+    description: state.batchDescription,
+    timestamp: new Date(),
+  };
+
+  // If this is the first entry and we had no base, use the batch start as base
+  let baseSnapshot = state.baseSnapshot;
+  if (!baseSnapshot) {
+    baseSnapshot = state.batchStartSnapshot;
+  }
+
+  // Create new entries array (truncate future entries if needed)
+  let newEntries: HistoryEntry[];
+
+  if (state.currentIndex < state.entries.length - 1) {
+    newEntries = [...state.entries.slice(0, state.currentIndex + 1), entry];
+  } else {
+    newEntries = [...state.entries, entry];
+  }
+
+  // Enforce history limit
+  if (newEntries.length > HISTORY_LIMIT) {
+    newEntries = newEntries.slice(newEntries.length - HISTORY_LIMIT);
+  }
+
+  $history.set({
+    baseSnapshot,
+    entries: newEntries,
+    currentIndex: newEntries.length - 1,
+    isBatching: false,
+    batchDescription: null,
+    batchStartSnapshot: null,
+  });
+
+  return { ok: true, value: undefined };
+}
+
+/**
+ * Rollback a batch operation
+ *
+ * Restores the document to the state before startBatch() was called.
+ */
+export function rollbackBatch(): HistoryResult<void> {
+  const state = $history.get();
+
+  if (!state.isBatching) {
+    return {
+      ok: false,
+      error: createHistoryError(
+        "NO_BATCH_ACTIVE",
+        "No batch operation is in progress"
+      ),
+    };
+  }
+
+  if (!state.batchStartSnapshot) {
+    return {
+      ok: false,
+      error: createHistoryError(
+        "NO_BATCH_ACTIVE",
+        "Batch start snapshot is missing"
+      ),
+    };
+  }
+
+  // Restore the snapshot from before the batch started
+  restoreSnapshot(state.batchStartSnapshot);
+
+  $history.set({
+    ...state,
+    isBatching: false,
+    batchDescription: null,
+    batchStartSnapshot: null,
+  });
+
+  return { ok: true, value: undefined };
+}
+
+/**
+ * Execute a function within a batch
+ *
+ * Convenience wrapper that handles startBatch/commitBatch automatically.
+ * If the function throws, the batch is rolled back.
+ */
+export function batchChanges<T>(
+  description: string,
+  fn: () => T
+): HistoryResult<T> {
+  const startResult = startBatch(description);
+  if (!startResult.ok) {
+    return startResult;
+  }
+
+  try {
+    const result = fn();
+    const commitResult = commitBatch();
+    if (!commitResult.ok) {
+      return commitResult;
+    }
+    return { ok: true, value: result };
+  } catch (error) {
+    rollbackBatch();
+    throw error;
+  }
+}
+
+/**
+ * Get the current snapshot that would be restored on undo
+ */
+export function getUndoSnapshot(): DocumentSnapshot | null {
+  const state = $history.get();
+  if (!canUndo(state)) return null;
+
+  if (state.currentIndex === 0) {
+    return state.baseSnapshot;
+  }
+
+  return state.entries[state.currentIndex - 1]?.snapshot ?? null;
+}
+
+/**
+ * Get the snapshot that would be restored on redo
+ */
+export function getRedoSnapshot(): DocumentSnapshot | null {
+  const state = $history.get();
+  if (!canRedo(state)) return null;
+
+  return state.entries[state.currentIndex + 1]?.snapshot ?? null;
+}

--- a/packages/edit/src/history/index.ts
+++ b/packages/edit/src/history/index.ts
@@ -1,0 +1,68 @@
+/**
+ * History Module
+ *
+ * Undo/redo history management for the editor.
+ * Implements PZ-210: Undo/Redo History
+ */
+
+// Types
+export {
+  type HistoryEntry,
+  type HistoryError,
+  type HistoryErrorCode,
+  type HistoryFlags,
+  type HistoryKeyboardAction,
+  type HistoryResult,
+  type HistoryState,
+  // Constants
+  HISTORY_LIMIT,
+  // Utility functions
+  canRedo,
+  canUndo,
+  createHistoryError,
+  createInitialHistoryState,
+  getRedoDescription,
+  getUndoDescription,
+} from "./types";
+
+// State atoms and computed values
+export {
+  // Atoms
+  $history,
+  // Computed
+  $canRedo,
+  $canUndo,
+  $currentHistoryIndex,
+  $historySize,
+  $isBatching,
+  $redoDescription,
+  $undoDescription,
+  // Utility functions
+  resetHistoryState,
+} from "./state";
+
+// Actions
+export {
+  batchChanges,
+  clearHistory,
+  commitBatch,
+  getRedoSnapshot,
+  getUndoSnapshot,
+  initializeHistory,
+  pushHistory,
+  redo,
+  rollbackBatch,
+  startBatch,
+  undo,
+} from "./actions";
+
+// Keyboard handling
+export {
+  type HistoryKeyboardConfig,
+  createHistoryKeyboardHandler,
+  defaultHistoryKeyboardConfig,
+  executeHistoryKeyboardAction,
+  handleHistoryKeyboardEvent,
+  parseHistoryKeyboardEvent,
+  shouldHandleHistoryKeyboardEvent,
+} from "./keyboard";

--- a/packages/edit/src/history/keyboard.ts
+++ b/packages/edit/src/history/keyboard.ts
@@ -1,0 +1,121 @@
+/**
+ * Keyboard Event Handlers for History
+ *
+ * Keyboard shortcuts for undo/redo operations.
+ * Implements PZ-210: Undo/Redo History
+ */
+
+import { redo, undo } from "./actions";
+import type { HistoryKeyboardAction, HistoryResult } from "./types";
+
+/**
+ * Keyboard configuration for history
+ */
+export interface HistoryKeyboardConfig {
+  /** Enable Cmd/Ctrl+Z for undo */
+  enableUndo: boolean;
+  /** Enable Cmd/Ctrl+Shift+Z for redo */
+  enableRedo: boolean;
+}
+
+/**
+ * Default keyboard configuration
+ */
+export const defaultHistoryKeyboardConfig: HistoryKeyboardConfig = {
+  enableUndo: true,
+  enableRedo: true,
+};
+
+/**
+ * Parse a keyboard event into a history action
+ */
+export function parseHistoryKeyboardEvent(
+  event: KeyboardEvent,
+  config: HistoryKeyboardConfig = defaultHistoryKeyboardConfig
+): HistoryKeyboardAction | null {
+  const { key, shiftKey, metaKey, ctrlKey } = event;
+  const cmdOrCtrl = metaKey || ctrlKey;
+
+  // Cmd/Ctrl+Z - Undo
+  if (key === "z" && cmdOrCtrl && !shiftKey && config.enableUndo) {
+    return { type: "UNDO" };
+  }
+
+  // Cmd/Ctrl+Shift+Z - Redo
+  if (key === "z" && cmdOrCtrl && shiftKey && config.enableRedo) {
+    return { type: "REDO" };
+  }
+
+  // Cmd/Ctrl+Y - Redo (Windows convention)
+  if (key === "y" && cmdOrCtrl && config.enableRedo) {
+    return { type: "REDO" };
+  }
+
+  return null;
+}
+
+/**
+ * Execute a history keyboard action
+ */
+export function executeHistoryKeyboardAction(
+  action: HistoryKeyboardAction
+): HistoryResult<void> {
+  switch (action.type) {
+    case "UNDO":
+      return undo();
+
+    case "REDO":
+      return redo();
+
+    default: {
+      // Exhaustive type check
+      const _exhaustive: never = action;
+      return { ok: true, value: undefined };
+    }
+  }
+}
+
+/**
+ * Handle a keyboard event for history
+ * Returns true if the event was handled
+ */
+export function handleHistoryKeyboardEvent(
+  event: KeyboardEvent,
+  config: HistoryKeyboardConfig = defaultHistoryKeyboardConfig
+): boolean {
+  const action = parseHistoryKeyboardEvent(event, config);
+
+  if (!action) {
+    return false;
+  }
+
+  const result = executeHistoryKeyboardAction(action);
+
+  // Prevent default even if the action failed (e.g., nothing to undo)
+  // This prevents browser default behavior like undoing text input
+  event.preventDefault();
+  return true;
+}
+
+/**
+ * Create a keyboard event listener for history
+ * Use this to attach to a container element
+ */
+export function createHistoryKeyboardHandler(
+  config: HistoryKeyboardConfig = defaultHistoryKeyboardConfig
+): (event: KeyboardEvent) => void {
+  return (event: KeyboardEvent) => {
+    handleHistoryKeyboardEvent(event, config);
+  };
+}
+
+/**
+ * Check if a keyboard event should be handled by the history system
+ * Useful for determining whether to let events bubble
+ */
+export function shouldHandleHistoryKeyboardEvent(
+  event: KeyboardEvent,
+  config: HistoryKeyboardConfig = defaultHistoryKeyboardConfig
+): boolean {
+  return parseHistoryKeyboardEvent(event, config) !== null;
+}

--- a/packages/edit/src/history/state.ts
+++ b/packages/edit/src/history/state.ts
@@ -1,0 +1,84 @@
+/**
+ * History State Management
+ *
+ * Nanostores atoms and computed values for undo/redo history.
+ * Implements PZ-210: Undo/Redo History
+ */
+
+import { atom, computed, type ReadableAtom, type WritableAtom } from "nanostores";
+import {
+  canRedo,
+  canUndo,
+  createInitialHistoryState,
+  getRedoDescription,
+  getUndoDescription,
+  type HistoryState,
+} from "./types";
+
+/**
+ * Main history state atom
+ */
+export const $history: WritableAtom<HistoryState> = atom<HistoryState>(
+  createInitialHistoryState()
+);
+
+/**
+ * Computed: Whether undo is available
+ */
+export const $canUndo: ReadableAtom<boolean> = computed($history, (state) =>
+  canUndo(state)
+);
+
+/**
+ * Computed: Whether redo is available
+ */
+export const $canRedo: ReadableAtom<boolean> = computed($history, (state) =>
+  canRedo(state)
+);
+
+/**
+ * Computed: Description of the action that would be undone
+ */
+export const $undoDescription: ReadableAtom<string | null> = computed(
+  $history,
+  (state) => getUndoDescription(state)
+);
+
+/**
+ * Computed: Description of the action that would be redone
+ */
+export const $redoDescription: ReadableAtom<string | null> = computed(
+  $history,
+  (state) => getRedoDescription(state)
+);
+
+/**
+ * Computed: Whether a batch operation is currently active
+ */
+export const $isBatching: ReadableAtom<boolean> = computed(
+  $history,
+  (state) => state.isBatching
+);
+
+/**
+ * Computed: Number of entries in the history stack
+ */
+export const $historySize: ReadableAtom<number> = computed(
+  $history,
+  (state) => state.entries.length
+);
+
+/**
+ * Computed: Current position in the history stack
+ */
+export const $currentHistoryIndex: ReadableAtom<number> = computed(
+  $history,
+  (state) => state.currentIndex
+);
+
+/**
+ * Reset history state to initial values
+ */
+export function resetHistoryState(): void {
+  $history.set(createInitialHistoryState());
+}

--- a/packages/edit/src/history/types.ts
+++ b/packages/edit/src/history/types.ts
@@ -1,0 +1,141 @@
+/**
+ * History Types
+ *
+ * Type definitions for undo/redo history management.
+ * Implements PZ-210: Undo/Redo History
+ */
+
+import type { DocumentSnapshot } from "../model/types";
+import type { Result } from "../model/types";
+
+/**
+ * Maximum number of history entries to keep
+ */
+export const HISTORY_LIMIT = 100;
+
+/**
+ * A single entry in the history stack
+ * Each entry represents a state AFTER a change was made
+ */
+export interface HistoryEntry {
+  /** The document snapshot after the change */
+  snapshot: DocumentSnapshot;
+  /** Human-readable description of the change */
+  description: string;
+  /** Timestamp when this entry was created */
+  timestamp: Date;
+}
+
+/**
+ * The complete history state
+ */
+export interface HistoryState {
+  /** The base snapshot (state before any history entries) */
+  baseSnapshot: DocumentSnapshot | null;
+  /** Stack of history entries (oldest first) - each contains state AFTER a change */
+  entries: HistoryEntry[];
+  /** Current position in the history stack (-1 means at base state) */
+  currentIndex: number;
+  /** Whether we are currently in a batch operation */
+  isBatching: boolean;
+  /** Pending batch description (set when batching starts) */
+  batchDescription: string | null;
+  /** Snapshot before batch started (for rollback/commit) */
+  batchStartSnapshot: DocumentSnapshot | null;
+}
+
+/**
+ * Computed flags derived from history state
+ */
+export interface HistoryFlags {
+  /** Whether undo is available */
+  canUndo: boolean;
+  /** Whether redo is available */
+  canRedo: boolean;
+}
+
+/**
+ * History error codes
+ */
+export type HistoryErrorCode =
+  | "NOTHING_TO_UNDO"
+  | "NOTHING_TO_REDO"
+  | "BATCH_ALREADY_ACTIVE"
+  | "NO_BATCH_ACTIVE"
+  | "HISTORY_LIMIT_REACHED";
+
+/**
+ * History error type
+ */
+export interface HistoryError {
+  code: HistoryErrorCode;
+  message: string;
+  cause?: unknown;
+}
+
+/**
+ * Create a history error
+ */
+export function createHistoryError(
+  code: HistoryErrorCode,
+  message: string,
+  cause?: unknown
+): HistoryError {
+  return { code, message, cause };
+}
+
+/**
+ * Result type for history operations
+ */
+export type HistoryResult<T> = Result<T, HistoryError>;
+
+/**
+ * Create initial history state
+ */
+export function createInitialHistoryState(): HistoryState {
+  return {
+    baseSnapshot: null,
+    entries: [],
+    currentIndex: -1,
+    isBatching: false,
+    batchDescription: null,
+    batchStartSnapshot: null,
+  };
+}
+
+/**
+ * Check if undo is available
+ */
+export function canUndo(state: HistoryState): boolean {
+  return state.currentIndex >= 0;
+}
+
+/**
+ * Check if redo is available
+ */
+export function canRedo(state: HistoryState): boolean {
+  return state.currentIndex < state.entries.length - 1;
+}
+
+/**
+ * Get the description of the action that would be undone
+ */
+export function getUndoDescription(state: HistoryState): string | null {
+  if (!canUndo(state)) return null;
+  return state.entries[state.currentIndex]?.description ?? null;
+}
+
+/**
+ * Get the description of the action that would be redone
+ */
+export function getRedoDescription(state: HistoryState): string | null {
+  if (!canRedo(state)) return null;
+  return state.entries[state.currentIndex + 1]?.description ?? null;
+}
+
+/**
+ * Keyboard action for history
+ */
+export type HistoryKeyboardAction =
+  | { type: "UNDO" }
+  | { type: "REDO" };

--- a/packages/edit/src/index.ts
+++ b/packages/edit/src/index.ts
@@ -342,6 +342,57 @@ export {
   useDragState,
 } from "./dnd";
 
+// Undo/Redo History (PZ-210)
+export {
+  // Types
+  type HistoryEntry as HistoryStackEntry,
+  type HistoryError,
+  type HistoryErrorCode,
+  type HistoryFlags,
+  type HistoryKeyboardAction,
+  type HistoryKeyboardConfig,
+  type HistoryResult,
+  type HistoryState,
+  // Constants
+  HISTORY_LIMIT,
+  // Utility functions
+  canRedo,
+  canUndo,
+  createHistoryError,
+  createInitialHistoryState,
+  getRedoDescription,
+  getUndoDescription,
+  // State atoms
+  $history,
+  $canRedo,
+  $canUndo,
+  $currentHistoryIndex,
+  $historySize,
+  $isBatching,
+  $redoDescription,
+  $undoDescription,
+  resetHistoryState,
+  // Actions
+  batchChanges,
+  clearHistory,
+  commitBatch,
+  getRedoSnapshot,
+  getUndoSnapshot,
+  initializeHistory,
+  pushHistory,
+  redo,
+  rollbackBatch,
+  startBatch,
+  undo,
+  // Keyboard handling
+  createHistoryKeyboardHandler,
+  defaultHistoryKeyboardConfig,
+  executeHistoryKeyboardAction,
+  handleHistoryKeyboardEvent,
+  parseHistoryKeyboardEvent,
+  shouldHandleHistoryKeyboardEvent,
+} from "./history";
+
 // Placeholder - to be implemented in Phase 2
 export function BlockEditor(): never {
   throw new Error("Not implemented - see PZ-200: https://github.com/ezmode-games/phantom-zone/issues/41");

--- a/packages/edit/test/history/actions.test.ts
+++ b/packages/edit/test/history/actions.test.ts
@@ -1,0 +1,616 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { uuidv7 } from "uuidv7";
+import {
+  $document,
+  initializeDocument,
+  insertBlockAction,
+  deleteBlockAction,
+  updateBlockPropsAction,
+} from "../../src/model/document";
+import type { Block } from "../../src/model/types";
+import {
+  batchChanges,
+  clearHistory,
+  commitBatch,
+  getRedoSnapshot,
+  getUndoSnapshot,
+  initializeHistory,
+  pushHistory,
+  redo,
+  rollbackBatch,
+  startBatch,
+  undo,
+} from "../../src/history/actions";
+import {
+  $canRedo,
+  $canUndo,
+  $history,
+  $historySize,
+  $isBatching,
+  resetHistoryState,
+} from "../../src/history/state";
+import { HISTORY_LIMIT } from "../../src/history/types";
+
+// Helper to create a test block
+function createTestBlock(
+  type: string,
+  props: Record<string, unknown> = {}
+): Block {
+  return {
+    id: uuidv7(),
+    type,
+    props,
+  };
+}
+
+describe("History Actions", () => {
+  beforeEach(() => {
+    initializeDocument();
+    resetHistoryState();
+    // Initialize history to capture the base state (empty document)
+    initializeHistory();
+  });
+
+  afterEach(() => {
+    initializeDocument();
+    resetHistoryState();
+  });
+
+  describe("pushHistory", () => {
+    it("adds entry to history", () => {
+      const block = createTestBlock("paragraph", { text: "Hello" });
+      insertBlockAction(block);
+      const result = pushHistory("Add paragraph");
+
+      expect(result.ok).toBe(true);
+      expect($historySize.get()).toBe(1);
+    });
+
+    it("stores snapshot of current state", () => {
+      const block = createTestBlock("paragraph", { text: "Hello" });
+      insertBlockAction(block);
+      pushHistory("Add paragraph");
+
+      const state = $history.get();
+      expect(state.entries[0]?.snapshot.document.blocks).toHaveLength(1);
+    });
+
+    it("stores description", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+      pushHistory("Custom description");
+
+      const state = $history.get();
+      expect(state.entries[0]?.description).toBe("Custom description");
+    });
+
+    it("stores timestamp", () => {
+      const before = new Date();
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+      pushHistory("Add block");
+      const after = new Date();
+
+      const state = $history.get();
+      const timestamp = state.entries[0]?.timestamp;
+      expect(timestamp).toBeDefined();
+      expect(timestamp!.getTime()).toBeGreaterThanOrEqual(before.getTime());
+      expect(timestamp!.getTime()).toBeLessThanOrEqual(after.getTime());
+    });
+
+    it("updates currentIndex", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+      pushHistory("First");
+
+      expect($history.get().currentIndex).toBe(0);
+
+      const block2 = createTestBlock("heading");
+      insertBlockAction(block2);
+      pushHistory("Second");
+
+      expect($history.get().currentIndex).toBe(1);
+    });
+
+    it("truncates future entries when pushing after undo", () => {
+      // Create initial state with blocks
+      const block1 = createTestBlock("paragraph", { text: "One" });
+      insertBlockAction(block1);
+      pushHistory("Add first");
+
+      const block2 = createTestBlock("paragraph", { text: "Two" });
+      insertBlockAction(block2);
+      pushHistory("Add second");
+
+      const block3 = createTestBlock("paragraph", { text: "Three" });
+      insertBlockAction(block3);
+      pushHistory("Add third");
+
+      expect($historySize.get()).toBe(3);
+
+      // Undo twice
+      undo();
+      undo();
+
+      expect($history.get().currentIndex).toBe(0);
+
+      // Push new entry - should truncate "Add third" and "Add second"
+      const block4 = createTestBlock("heading", { level: 1 });
+      insertBlockAction(block4);
+      pushHistory("Add heading");
+
+      expect($historySize.get()).toBe(2);
+      expect($history.get().entries[1]?.description).toBe("Add heading");
+    });
+
+    it("enforces history limit", () => {
+      // Add more than HISTORY_LIMIT entries
+      for (let i = 0; i < HISTORY_LIMIT + 10; i++) {
+        const block = createTestBlock("paragraph", { index: i });
+        insertBlockAction(block);
+        pushHistory(`Add block ${i}`);
+      }
+
+      expect($historySize.get()).toBe(HISTORY_LIMIT);
+    });
+
+    it("does not push when batching is active", () => {
+      startBatch("Batch operation");
+
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+      pushHistory("Should be ignored");
+
+      expect($historySize.get()).toBe(0);
+    });
+  });
+
+  describe("undo", () => {
+    it("returns error when nothing to undo", () => {
+      const result = undo();
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("NOTHING_TO_UNDO");
+      }
+    });
+
+    it("restores previous document state", () => {
+      // Initial state with one block
+      const block1 = createTestBlock("paragraph", { text: "Original" });
+      insertBlockAction(block1);
+      pushHistory("Add first block");
+
+      // Add second block
+      const block2 = createTestBlock("heading", { level: 1 });
+      insertBlockAction(block2);
+      pushHistory("Add second block");
+
+      expect($document.get().blocks).toHaveLength(2);
+
+      // Undo should restore to one block
+      const result = undo();
+
+      expect(result.ok).toBe(true);
+      expect($document.get().blocks).toHaveLength(1);
+    });
+
+    it("decrements currentIndex", () => {
+      const block1 = createTestBlock("paragraph");
+      insertBlockAction(block1);
+      pushHistory("First");
+
+      const block2 = createTestBlock("heading");
+      insertBlockAction(block2);
+      pushHistory("Second");
+
+      expect($history.get().currentIndex).toBe(1);
+
+      undo();
+
+      expect($history.get().currentIndex).toBe(0);
+    });
+
+    it("enables redo after undo", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+      pushHistory("Add block");
+
+      expect($canRedo.get()).toBe(false);
+
+      undo();
+
+      expect($canRedo.get()).toBe(true);
+    });
+
+    it("can undo multiple times", () => {
+      const block1 = createTestBlock("paragraph", { text: "First" });
+      insertBlockAction(block1);
+      pushHistory("Add first");
+
+      const block2 = createTestBlock("paragraph", { text: "Second" });
+      insertBlockAction(block2);
+      pushHistory("Add second");
+
+      const block3 = createTestBlock("paragraph", { text: "Third" });
+      insertBlockAction(block3);
+      pushHistory("Add third");
+
+      expect($document.get().blocks).toHaveLength(3);
+
+      undo();
+      expect($document.get().blocks).toHaveLength(2);
+
+      undo();
+      expect($document.get().blocks).toHaveLength(1);
+
+      undo();
+      expect($document.get().blocks).toHaveLength(0);
+    });
+  });
+
+  describe("redo", () => {
+    it("returns error when nothing to redo", () => {
+      const result = redo();
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("NOTHING_TO_REDO");
+      }
+    });
+
+    it("returns error when at end of history", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+      pushHistory("Add block");
+
+      const result = redo();
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("NOTHING_TO_REDO");
+      }
+    });
+
+    it("restores next document state", () => {
+      const block1 = createTestBlock("paragraph", { text: "First" });
+      insertBlockAction(block1);
+      pushHistory("Add first");
+
+      const block2 = createTestBlock("heading", { level: 1 });
+      insertBlockAction(block2);
+      pushHistory("Add second");
+
+      undo();
+      expect($document.get().blocks).toHaveLength(1);
+
+      const result = redo();
+
+      expect(result.ok).toBe(true);
+      expect($document.get().blocks).toHaveLength(2);
+    });
+
+    it("increments currentIndex", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+      pushHistory("Add block");
+
+      undo();
+      expect($history.get().currentIndex).toBe(-1);
+
+      redo();
+      expect($history.get().currentIndex).toBe(0);
+    });
+
+    it("can redo multiple times", () => {
+      const block1 = createTestBlock("paragraph");
+      insertBlockAction(block1);
+      pushHistory("First");
+
+      const block2 = createTestBlock("paragraph");
+      insertBlockAction(block2);
+      pushHistory("Second");
+
+      const block3 = createTestBlock("paragraph");
+      insertBlockAction(block3);
+      pushHistory("Third");
+
+      undo();
+      undo();
+      undo();
+
+      expect($document.get().blocks).toHaveLength(0);
+
+      redo();
+      expect($document.get().blocks).toHaveLength(1);
+
+      redo();
+      expect($document.get().blocks).toHaveLength(2);
+
+      redo();
+      expect($document.get().blocks).toHaveLength(3);
+    });
+  });
+
+  describe("clearHistory", () => {
+    it("removes all history entries", () => {
+      const block1 = createTestBlock("paragraph");
+      insertBlockAction(block1);
+      pushHistory("First");
+
+      const block2 = createTestBlock("heading");
+      insertBlockAction(block2);
+      pushHistory("Second");
+
+      expect($historySize.get()).toBe(2);
+
+      clearHistory();
+
+      expect($historySize.get()).toBe(0);
+      expect($canUndo.get()).toBe(false);
+      expect($canRedo.get()).toBe(false);
+    });
+  });
+
+  describe("batch operations", () => {
+    describe("startBatch", () => {
+      it("sets isBatching to true", () => {
+        const result = startBatch("Test batch");
+
+        expect(result.ok).toBe(true);
+        expect($isBatching.get()).toBe(true);
+      });
+
+      it("stores batch description", () => {
+        startBatch("My batch description");
+
+        const state = $history.get();
+        expect(state.batchDescription).toBe("My batch description");
+      });
+
+      it("stores start snapshot", () => {
+        const block = createTestBlock("paragraph");
+        insertBlockAction(block);
+
+        startBatch("Test batch");
+
+        const state = $history.get();
+        expect(state.batchStartSnapshot).not.toBeNull();
+        expect(state.batchStartSnapshot?.document.blocks).toHaveLength(1);
+      });
+
+      it("returns error if batch already active", () => {
+        startBatch("First batch");
+        const result = startBatch("Second batch");
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+          expect(result.error.code).toBe("BATCH_ALREADY_ACTIVE");
+        }
+      });
+    });
+
+    describe("commitBatch", () => {
+      it("creates single history entry for all changes", () => {
+        startBatch("Multiple changes");
+
+        const block1 = createTestBlock("paragraph");
+        insertBlockAction(block1);
+
+        const block2 = createTestBlock("heading");
+        insertBlockAction(block2);
+
+        const result = commitBatch();
+
+        expect(result.ok).toBe(true);
+        expect($historySize.get()).toBe(1);
+        expect($history.get().entries[0]?.description).toBe("Multiple changes");
+      });
+
+      it("sets isBatching to false", () => {
+        startBatch("Test batch");
+        commitBatch();
+
+        expect($isBatching.get()).toBe(false);
+      });
+
+      it("clears batch state", () => {
+        startBatch("Test batch");
+        commitBatch();
+
+        const state = $history.get();
+        expect(state.batchDescription).toBeNull();
+        expect(state.batchStartSnapshot).toBeNull();
+      });
+
+      it("returns error if no batch active", () => {
+        const result = commitBatch();
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+          expect(result.error.code).toBe("NO_BATCH_ACTIVE");
+        }
+      });
+    });
+
+    describe("rollbackBatch", () => {
+      it("restores document to state before batch", () => {
+        const block1 = createTestBlock("paragraph");
+        insertBlockAction(block1);
+
+        startBatch("Rollback test");
+
+        const block2 = createTestBlock("heading");
+        insertBlockAction(block2);
+        const block3 = createTestBlock("list");
+        insertBlockAction(block3);
+
+        expect($document.get().blocks).toHaveLength(3);
+
+        const result = rollbackBatch();
+
+        expect(result.ok).toBe(true);
+        expect($document.get().blocks).toHaveLength(1);
+      });
+
+      it("sets isBatching to false", () => {
+        startBatch("Test batch");
+        rollbackBatch();
+
+        expect($isBatching.get()).toBe(false);
+      });
+
+      it("does not add history entry", () => {
+        startBatch("Rollback test");
+        const block = createTestBlock("paragraph");
+        insertBlockAction(block);
+        rollbackBatch();
+
+        expect($historySize.get()).toBe(0);
+      });
+
+      it("returns error if no batch active", () => {
+        const result = rollbackBatch();
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+          expect(result.error.code).toBe("NO_BATCH_ACTIVE");
+        }
+      });
+    });
+
+    describe("batchChanges", () => {
+      it("wraps function in batch", () => {
+        const result = batchChanges("Add multiple blocks", () => {
+          const block1 = createTestBlock("paragraph");
+          insertBlockAction(block1);
+
+          const block2 = createTestBlock("heading");
+          insertBlockAction(block2);
+
+          return "done";
+        });
+
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+          expect(result.value).toBe("done");
+        }
+        expect($historySize.get()).toBe(1);
+        expect($isBatching.get()).toBe(false);
+      });
+
+      it("rolls back on error", () => {
+        const block1 = createTestBlock("paragraph");
+        insertBlockAction(block1);
+
+        expect(() => {
+          batchChanges("Failing batch", () => {
+            const block2 = createTestBlock("heading");
+            insertBlockAction(block2);
+            throw new Error("Intentional error");
+          });
+        }).toThrow("Intentional error");
+
+        // Should have rolled back to state before batch
+        expect($document.get().blocks).toHaveLength(1);
+        expect($isBatching.get()).toBe(false);
+      });
+
+      it("returns error if batch already active", () => {
+        startBatch("First batch");
+
+        const result = batchChanges("Second batch", () => {
+          return "value";
+        });
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+          expect(result.error.code).toBe("BATCH_ALREADY_ACTIVE");
+        }
+      });
+    });
+  });
+
+  describe("getUndoSnapshot", () => {
+    it("returns null when undo not available", () => {
+      expect(getUndoSnapshot()).toBeNull();
+    });
+
+    it("returns snapshot that would be restored", () => {
+      const block = createTestBlock("paragraph", { text: "Test" });
+      insertBlockAction(block);
+      pushHistory("Add block");
+
+      const snapshot = getUndoSnapshot();
+      expect(snapshot).not.toBeNull();
+    });
+  });
+
+  describe("getRedoSnapshot", () => {
+    it("returns null when redo not available", () => {
+      expect(getRedoSnapshot()).toBeNull();
+    });
+
+    it("returns snapshot that would be restored", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+      pushHistory("Add block");
+
+      undo();
+
+      const snapshot = getRedoSnapshot();
+      expect(snapshot).not.toBeNull();
+      expect(snapshot?.document.blocks).toHaveLength(1);
+    });
+  });
+
+  describe("undo/redo integration", () => {
+    it("handles complex undo/redo sequence", () => {
+      // Add three blocks
+      const block1 = createTestBlock("paragraph", { text: "One" });
+      insertBlockAction(block1);
+      pushHistory("Add first");
+
+      const block2 = createTestBlock("paragraph", { text: "Two" });
+      insertBlockAction(block2);
+      pushHistory("Add second");
+
+      const block3 = createTestBlock("paragraph", { text: "Three" });
+      insertBlockAction(block3);
+      pushHistory("Add third");
+
+      expect($document.get().blocks).toHaveLength(3);
+
+      // Undo twice
+      undo();
+      undo();
+      expect($document.get().blocks).toHaveLength(1);
+
+      // Redo once
+      redo();
+      expect($document.get().blocks).toHaveLength(2);
+
+      // Add new block (should truncate history)
+      const block4 = createTestBlock("heading", { level: 1 });
+      insertBlockAction(block4);
+      pushHistory("Add heading");
+
+      expect($document.get().blocks).toHaveLength(3);
+      expect($canRedo.get()).toBe(false);
+
+      // Undo should work
+      undo();
+      expect($document.get().blocks).toHaveLength(2);
+    });
+
+    it("preserves selection state in snapshots", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+      // Selection is included in the snapshot
+      pushHistory("Add block");
+
+      const snapshot = $history.get().entries[0]?.snapshot;
+      expect(snapshot?.selection).toBeDefined();
+    });
+  });
+});

--- a/packages/edit/test/history/keyboard.test.ts
+++ b/packages/edit/test/history/keyboard.test.ts
@@ -1,0 +1,365 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { uuidv7 } from "uuidv7";
+import {
+  $document,
+  initializeDocument,
+  insertBlockAction,
+} from "../../src/model/document";
+import type { Block } from "../../src/model/types";
+import { initializeHistory, pushHistory, undo } from "../../src/history/actions";
+import {
+  createHistoryKeyboardHandler,
+  defaultHistoryKeyboardConfig,
+  executeHistoryKeyboardAction,
+  handleHistoryKeyboardEvent,
+  parseHistoryKeyboardEvent,
+  shouldHandleHistoryKeyboardEvent,
+  type HistoryKeyboardConfig,
+} from "../../src/history/keyboard";
+import { resetHistoryState } from "../../src/history/state";
+
+// Helper to create a test block
+function createTestBlock(
+  type: string,
+  props: Record<string, unknown> = {}
+): Block {
+  return {
+    id: uuidv7(),
+    type,
+    props,
+  };
+}
+
+// Mock keyboard event interface for testing in Node environment
+interface MockKeyboardEvent {
+  key: string;
+  shiftKey: boolean;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  preventDefault: () => void;
+}
+
+// Helper to create a mock keyboard event
+function createKeyboardEvent(
+  key: string,
+  options: {
+    shiftKey?: boolean;
+    metaKey?: boolean;
+    ctrlKey?: boolean;
+  } = {}
+): KeyboardEvent {
+  const mock: MockKeyboardEvent = {
+    key,
+    shiftKey: options.shiftKey ?? false,
+    metaKey: options.metaKey ?? false,
+    ctrlKey: options.ctrlKey ?? false,
+    preventDefault: vi.fn(),
+  };
+  return mock as unknown as KeyboardEvent;
+}
+
+describe("History Keyboard Handling", () => {
+  beforeEach(() => {
+    initializeDocument();
+    resetHistoryState();
+    // Initialize history to capture the base state (empty document)
+    initializeHistory();
+  });
+
+  afterEach(() => {
+    initializeDocument();
+    resetHistoryState();
+  });
+
+  describe("parseHistoryKeyboardEvent", () => {
+    describe("Cmd/Ctrl+Z (Undo)", () => {
+      it("returns UNDO for Cmd+Z", () => {
+        const event = createKeyboardEvent("z", { metaKey: true });
+        const action = parseHistoryKeyboardEvent(event);
+
+        expect(action).toEqual({ type: "UNDO" });
+      });
+
+      it("returns UNDO for Ctrl+Z", () => {
+        const event = createKeyboardEvent("z", { ctrlKey: true });
+        const action = parseHistoryKeyboardEvent(event);
+
+        expect(action).toEqual({ type: "UNDO" });
+      });
+
+      it("returns null when undo is disabled", () => {
+        const config: HistoryKeyboardConfig = {
+          ...defaultHistoryKeyboardConfig,
+          enableUndo: false,
+        };
+        const event = createKeyboardEvent("z", { metaKey: true });
+        const action = parseHistoryKeyboardEvent(event, config);
+
+        expect(action).toBeNull();
+      });
+
+      it("returns REDO for Cmd+Shift+Z (not undo)", () => {
+        const event = createKeyboardEvent("z", { metaKey: true, shiftKey: true });
+        const action = parseHistoryKeyboardEvent(event);
+
+        expect(action).toEqual({ type: "REDO" });
+      });
+    });
+
+    describe("Cmd/Ctrl+Shift+Z (Redo)", () => {
+      it("returns REDO for Cmd+Shift+Z", () => {
+        const event = createKeyboardEvent("z", { metaKey: true, shiftKey: true });
+        const action = parseHistoryKeyboardEvent(event);
+
+        expect(action).toEqual({ type: "REDO" });
+      });
+
+      it("returns REDO for Ctrl+Shift+Z", () => {
+        const event = createKeyboardEvent("z", { ctrlKey: true, shiftKey: true });
+        const action = parseHistoryKeyboardEvent(event);
+
+        expect(action).toEqual({ type: "REDO" });
+      });
+
+      it("returns null when redo is disabled", () => {
+        const config: HistoryKeyboardConfig = {
+          ...defaultHistoryKeyboardConfig,
+          enableRedo: false,
+        };
+        const event = createKeyboardEvent("z", { metaKey: true, shiftKey: true });
+        const action = parseHistoryKeyboardEvent(event, config);
+
+        expect(action).toBeNull();
+      });
+    });
+
+    describe("Cmd/Ctrl+Y (Redo - Windows)", () => {
+      it("returns REDO for Cmd+Y", () => {
+        const event = createKeyboardEvent("y", { metaKey: true });
+        const action = parseHistoryKeyboardEvent(event);
+
+        expect(action).toEqual({ type: "REDO" });
+      });
+
+      it("returns REDO for Ctrl+Y", () => {
+        const event = createKeyboardEvent("y", { ctrlKey: true });
+        const action = parseHistoryKeyboardEvent(event);
+
+        expect(action).toEqual({ type: "REDO" });
+      });
+
+      it("returns null when redo is disabled", () => {
+        const config: HistoryKeyboardConfig = {
+          ...defaultHistoryKeyboardConfig,
+          enableRedo: false,
+        };
+        const event = createKeyboardEvent("y", { metaKey: true });
+        const action = parseHistoryKeyboardEvent(event, config);
+
+        expect(action).toBeNull();
+      });
+    });
+
+    describe("unhandled keys", () => {
+      it("returns null for z without modifier", () => {
+        const event = createKeyboardEvent("z");
+        const action = parseHistoryKeyboardEvent(event);
+
+        expect(action).toBeNull();
+      });
+
+      it("returns null for other keys", () => {
+        const event = createKeyboardEvent("x", { metaKey: true });
+        const action = parseHistoryKeyboardEvent(event);
+
+        expect(action).toBeNull();
+      });
+
+      it("returns null for regular letters", () => {
+        const event = createKeyboardEvent("a");
+        const action = parseHistoryKeyboardEvent(event);
+
+        expect(action).toBeNull();
+      });
+    });
+  });
+
+  describe("executeHistoryKeyboardAction", () => {
+    it("executes UNDO action", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+      pushHistory("Add block");
+
+      expect($document.get().blocks).toHaveLength(1);
+
+      const result = executeHistoryKeyboardAction({ type: "UNDO" });
+
+      expect(result.ok).toBe(true);
+      expect($document.get().blocks).toHaveLength(0);
+    });
+
+    it("executes REDO action", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+      pushHistory("Add block");
+
+      undo();
+      expect($document.get().blocks).toHaveLength(0);
+
+      const result = executeHistoryKeyboardAction({ type: "REDO" });
+
+      expect(result.ok).toBe(true);
+      expect($document.get().blocks).toHaveLength(1);
+    });
+
+    it("returns error when nothing to undo", () => {
+      const result = executeHistoryKeyboardAction({ type: "UNDO" });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("NOTHING_TO_UNDO");
+      }
+    });
+
+    it("returns error when nothing to redo", () => {
+      const result = executeHistoryKeyboardAction({ type: "REDO" });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("NOTHING_TO_REDO");
+      }
+    });
+  });
+
+  describe("handleHistoryKeyboardEvent", () => {
+    it("returns true and prevents default for handled events", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+      pushHistory("Add block");
+
+      const event = createKeyboardEvent("z", { metaKey: true });
+      const handled = handleHistoryKeyboardEvent(event);
+
+      expect(handled).toBe(true);
+      expect((event as unknown as MockKeyboardEvent).preventDefault).toHaveBeenCalled();
+    });
+
+    it("returns false for unhandled events", () => {
+      const event = createKeyboardEvent("x", { metaKey: true });
+      const handled = handleHistoryKeyboardEvent(event);
+
+      expect(handled).toBe(false);
+      expect((event as unknown as MockKeyboardEvent).preventDefault).not.toHaveBeenCalled();
+    });
+
+    it("prevents default even when undo fails", () => {
+      // No history, undo will fail but should still prevent default
+      const event = createKeyboardEvent("z", { metaKey: true });
+      const handled = handleHistoryKeyboardEvent(event);
+
+      expect(handled).toBe(true);
+      expect((event as unknown as MockKeyboardEvent).preventDefault).toHaveBeenCalled();
+    });
+
+    it("prevents default even when redo fails", () => {
+      // No history, redo will fail but should still prevent default
+      const event = createKeyboardEvent("z", { metaKey: true, shiftKey: true });
+      const handled = handleHistoryKeyboardEvent(event);
+
+      expect(handled).toBe(true);
+      expect((event as unknown as MockKeyboardEvent).preventDefault).toHaveBeenCalled();
+    });
+  });
+
+  describe("shouldHandleHistoryKeyboardEvent", () => {
+    it("returns true for Cmd/Ctrl+Z", () => {
+      expect(
+        shouldHandleHistoryKeyboardEvent(createKeyboardEvent("z", { metaKey: true }))
+      ).toBe(true);
+      expect(
+        shouldHandleHistoryKeyboardEvent(createKeyboardEvent("z", { ctrlKey: true }))
+      ).toBe(true);
+    });
+
+    it("returns true for Cmd/Ctrl+Shift+Z", () => {
+      expect(
+        shouldHandleHistoryKeyboardEvent(
+          createKeyboardEvent("z", { metaKey: true, shiftKey: true })
+        )
+      ).toBe(true);
+      expect(
+        shouldHandleHistoryKeyboardEvent(
+          createKeyboardEvent("z", { ctrlKey: true, shiftKey: true })
+        )
+      ).toBe(true);
+    });
+
+    it("returns true for Cmd/Ctrl+Y", () => {
+      expect(
+        shouldHandleHistoryKeyboardEvent(createKeyboardEvent("y", { metaKey: true }))
+      ).toBe(true);
+      expect(
+        shouldHandleHistoryKeyboardEvent(createKeyboardEvent("y", { ctrlKey: true }))
+      ).toBe(true);
+    });
+
+    it("returns false for unhandled keys", () => {
+      expect(shouldHandleHistoryKeyboardEvent(createKeyboardEvent("z"))).toBe(false);
+      expect(
+        shouldHandleHistoryKeyboardEvent(createKeyboardEvent("x", { metaKey: true }))
+      ).toBe(false);
+      expect(shouldHandleHistoryKeyboardEvent(createKeyboardEvent("a"))).toBe(false);
+    });
+  });
+
+  describe("createHistoryKeyboardHandler", () => {
+    it("creates a handler function", () => {
+      const handler = createHistoryKeyboardHandler();
+      expect(typeof handler).toBe("function");
+    });
+
+    it("handler processes keyboard events", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+      pushHistory("Add block");
+
+      const handler = createHistoryKeyboardHandler();
+      const event = createKeyboardEvent("z", { metaKey: true });
+
+      expect($document.get().blocks).toHaveLength(1);
+
+      handler(event);
+
+      expect($document.get().blocks).toHaveLength(0);
+    });
+
+    it("handler respects custom config", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+      pushHistory("Add block");
+
+      const config: HistoryKeyboardConfig = {
+        ...defaultHistoryKeyboardConfig,
+        enableUndo: false,
+      };
+
+      const handler = createHistoryKeyboardHandler(config);
+      const event = createKeyboardEvent("z", { metaKey: true });
+
+      handler(event);
+
+      // Undo should not have happened because it's disabled
+      expect($document.get().blocks).toHaveLength(1);
+    });
+  });
+
+  describe("defaultHistoryKeyboardConfig", () => {
+    it("has undo enabled by default", () => {
+      expect(defaultHistoryKeyboardConfig.enableUndo).toBe(true);
+    });
+
+    it("has redo enabled by default", () => {
+      expect(defaultHistoryKeyboardConfig.enableRedo).toBe(true);
+    });
+  });
+});

--- a/packages/edit/test/history/state.test.ts
+++ b/packages/edit/test/history/state.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { uuidv7 } from "uuidv7";
+import { initializeDocument, insertBlockAction } from "../../src/model/document";
+import type { Block } from "../../src/model/types";
+import { pushHistory, clearHistory } from "../../src/history/actions";
+import {
+  $canRedo,
+  $canUndo,
+  $currentHistoryIndex,
+  $history,
+  $historySize,
+  $isBatching,
+  $redoDescription,
+  $undoDescription,
+  resetHistoryState,
+} from "../../src/history/state";
+
+// Helper to create a test block
+function createTestBlock(
+  type: string,
+  props: Record<string, unknown> = {}
+): Block {
+  return {
+    id: uuidv7(),
+    type,
+    props,
+  };
+}
+
+describe("History State", () => {
+  beforeEach(() => {
+    initializeDocument();
+    resetHistoryState();
+  });
+
+  afterEach(() => {
+    initializeDocument();
+    resetHistoryState();
+  });
+
+  describe("$history atom", () => {
+    it("has initial state", () => {
+      const state = $history.get();
+
+      expect(state.entries).toEqual([]);
+      expect(state.currentIndex).toBe(-1);
+      expect(state.isBatching).toBe(false);
+    });
+  });
+
+  describe("$canUndo computed", () => {
+    it("returns false initially", () => {
+      expect($canUndo.get()).toBe(false);
+    });
+
+    it("returns true after pushing history", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+      pushHistory("Add block");
+
+      expect($canUndo.get()).toBe(true);
+    });
+  });
+
+  describe("$canRedo computed", () => {
+    it("returns false initially", () => {
+      expect($canRedo.get()).toBe(false);
+    });
+
+    it("returns false when at end of history", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+      pushHistory("Add block");
+
+      expect($canRedo.get()).toBe(false);
+    });
+  });
+
+  describe("$undoDescription computed", () => {
+    it("returns null initially", () => {
+      expect($undoDescription.get()).toBeNull();
+    });
+
+    it("returns description after pushing history", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+      pushHistory("Add paragraph block");
+
+      expect($undoDescription.get()).toBe("Add paragraph block");
+    });
+  });
+
+  describe("$redoDescription computed", () => {
+    it("returns null initially", () => {
+      expect($redoDescription.get()).toBeNull();
+    });
+  });
+
+  describe("$isBatching computed", () => {
+    it("returns false initially", () => {
+      expect($isBatching.get()).toBe(false);
+    });
+  });
+
+  describe("$historySize computed", () => {
+    it("returns 0 initially", () => {
+      expect($historySize.get()).toBe(0);
+    });
+
+    it("increases as history is added", () => {
+      const block1 = createTestBlock("paragraph");
+      insertBlockAction(block1);
+      pushHistory("First");
+
+      expect($historySize.get()).toBe(1);
+
+      const block2 = createTestBlock("heading");
+      insertBlockAction(block2);
+      pushHistory("Second");
+
+      expect($historySize.get()).toBe(2);
+    });
+  });
+
+  describe("$currentHistoryIndex computed", () => {
+    it("returns -1 initially", () => {
+      expect($currentHistoryIndex.get()).toBe(-1);
+    });
+
+    it("returns correct index after pushing history", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+      pushHistory("First");
+
+      expect($currentHistoryIndex.get()).toBe(0);
+    });
+  });
+
+  describe("resetHistoryState", () => {
+    it("resets history to initial state", () => {
+      const block = createTestBlock("paragraph");
+      insertBlockAction(block);
+      pushHistory("First");
+
+      expect($historySize.get()).toBe(1);
+
+      resetHistoryState();
+
+      expect($historySize.get()).toBe(0);
+      expect($currentHistoryIndex.get()).toBe(-1);
+      expect($canUndo.get()).toBe(false);
+    });
+  });
+});

--- a/packages/edit/test/history/types.test.ts
+++ b/packages/edit/test/history/types.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest";
+import {
+  canRedo,
+  canUndo,
+  createHistoryError,
+  createInitialHistoryState,
+  getRedoDescription,
+  getUndoDescription,
+  HISTORY_LIMIT,
+  type HistoryState,
+} from "../../src/history/types";
+
+describe("History Types", () => {
+  describe("HISTORY_LIMIT", () => {
+    it("is set to 100", () => {
+      expect(HISTORY_LIMIT).toBe(100);
+    });
+  });
+
+  describe("createInitialHistoryState", () => {
+    it("creates empty history state", () => {
+      const state = createInitialHistoryState();
+
+      expect(state.baseSnapshot).toBeNull();
+      expect(state.entries).toEqual([]);
+      expect(state.currentIndex).toBe(-1);
+      expect(state.isBatching).toBe(false);
+      expect(state.batchDescription).toBeNull();
+      expect(state.batchStartSnapshot).toBeNull();
+    });
+  });
+
+  describe("createHistoryError", () => {
+    it("creates error with code and message", () => {
+      const error = createHistoryError("NOTHING_TO_UNDO", "No changes to undo");
+
+      expect(error.code).toBe("NOTHING_TO_UNDO");
+      expect(error.message).toBe("No changes to undo");
+      expect(error.cause).toBeUndefined();
+    });
+
+    it("creates error with cause", () => {
+      const cause = new Error("Original error");
+      const error = createHistoryError(
+        "BATCH_ALREADY_ACTIVE",
+        "Batch in progress",
+        cause
+      );
+
+      expect(error.code).toBe("BATCH_ALREADY_ACTIVE");
+      expect(error.message).toBe("Batch in progress");
+      expect(error.cause).toBe(cause);
+    });
+  });
+
+  describe("canUndo", () => {
+    it("returns false when history is empty", () => {
+      const state = createInitialHistoryState();
+      expect(canUndo(state)).toBe(false);
+    });
+
+    it("returns false when currentIndex is -1", () => {
+      const state: HistoryState = {
+        ...createInitialHistoryState(),
+        entries: [
+          {
+            snapshot: { document: {} as never, selection: { blockId: null } },
+            description: "Test",
+            timestamp: new Date(),
+          },
+        ],
+        currentIndex: -1,
+      };
+      expect(canUndo(state)).toBe(false);
+    });
+
+    it("returns true when currentIndex is 0 or greater", () => {
+      const state: HistoryState = {
+        ...createInitialHistoryState(),
+        entries: [
+          {
+            snapshot: { document: {} as never, selection: { blockId: null } },
+            description: "Test",
+            timestamp: new Date(),
+          },
+        ],
+        currentIndex: 0,
+      };
+      expect(canUndo(state)).toBe(true);
+    });
+  });
+
+  describe("canRedo", () => {
+    it("returns false when history is empty", () => {
+      const state = createInitialHistoryState();
+      expect(canRedo(state)).toBe(false);
+    });
+
+    it("returns false when at end of history", () => {
+      const state: HistoryState = {
+        ...createInitialHistoryState(),
+        entries: [
+          {
+            snapshot: { document: {} as never, selection: { blockId: null } },
+            description: "Test",
+            timestamp: new Date(),
+          },
+        ],
+        currentIndex: 0,
+      };
+      expect(canRedo(state)).toBe(false);
+    });
+
+    it("returns true when there are entries after current index", () => {
+      const state: HistoryState = {
+        ...createInitialHistoryState(),
+        entries: [
+          {
+            snapshot: { document: {} as never, selection: { blockId: null } },
+            description: "First",
+            timestamp: new Date(),
+          },
+          {
+            snapshot: { document: {} as never, selection: { blockId: null } },
+            description: "Second",
+            timestamp: new Date(),
+          },
+        ],
+        currentIndex: 0,
+      };
+      expect(canRedo(state)).toBe(true);
+    });
+  });
+
+  describe("getUndoDescription", () => {
+    it("returns null when undo is not available", () => {
+      const state = createInitialHistoryState();
+      expect(getUndoDescription(state)).toBeNull();
+    });
+
+    it("returns description of current entry", () => {
+      const state: HistoryState = {
+        ...createInitialHistoryState(),
+        entries: [
+          {
+            snapshot: { document: {} as never, selection: { blockId: null } },
+            description: "Add block",
+            timestamp: new Date(),
+          },
+        ],
+        currentIndex: 0,
+      };
+      expect(getUndoDescription(state)).toBe("Add block");
+    });
+  });
+
+  describe("getRedoDescription", () => {
+    it("returns null when redo is not available", () => {
+      const state = createInitialHistoryState();
+      expect(getRedoDescription(state)).toBeNull();
+    });
+
+    it("returns description of next entry", () => {
+      const state: HistoryState = {
+        ...createInitialHistoryState(),
+        entries: [
+          {
+            snapshot: { document: {} as never, selection: { blockId: null } },
+            description: "First",
+            timestamp: new Date(),
+          },
+          {
+            snapshot: { document: {} as never, selection: { blockId: null } },
+            description: "Second",
+            timestamp: new Date(),
+          },
+        ],
+        currentIndex: 0,
+      };
+      expect(getRedoDescription(state)).toBe("Second");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Implements PZ-210 (#45): Command history for document changes.

- Ctrl/Cmd+Z undo, Ctrl/Cmd+Shift+Z redo
- 100 step history limit
- Batched changes support
- Toolbar button state atoms

Closes #45

:robot: Generated with [Claude Code](https://claude.com/claude-code)