### PR TITLE
feat(ui): implement Schema Export/Import (PZ-105)

### DIFF
--- a/packages/ui/src/designer/ExportImport.tsx
+++ b/packages/ui/src/designer/ExportImport.tsx
@@ -1,0 +1,626 @@
+/**
+ * Schema Export/Import (PZ-105)
+ *
+ * Export form designs as JSON and import existing schemas.
+ * Features:
+ * - Export canvas state to downloadable JSON file
+ * - Import JSON file and validate before loading
+ * - Version field for future compatibility
+ * - Documented schema format with metadata
+ */
+
+import { z } from "zod";
+import {
+  type ReactNode,
+  useState,
+  useCallback,
+  useMemo,
+  useRef,
+  createContext,
+  useContext,
+} from "react";
+import {
+  CanvasStateSchema,
+  type CanvasState,
+  type CanvasField,
+} from "./types";
+
+// -----------------------------------------------------------------------------
+// Schema Version
+// -----------------------------------------------------------------------------
+
+/**
+ * Current schema version.
+ * Increment when making breaking changes to the schema format.
+ *
+ * Version history:
+ * - 1.0.0: Initial schema format
+ */
+export const SCHEMA_VERSION = "1.0.0";
+
+/**
+ * Minimum supported schema version for import.
+ * Older versions will be rejected.
+ */
+export const MIN_SUPPORTED_VERSION = "1.0.0";
+
+// -----------------------------------------------------------------------------
+// Types
+// -----------------------------------------------------------------------------
+
+/**
+ * Metadata about the exported schema.
+ */
+export interface ExportMetadata {
+  /** When the schema was exported (ISO 8601) */
+  exportedAt: string;
+  /** Optional name of the application that exported the schema */
+  exportedBy?: string;
+  /** Optional description or notes about this export */
+  notes?: string;
+}
+
+/**
+ * The exportable schema format that wraps the canvas state.
+ * This is the JSON structure that gets exported/imported.
+ */
+export interface ExportableSchema {
+  /** Schema format version for compatibility checking */
+  version: string;
+  /** Metadata about this export */
+  metadata: ExportMetadata;
+  /** The form definition (canvas state without UI-specific fields) */
+  form: {
+    /** Form identifier */
+    id: string;
+    /** Form title */
+    title: string;
+    /** Form description */
+    description?: string;
+    /** Ordered list of fields */
+    fields: CanvasField[];
+  };
+}
+
+/**
+ * Result of schema validation.
+ */
+export type SchemaValidationResult =
+  | { valid: true; schema: ExportableSchema }
+  | { valid: false; errors: SchemaValidationError[] };
+
+/**
+ * A validation error with details.
+ */
+export interface SchemaValidationError {
+  /** Error code for programmatic handling */
+  code: "INVALID_JSON" | "INVALID_SCHEMA" | "UNSUPPORTED_VERSION" | "VALIDATION_ERROR";
+  /** Human-readable error message */
+  message: string;
+  /** Optional path to the problematic field */
+  path?: string;
+}
+
+/**
+ * Event emitted when a schema is imported.
+ */
+export interface SchemaImportEvent {
+  /** The imported schema */
+  schema: ExportableSchema;
+  /** The canvas state derived from the schema */
+  canvasState: CanvasState;
+}
+
+/**
+ * Event emitted when import fails.
+ */
+export interface SchemaImportErrorEvent {
+  /** Validation errors */
+  errors: SchemaValidationError[];
+  /** The raw content that failed to import */
+  rawContent?: string;
+}
+
+// -----------------------------------------------------------------------------
+// Zod Schemas for Validation
+// -----------------------------------------------------------------------------
+
+/**
+ * Schema for validating the metadata portion of an export.
+ */
+export const ExportMetadataSchema = z.object({
+  exportedAt: z.string(),
+  exportedBy: z.string().optional(),
+  notes: z.string().optional(),
+});
+
+/**
+ * Schema for validating the form portion of an export.
+ * This is a subset of CanvasState without UI-specific fields.
+ */
+export const ExportedFormSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  description: z.string().optional(),
+  fields: CanvasStateSchema.shape.fields,
+});
+
+/**
+ * Complete schema for validating an exportable schema.
+ */
+export const ExportableSchemaSchema = z.object({
+  version: z.string(),
+  metadata: ExportMetadataSchema,
+  form: ExportedFormSchema,
+});
+
+// -----------------------------------------------------------------------------
+// Version Utilities
+// -----------------------------------------------------------------------------
+
+/**
+ * Parses a semver-like version string into its components.
+ */
+function parseVersion(version: string): { major: number; minor: number; patch: number } | null {
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)$/);
+  if (!match) return null;
+  return {
+    major: parseInt(match[1] as string, 10),
+    minor: parseInt(match[2] as string, 10),
+    patch: parseInt(match[3] as string, 10),
+  };
+}
+
+/**
+ * Compares two version strings.
+ * Returns negative if a < b, positive if a > b, zero if equal.
+ */
+export function compareVersions(a: string, b: string): number {
+  const va = parseVersion(a);
+  const vb = parseVersion(b);
+  if (!va || !vb) return 0;
+
+  if (va.major !== vb.major) return va.major - vb.major;
+  if (va.minor !== vb.minor) return va.minor - vb.minor;
+  return va.patch - vb.patch;
+}
+
+/**
+ * Checks if a version is supported for import.
+ */
+export function isVersionSupported(version: string): boolean {
+  const current = parseVersion(SCHEMA_VERSION);
+  const target = parseVersion(version);
+  const min = parseVersion(MIN_SUPPORTED_VERSION);
+
+  if (!current || !target || !min) return false;
+
+  // Version must be >= minimum and <= current
+  return compareVersions(version, MIN_SUPPORTED_VERSION) >= 0 &&
+         compareVersions(version, SCHEMA_VERSION) <= 0;
+}
+
+// -----------------------------------------------------------------------------
+// Export Functions
+// -----------------------------------------------------------------------------
+
+/**
+ * Converts a canvas state to an exportable schema.
+ *
+ * @param canvasState - The current canvas state
+ * @param options - Optional export options
+ * @returns The exportable schema
+ */
+export function exportSchema(
+  canvasState: CanvasState,
+  options?: {
+    exportedBy?: string;
+    notes?: string;
+  }
+): ExportableSchema {
+  return {
+    version: SCHEMA_VERSION,
+    metadata: {
+      exportedAt: new Date().toISOString(),
+      exportedBy: options?.exportedBy,
+      notes: options?.notes,
+    },
+    form: {
+      id: canvasState.id,
+      title: canvasState.title,
+      description: canvasState.description,
+      fields: canvasState.fields,
+    },
+  };
+}
+
+/**
+ * Converts an exportable schema to a JSON string.
+ *
+ * @param schema - The schema to serialize
+ * @param prettyPrint - Whether to format the JSON with indentation
+ * @returns The JSON string
+ */
+export function serializeSchema(schema: ExportableSchema, prettyPrint = true): string {
+  return JSON.stringify(schema, null, prettyPrint ? 2 : undefined);
+}
+
+/**
+ * Creates a downloadable file from the schema.
+ *
+ * @param schema - The schema to download
+ * @param filename - Optional custom filename
+ */
+export function downloadSchema(schema: ExportableSchema, filename?: string): void {
+  const json = serializeSchema(schema);
+  const blob = new Blob([json], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename ?? `${sanitizeFilename(schema.form.title)}.json`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Sanitizes a string for use as a filename.
+ */
+function sanitizeFilename(name: string): string {
+  return name
+    .replace(/[^a-z0-9]/gi, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .toLowerCase() || "form-schema";
+}
+
+// -----------------------------------------------------------------------------
+// Import/Validation Functions
+// -----------------------------------------------------------------------------
+
+/**
+ * Validates and parses a JSON string into an exportable schema.
+ *
+ * @param jsonString - The JSON string to validate
+ * @returns Validation result with parsed schema or errors
+ */
+export function validateSchema(jsonString: string): SchemaValidationResult {
+  // Step 1: Parse JSON
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonString);
+  } catch (error) {
+    return {
+      valid: false,
+      errors: [{
+        code: "INVALID_JSON",
+        message: error instanceof Error ? error.message : "Invalid JSON format",
+      }],
+    };
+  }
+
+  // Step 2: Validate against Zod schema
+  const result = ExportableSchemaSchema.safeParse(parsed);
+  if (!result.success) {
+    // Zod v4 uses .issues instead of .errors
+    const errors: SchemaValidationError[] = result.error.issues.map((issue) => ({
+      code: "VALIDATION_ERROR" as const,
+      message: issue.message,
+      path: issue.path.join("."),
+    }));
+    return { valid: false, errors };
+  }
+
+  // Step 3: Check version compatibility
+  if (!isVersionSupported(result.data.version)) {
+    return {
+      valid: false,
+      errors: [{
+        code: "UNSUPPORTED_VERSION",
+        message: `Schema version ${result.data.version} is not supported. ` +
+                 `Supported versions: ${MIN_SUPPORTED_VERSION} to ${SCHEMA_VERSION}`,
+      }],
+    };
+  }
+
+  return { valid: true, schema: result.data };
+}
+
+/**
+ * Converts an imported schema to a canvas state.
+ *
+ * @param schema - The validated schema
+ * @returns A canvas state ready for use
+ */
+export function schemaToCanvasState(schema: ExportableSchema): CanvasState {
+  return {
+    id: schema.form.id,
+    title: schema.form.title,
+    description: schema.form.description,
+    fields: schema.form.fields,
+    selectedFieldId: null,
+    isPreviewMode: false,
+  };
+}
+
+/**
+ * Reads a file and returns its content as a string.
+ */
+function readFileAsText(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(new Error("Failed to read file"));
+    reader.readAsText(file);
+  });
+}
+
+// -----------------------------------------------------------------------------
+// Context
+// -----------------------------------------------------------------------------
+
+interface ExportImportContextValue {
+  /** Whether an import operation is in progress */
+  isImporting: boolean;
+  /** Current import errors, if any */
+  importErrors: SchemaValidationError[];
+  /** Export the current canvas state */
+  exportCanvas: () => void;
+  /** Trigger file selection for import */
+  triggerImport: () => void;
+  /** Clear import errors */
+  clearErrors: () => void;
+}
+
+const ExportImportContext = createContext<ExportImportContextValue | null>(null);
+
+/**
+ * Hook to access the ExportImport context.
+ * Must be used within an ExportImport component.
+ */
+export function useExportImport(): ExportImportContextValue {
+  const context = useContext(ExportImportContext);
+  if (!context) {
+    throw new Error("useExportImport must be used within an ExportImport component");
+  }
+  return context;
+}
+
+// -----------------------------------------------------------------------------
+// Icons
+// -----------------------------------------------------------------------------
+
+function ExportIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      aria-hidden="true"
+    >
+      <path d="M8 2v8M4 6l4-4 4 4M2 10v3a1 1 0 001 1h10a1 1 0 001-1v-3" />
+    </svg>
+  );
+}
+
+function ImportIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      aria-hidden="true"
+    >
+      <path d="M8 10V2M4 6l4 4 4-4M2 10v3a1 1 0 001 1h10a1 1 0 001-1v-3" />
+    </svg>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// Component Props
+// -----------------------------------------------------------------------------
+
+export interface ExportImportProps {
+  /** Current canvas state to export */
+  canvasState: CanvasState;
+  /** Callback when a schema is successfully imported */
+  onImport?: (event: SchemaImportEvent) => void;
+  /** Callback when import fails */
+  onImportError?: (event: SchemaImportErrorEvent) => void;
+  /** Callback when export is triggered */
+  onExport?: (schema: ExportableSchema) => void;
+  /** Optional name to include in export metadata */
+  exportedBy?: string;
+  /** Additional class name */
+  className?: string;
+  /** Children to render (e.g., custom layout) */
+  children?: ReactNode;
+}
+
+// -----------------------------------------------------------------------------
+// ExportImport Component
+// -----------------------------------------------------------------------------
+
+/**
+ * ExportImport provides export and import functionality for form schemas.
+ *
+ * Features:
+ * - Export canvas state as downloadable JSON
+ * - Import JSON files with validation
+ * - Version compatibility checking
+ * - Error handling and display
+ */
+export function ExportImport({
+  canvasState,
+  onImport,
+  onImportError,
+  onExport,
+  exportedBy,
+  className,
+  children,
+}: ExportImportProps) {
+  const [isImporting, setIsImporting] = useState(false);
+  const [importErrors, setImportErrors] = useState<SchemaValidationError[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Handle export
+  const handleExport = useCallback(() => {
+    const schema = exportSchema(canvasState, { exportedBy });
+    onExport?.(schema);
+    downloadSchema(schema);
+  }, [canvasState, exportedBy, onExport]);
+
+  // Handle file selection
+  const handleFileSelect = useCallback(
+    async (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      if (!file) return;
+
+      setIsImporting(true);
+      setImportErrors([]);
+
+      try {
+        const content = await readFileAsText(file);
+        const result = validateSchema(content);
+
+        if (result.valid) {
+          const importedCanvasState = schemaToCanvasState(result.schema);
+          onImport?.({
+            schema: result.schema,
+            canvasState: importedCanvasState,
+          });
+        } else {
+          setImportErrors(result.errors);
+          onImportError?.({
+            errors: result.errors,
+            rawContent: content,
+          });
+        }
+      } catch (error) {
+        const errorResult: SchemaValidationError[] = [{
+          code: "INVALID_JSON",
+          message: error instanceof Error ? error.message : "Failed to read file",
+        }];
+        setImportErrors(errorResult);
+        onImportError?.({ errors: errorResult });
+      } finally {
+        setIsImporting(false);
+        // Reset file input to allow re-selecting the same file
+        if (fileInputRef.current) {
+          fileInputRef.current.value = "";
+        }
+      }
+    },
+    [onImport, onImportError]
+  );
+
+  // Trigger file input click
+  const triggerImport = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  // Clear errors
+  const clearErrors = useCallback(() => {
+    setImportErrors([]);
+  }, []);
+
+  // Context value
+  const contextValue = useMemo<ExportImportContextValue>(
+    () => ({
+      isImporting,
+      importErrors,
+      exportCanvas: handleExport,
+      triggerImport,
+      clearErrors,
+    }),
+    [isImporting, importErrors, handleExport, triggerImport, clearErrors]
+  );
+
+  return (
+    <ExportImportContext.Provider value={contextValue}>
+      <div
+        data-testid="export-import"
+        className={className}
+        role="group"
+        aria-label="Export and import form schema"
+      >
+        {/* Hidden file input */}
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".json,application/json"
+          data-testid="import-file-input"
+          onChange={handleFileSelect}
+          style={{ display: "none" }}
+          aria-hidden="true"
+        />
+
+        {children ? (
+          children
+        ) : (
+          <div data-testid="export-import-buttons">
+            <button
+              type="button"
+              data-testid="export-button"
+              onClick={handleExport}
+              aria-label="Export form schema as JSON"
+            >
+              <ExportIcon />
+              <span>Export</span>
+            </button>
+
+            <button
+              type="button"
+              data-testid="import-button"
+              onClick={triggerImport}
+              disabled={isImporting}
+              aria-label="Import form schema from JSON file"
+            >
+              <ImportIcon />
+              <span>{isImporting ? "Importing..." : "Import"}</span>
+            </button>
+          </div>
+        )}
+
+        {/* Error display */}
+        {importErrors.length > 0 && (
+          <div
+            data-testid="import-errors"
+            role="alert"
+            aria-live="polite"
+          >
+            <p data-testid="import-error-title">Import failed:</p>
+            <ul data-testid="import-error-list">
+              {importErrors.map((error, index) => (
+                <li key={index} data-testid={`import-error-${index}`}>
+                  {error.path ? `${error.path}: ` : ""}
+                  {error.message}
+                </li>
+              ))}
+            </ul>
+            <button
+              type="button"
+              data-testid="clear-errors-button"
+              onClick={clearErrors}
+              aria-label="Dismiss import errors"
+            >
+              Dismiss
+            </button>
+          </div>
+        )}
+      </div>
+    </ExportImportContext.Provider>
+  );
+}
+
+// Export sub-components for flexibility
+ExportImport.ExportIcon = ExportIcon;
+ExportImport.ImportIcon = ImportIcon;

--- a/packages/ui/src/designer/index.ts
+++ b/packages/ui/src/designer/index.ts
@@ -82,6 +82,38 @@ export type {
   FormStatus,
 } from "./FormSettings";
 
+// Export/Import component and utilities (PZ-105)
+export {
+  ExportImport,
+  useExportImport,
+  // Export functions
+  exportSchema,
+  serializeSchema,
+  downloadSchema,
+  // Import/validation functions
+  validateSchema,
+  schemaToCanvasState,
+  // Version utilities
+  compareVersions,
+  isVersionSupported,
+  // Schemas
+  ExportMetadataSchema,
+  ExportedFormSchema,
+  ExportableSchemaSchema,
+  // Constants
+  SCHEMA_VERSION,
+  MIN_SUPPORTED_VERSION,
+} from "./ExportImport";
+export type {
+  ExportImportProps,
+  ExportableSchema,
+  ExportMetadata,
+  SchemaValidationResult,
+  SchemaValidationError,
+  SchemaImportEvent,
+  SchemaImportErrorEvent,
+} from "./ExportImport";
+
 // Types and utilities
 export {
   // Schemas for runtime validation

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -45,6 +45,39 @@ export type {
   CanvasAction,
 } from "./designer";
 
+// Schema Export/Import (PZ-105)
+export {
+  ExportImport,
+  useExportImport,
+  // Export functions
+  exportSchema,
+  serializeSchema,
+  downloadSchema,
+  // Import/validation functions
+  validateSchema,
+  schemaToCanvasState,
+  // Version utilities
+  compareVersions,
+  isVersionSupported,
+  // Schemas
+  ExportMetadataSchema,
+  ExportedFormSchema,
+  ExportableSchemaSchema,
+  // Constants
+  SCHEMA_VERSION,
+  MIN_SUPPORTED_VERSION,
+} from "./designer";
+
+export type {
+  ExportImportProps,
+  ExportableSchema,
+  ExportMetadata,
+  SchemaValidationResult,
+  SchemaValidationError,
+  SchemaImportEvent,
+  SchemaImportErrorEvent,
+} from "./designer";
+
 // Placeholder - full designer to be completed in Phase 2
 export function FormDesigner(): never {
   throw new Error("Not implemented - see PZ-100: https://github.com/ezmode-games/phantom-zone/issues/34");

--- a/packages/ui/test/designer/ExportImport.test.ts
+++ b/packages/ui/test/designer/ExportImport.test.ts
@@ -1,0 +1,979 @@
+/**
+ * ExportImport Tests (PZ-105)
+ *
+ * Note: These tests are limited since we use node environment.
+ * Full component testing would require jsdom environment and @testing-library/react.
+ * These tests verify types, exports, validation functions, and basic functionality.
+ */
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import {
+  ExportImport,
+  useExportImport,
+  exportSchema,
+  serializeSchema,
+  validateSchema,
+  schemaToCanvasState,
+  compareVersions,
+  isVersionSupported,
+  ExportMetadataSchema,
+  ExportedFormSchema,
+  ExportableSchemaSchema,
+  SCHEMA_VERSION,
+  MIN_SUPPORTED_VERSION,
+} from "../../src/designer";
+import type {
+  ExportImportProps,
+  ExportableSchema,
+  ExportMetadata,
+  SchemaValidationResult,
+  SchemaValidationError,
+  SchemaImportEvent,
+  SchemaImportErrorEvent,
+} from "../../src/designer";
+import {
+  createEmptyCanvasState,
+  createField,
+  type CanvasState,
+} from "../../src/designer/types";
+
+describe("ExportImport", () => {
+  describe("exports", () => {
+    it("ExportImport is exported as a function", () => {
+      expect(typeof ExportImport).toBe("function");
+    });
+
+    it("useExportImport is exported as a function", () => {
+      expect(typeof useExportImport).toBe("function");
+    });
+
+    it("exportSchema is exported as a function", () => {
+      expect(typeof exportSchema).toBe("function");
+    });
+
+    it("serializeSchema is exported as a function", () => {
+      expect(typeof serializeSchema).toBe("function");
+    });
+
+    it("validateSchema is exported as a function", () => {
+      expect(typeof validateSchema).toBe("function");
+    });
+
+    it("schemaToCanvasState is exported as a function", () => {
+      expect(typeof schemaToCanvasState).toBe("function");
+    });
+
+    it("compareVersions is exported as a function", () => {
+      expect(typeof compareVersions).toBe("function");
+    });
+
+    it("isVersionSupported is exported as a function", () => {
+      expect(typeof isVersionSupported).toBe("function");
+    });
+
+    it("SCHEMA_VERSION is exported as a string", () => {
+      expect(typeof SCHEMA_VERSION).toBe("string");
+      expect(SCHEMA_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
+    });
+
+    it("MIN_SUPPORTED_VERSION is exported as a string", () => {
+      expect(typeof MIN_SUPPORTED_VERSION).toBe("string");
+      expect(MIN_SUPPORTED_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
+    });
+  });
+
+  describe("ExportImport component", () => {
+    it("is a valid React component function", () => {
+      expect(ExportImport.length).toBeGreaterThanOrEqual(0);
+    });
+
+    it("has sub-components attached", () => {
+      expect(ExportImport.ExportIcon).toBeDefined();
+      expect(ExportImport.ImportIcon).toBeDefined();
+    });
+  });
+
+  describe("useExportImport hook", () => {
+    it("is exported as a function", () => {
+      // Note: We cannot test the actual hook behavior in node environment
+      // since React hooks require a React component context.
+      expect(typeof useExportImport).toBe("function");
+    });
+  });
+});
+
+describe("ExportImport Type Tests", () => {
+  it("ExportImportProps interface is correct", () => {
+    const canvasState = createEmptyCanvasState();
+    const props: ExportImportProps = {
+      canvasState,
+      onImport: (event: SchemaImportEvent) => {
+        void event;
+      },
+      onImportError: (event: SchemaImportErrorEvent) => {
+        void event;
+      },
+      onExport: (schema: ExportableSchema) => {
+        void schema;
+      },
+      exportedBy: "Test App",
+      className: "test-class",
+      children: null,
+    };
+
+    expect(props.canvasState).toBeDefined();
+    expect(typeof props.onImport).toBe("function");
+    expect(typeof props.onImportError).toBe("function");
+    expect(typeof props.onExport).toBe("function");
+    expect(props.exportedBy).toBe("Test App");
+    expect(props.className).toBe("test-class");
+  });
+
+  it("ExportImportProps supports minimal configuration", () => {
+    const canvasState = createEmptyCanvasState();
+    const props: ExportImportProps = {
+      canvasState,
+    };
+
+    expect(props.canvasState).toBeDefined();
+    expect(props.onImport).toBeUndefined();
+  });
+
+  it("ExportableSchema type has correct structure", () => {
+    const schema: ExportableSchema = {
+      version: "1.0.0",
+      metadata: {
+        exportedAt: new Date().toISOString(),
+        exportedBy: "Test App",
+        notes: "Test notes",
+      },
+      form: {
+        id: "form-123",
+        title: "Test Form",
+        description: "A test form",
+        fields: [],
+      },
+    };
+
+    expect(schema.version).toBe("1.0.0");
+    expect(schema.metadata.exportedAt).toBeTruthy();
+    expect(schema.metadata.exportedBy).toBe("Test App");
+    expect(schema.form.id).toBe("form-123");
+    expect(schema.form.title).toBe("Test Form");
+  });
+
+  it("ExportMetadata type has correct structure", () => {
+    const metadata: ExportMetadata = {
+      exportedAt: new Date().toISOString(),
+      exportedBy: "Test App",
+      notes: "Some notes",
+    };
+
+    expect(metadata.exportedAt).toBeTruthy();
+    expect(metadata.exportedBy).toBe("Test App");
+    expect(metadata.notes).toBe("Some notes");
+  });
+
+  it("ExportMetadata supports minimal configuration", () => {
+    const metadata: ExportMetadata = {
+      exportedAt: new Date().toISOString(),
+    };
+
+    expect(metadata.exportedAt).toBeTruthy();
+    expect(metadata.exportedBy).toBeUndefined();
+    expect(metadata.notes).toBeUndefined();
+  });
+
+  it("SchemaValidationError type has correct structure", () => {
+    const error: SchemaValidationError = {
+      code: "INVALID_JSON",
+      message: "Unexpected token at position 0",
+      path: "form.fields[0]",
+    };
+
+    expect(error.code).toBe("INVALID_JSON");
+    expect(error.message).toBeTruthy();
+    expect(error.path).toBe("form.fields[0]");
+  });
+
+  it("SchemaValidationResult valid case is correct", () => {
+    const schema: ExportableSchema = {
+      version: "1.0.0",
+      metadata: { exportedAt: new Date().toISOString() },
+      form: { id: "1", title: "Test", fields: [] },
+    };
+    const result: SchemaValidationResult = { valid: true, schema };
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.schema).toBeDefined();
+    }
+  });
+
+  it("SchemaValidationResult invalid case is correct", () => {
+    const result: SchemaValidationResult = {
+      valid: false,
+      errors: [{ code: "INVALID_JSON", message: "Parse error" }],
+    };
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors.length).toBe(1);
+    }
+  });
+
+  it("SchemaImportEvent type has correct structure", () => {
+    const canvasState = createEmptyCanvasState();
+    const schema: ExportableSchema = {
+      version: "1.0.0",
+      metadata: { exportedAt: new Date().toISOString() },
+      form: { id: canvasState.id, title: canvasState.title, fields: [] },
+    };
+    const event: SchemaImportEvent = {
+      schema,
+      canvasState,
+    };
+
+    expect(event.schema).toBeDefined();
+    expect(event.canvasState).toBeDefined();
+  });
+
+  it("SchemaImportErrorEvent type has correct structure", () => {
+    const event: SchemaImportErrorEvent = {
+      errors: [{ code: "INVALID_JSON", message: "Error" }],
+      rawContent: "{ invalid json",
+    };
+
+    expect(event.errors.length).toBe(1);
+    expect(event.rawContent).toBe("{ invalid json");
+  });
+});
+
+describe("Zod Schemas", () => {
+  describe("ExportMetadataSchema", () => {
+    it("validates valid metadata", () => {
+      const metadata = {
+        exportedAt: "2024-01-15T10:30:00.000Z",
+        exportedBy: "Test App",
+        notes: "Some notes",
+      };
+      const result = ExportMetadataSchema.safeParse(metadata);
+      expect(result.success).toBe(true);
+    });
+
+    it("validates metadata with only required fields", () => {
+      const metadata = {
+        exportedAt: "2024-01-15T10:30:00.000Z",
+      };
+      const result = ExportMetadataSchema.safeParse(metadata);
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects metadata without exportedAt", () => {
+      const metadata = {
+        exportedBy: "Test App",
+      };
+      const result = ExportMetadataSchema.safeParse(metadata);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("ExportedFormSchema", () => {
+    it("validates valid form data", () => {
+      const form = {
+        id: "form-123",
+        title: "Test Form",
+        description: "A test form",
+        fields: [],
+      };
+      const result = ExportedFormSchema.safeParse(form);
+      expect(result.success).toBe(true);
+    });
+
+    it("validates form with fields", () => {
+      const form = {
+        id: "form-123",
+        title: "Test Form",
+        fields: [
+          { id: "field-1", inputType: "text", label: "Name" },
+        ],
+      };
+      const result = ExportedFormSchema.safeParse(form);
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects form without id", () => {
+      const form = {
+        title: "Test Form",
+        fields: [],
+      };
+      const result = ExportedFormSchema.safeParse(form);
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects form without title", () => {
+      const form = {
+        id: "form-123",
+        fields: [],
+      };
+      const result = ExportedFormSchema.safeParse(form);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("ExportableSchemaSchema", () => {
+    it("validates complete schema", () => {
+      const schema = {
+        version: "1.0.0",
+        metadata: {
+          exportedAt: "2024-01-15T10:30:00.000Z",
+        },
+        form: {
+          id: "form-123",
+          title: "Test Form",
+          fields: [],
+        },
+      };
+      const result = ExportableSchemaSchema.safeParse(schema);
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects schema without version", () => {
+      const schema = {
+        metadata: {
+          exportedAt: "2024-01-15T10:30:00.000Z",
+        },
+        form: {
+          id: "form-123",
+          title: "Test Form",
+          fields: [],
+        },
+      };
+      const result = ExportableSchemaSchema.safeParse(schema);
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects schema without metadata", () => {
+      const schema = {
+        version: "1.0.0",
+        form: {
+          id: "form-123",
+          title: "Test Form",
+          fields: [],
+        },
+      };
+      const result = ExportableSchemaSchema.safeParse(schema);
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects schema without form", () => {
+      const schema = {
+        version: "1.0.0",
+        metadata: {
+          exportedAt: "2024-01-15T10:30:00.000Z",
+        },
+      };
+      const result = ExportableSchemaSchema.safeParse(schema);
+      expect(result.success).toBe(false);
+    });
+  });
+});
+
+describe("compareVersions", () => {
+  it("returns 0 for equal versions", () => {
+    expect(compareVersions("1.0.0", "1.0.0")).toBe(0);
+    expect(compareVersions("2.3.4", "2.3.4")).toBe(0);
+  });
+
+  it("returns negative when first is less than second", () => {
+    expect(compareVersions("1.0.0", "2.0.0")).toBeLessThan(0);
+    expect(compareVersions("1.0.0", "1.1.0")).toBeLessThan(0);
+    expect(compareVersions("1.0.0", "1.0.1")).toBeLessThan(0);
+  });
+
+  it("returns positive when first is greater than second", () => {
+    expect(compareVersions("2.0.0", "1.0.0")).toBeGreaterThan(0);
+    expect(compareVersions("1.1.0", "1.0.0")).toBeGreaterThan(0);
+    expect(compareVersions("1.0.1", "1.0.0")).toBeGreaterThan(0);
+  });
+
+  it("handles multi-digit version numbers", () => {
+    expect(compareVersions("10.0.0", "9.0.0")).toBeGreaterThan(0);
+    expect(compareVersions("1.10.0", "1.9.0")).toBeGreaterThan(0);
+    expect(compareVersions("1.0.10", "1.0.9")).toBeGreaterThan(0);
+  });
+
+  it("returns 0 for invalid version formats", () => {
+    expect(compareVersions("invalid", "1.0.0")).toBe(0);
+    expect(compareVersions("1.0.0", "invalid")).toBe(0);
+    expect(compareVersions("1.0", "1.0.0")).toBe(0);
+  });
+});
+
+describe("isVersionSupported", () => {
+  it("returns true for current version", () => {
+    expect(isVersionSupported(SCHEMA_VERSION)).toBe(true);
+  });
+
+  it("returns true for minimum supported version", () => {
+    expect(isVersionSupported(MIN_SUPPORTED_VERSION)).toBe(true);
+  });
+
+  it("returns false for version below minimum", () => {
+    // Assuming MIN_SUPPORTED_VERSION is 1.0.0
+    expect(isVersionSupported("0.9.9")).toBe(false);
+  });
+
+  it("returns false for version above current", () => {
+    expect(isVersionSupported("99.0.0")).toBe(false);
+  });
+
+  it("returns false for invalid version format", () => {
+    expect(isVersionSupported("invalid")).toBe(false);
+    expect(isVersionSupported("1.0")).toBe(false);
+    expect(isVersionSupported("v1.0.0")).toBe(false);
+  });
+});
+
+describe("exportSchema", () => {
+  let canvasState: CanvasState;
+
+  beforeEach(() => {
+    canvasState = createEmptyCanvasState();
+    canvasState.title = "Test Form";
+    canvasState.description = "A test description";
+  });
+
+  it("exports canvas state with correct version", () => {
+    const schema = exportSchema(canvasState);
+    expect(schema.version).toBe(SCHEMA_VERSION);
+  });
+
+  it("exports canvas state with metadata", () => {
+    const schema = exportSchema(canvasState);
+    expect(schema.metadata.exportedAt).toBeTruthy();
+    // Verify it's a valid ISO date
+    expect(new Date(schema.metadata.exportedAt).toISOString()).toBe(schema.metadata.exportedAt);
+  });
+
+  it("exports canvas state with custom options", () => {
+    const schema = exportSchema(canvasState, {
+      exportedBy: "Test App",
+      notes: "Test notes",
+    });
+    expect(schema.metadata.exportedBy).toBe("Test App");
+    expect(schema.metadata.notes).toBe("Test notes");
+  });
+
+  it("exports form data correctly", () => {
+    const schema = exportSchema(canvasState);
+    expect(schema.form.id).toBe(canvasState.id);
+    expect(schema.form.title).toBe("Test Form");
+    expect(schema.form.description).toBe("A test description");
+    expect(schema.form.fields).toEqual([]);
+  });
+
+  it("exports fields correctly", () => {
+    const field1 = createField("text", "Name");
+    const field2 = createField("email", "Email");
+    canvasState.fields = [field1, field2];
+
+    const schema = exportSchema(canvasState);
+    expect(schema.form.fields).toHaveLength(2);
+    expect(schema.form.fields[0]).toEqual(field1);
+    expect(schema.form.fields[1]).toEqual(field2);
+  });
+
+  it("does not export UI-specific fields", () => {
+    canvasState.selectedFieldId = "some-id";
+    canvasState.isPreviewMode = true;
+
+    const schema = exportSchema(canvasState);
+    expect(schema.form).not.toHaveProperty("selectedFieldId");
+    expect(schema.form).not.toHaveProperty("isPreviewMode");
+  });
+});
+
+describe("serializeSchema", () => {
+  it("serializes schema to JSON string", () => {
+    const canvasState = createEmptyCanvasState();
+    const schema = exportSchema(canvasState);
+    const json = serializeSchema(schema);
+
+    expect(typeof json).toBe("string");
+    expect(() => JSON.parse(json)).not.toThrow();
+  });
+
+  it("pretty prints by default", () => {
+    const canvasState = createEmptyCanvasState();
+    const schema = exportSchema(canvasState);
+    const json = serializeSchema(schema);
+
+    // Pretty printed JSON has newlines
+    expect(json).toContain("\n");
+    expect(json).toContain("  ");
+  });
+
+  it("can disable pretty printing", () => {
+    const canvasState = createEmptyCanvasState();
+    const schema = exportSchema(canvasState);
+    const json = serializeSchema(schema, false);
+
+    // Minified JSON has no unnecessary whitespace
+    expect(json).not.toContain("\n");
+    expect(json).not.toContain("  ");
+  });
+
+  it("produces valid JSON that parses back to same structure", () => {
+    const canvasState = createEmptyCanvasState();
+    canvasState.title = "Test Form";
+    const field = createField("text", "Name");
+    canvasState.fields = [field];
+
+    const schema = exportSchema(canvasState);
+    const json = serializeSchema(schema);
+    const parsed = JSON.parse(json);
+
+    expect(parsed.version).toBe(schema.version);
+    expect(parsed.form.title).toBe(schema.form.title);
+    expect(parsed.form.fields).toHaveLength(1);
+  });
+});
+
+describe("validateSchema", () => {
+  it("validates valid schema JSON", () => {
+    const canvasState = createEmptyCanvasState();
+    const schema = exportSchema(canvasState);
+    const json = serializeSchema(schema);
+
+    const result = validateSchema(json);
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.schema.version).toBe(SCHEMA_VERSION);
+    }
+  });
+
+  it("returns error for invalid JSON", () => {
+    const result = validateSchema("{ invalid json");
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors[0]?.code).toBe("INVALID_JSON");
+    }
+  });
+
+  it("returns error for empty JSON", () => {
+    const result = validateSchema("{}");
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors[0]?.code).toBe("VALIDATION_ERROR");
+    }
+  });
+
+  it("returns error for missing version", () => {
+    const json = JSON.stringify({
+      metadata: { exportedAt: new Date().toISOString() },
+      form: { id: "1", title: "Test", fields: [] },
+    });
+    const result = validateSchema(json);
+    expect(result.valid).toBe(false);
+  });
+
+  it("returns error for unsupported version", () => {
+    const json = JSON.stringify({
+      version: "99.0.0",
+      metadata: { exportedAt: new Date().toISOString() },
+      form: { id: "1", title: "Test", fields: [] },
+    });
+    const result = validateSchema(json);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors[0]?.code).toBe("UNSUPPORTED_VERSION");
+    }
+  });
+
+  it("returns error for version below minimum", () => {
+    const json = JSON.stringify({
+      version: "0.0.1",
+      metadata: { exportedAt: new Date().toISOString() },
+      form: { id: "1", title: "Test", fields: [] },
+    });
+    const result = validateSchema(json);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors[0]?.code).toBe("UNSUPPORTED_VERSION");
+    }
+  });
+
+  it("defaults missing form fields to empty array", () => {
+    // The schema uses a default value for fields, so missing fields is valid
+    const json = JSON.stringify({
+      version: SCHEMA_VERSION,
+      metadata: { exportedAt: new Date().toISOString() },
+      form: { id: "1", title: "Test" },
+    });
+    const result = validateSchema(json);
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.schema.form.fields).toEqual([]);
+    }
+  });
+
+  it("includes path in validation errors", () => {
+    const json = JSON.stringify({
+      version: SCHEMA_VERSION,
+      metadata: { exportedAt: new Date().toISOString() },
+      form: { id: 123, title: "Test", fields: [] }, // id should be string
+    });
+    const result = validateSchema(json);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      const errorWithPath = result.errors.find((e) => e.path);
+      expect(errorWithPath?.path).toContain("form");
+    }
+  });
+
+  it("validates schema with fields", () => {
+    const canvasState = createEmptyCanvasState();
+    canvasState.fields = [
+      createField("text", "Name"),
+      createField("email", "Email"),
+    ];
+    const schema = exportSchema(canvasState);
+    const json = serializeSchema(schema);
+
+    const result = validateSchema(json);
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.schema.form.fields).toHaveLength(2);
+    }
+  });
+});
+
+describe("schemaToCanvasState", () => {
+  it("converts schema to canvas state", () => {
+    const schema: ExportableSchema = {
+      version: SCHEMA_VERSION,
+      metadata: { exportedAt: new Date().toISOString() },
+      form: {
+        id: "form-123",
+        title: "Test Form",
+        description: "Test description",
+        fields: [],
+      },
+    };
+
+    const state = schemaToCanvasState(schema);
+    expect(state.id).toBe("form-123");
+    expect(state.title).toBe("Test Form");
+    expect(state.description).toBe("Test description");
+    expect(state.fields).toEqual([]);
+  });
+
+  it("sets UI defaults", () => {
+    const schema: ExportableSchema = {
+      version: SCHEMA_VERSION,
+      metadata: { exportedAt: new Date().toISOString() },
+      form: {
+        id: "form-123",
+        title: "Test Form",
+        fields: [],
+      },
+    };
+
+    const state = schemaToCanvasState(schema);
+    expect(state.selectedFieldId).toBeNull();
+    expect(state.isPreviewMode).toBe(false);
+  });
+
+  it("preserves fields", () => {
+    const field = createField("text", "Name");
+    const schema: ExportableSchema = {
+      version: SCHEMA_VERSION,
+      metadata: { exportedAt: new Date().toISOString() },
+      form: {
+        id: "form-123",
+        title: "Test Form",
+        fields: [field],
+      },
+    };
+
+    const state = schemaToCanvasState(schema);
+    expect(state.fields).toHaveLength(1);
+    expect(state.fields[0]).toEqual(field);
+  });
+
+  it("handles missing description", () => {
+    const schema: ExportableSchema = {
+      version: SCHEMA_VERSION,
+      metadata: { exportedAt: new Date().toISOString() },
+      form: {
+        id: "form-123",
+        title: "Test Form",
+        fields: [],
+      },
+    };
+
+    const state = schemaToCanvasState(schema);
+    expect(state.description).toBeUndefined();
+  });
+});
+
+describe("Round-trip Export/Import", () => {
+  it("preserves data through export and import", () => {
+    // Create a canvas state with various data
+    const originalState = createEmptyCanvasState();
+    originalState.title = "My Form";
+    originalState.description = "A comprehensive form";
+    originalState.fields = [
+      createField("text", "Full Name", {
+        placeholder: "Enter your name",
+        required: true,
+        helpText: "Your legal name",
+      }),
+      createField("email", "Email Address", {
+        required: true,
+      }),
+      createField("select", "Country", {
+        options: [
+          { value: "us", label: "United States" },
+          { value: "ca", label: "Canada" },
+        ],
+      }),
+    ];
+
+    // Export
+    const schema = exportSchema(originalState);
+    const json = serializeSchema(schema);
+
+    // Import
+    const validationResult = validateSchema(json);
+    expect(validationResult.valid).toBe(true);
+
+    if (validationResult.valid) {
+      const importedState = schemaToCanvasState(validationResult.schema);
+
+      // Verify data preservation
+      expect(importedState.id).toBe(originalState.id);
+      expect(importedState.title).toBe(originalState.title);
+      expect(importedState.description).toBe(originalState.description);
+      expect(importedState.fields).toHaveLength(3);
+
+      // Check first field
+      expect(importedState.fields[0]?.label).toBe("Full Name");
+      expect(importedState.fields[0]?.placeholder).toBe("Enter your name");
+      expect(importedState.fields[0]?.required).toBe(true);
+      expect(importedState.fields[0]?.helpText).toBe("Your legal name");
+
+      // Check select field options
+      expect(importedState.fields[2]?.options).toHaveLength(2);
+    }
+  });
+
+  it("handles complex field configurations", () => {
+    const originalState = createEmptyCanvasState();
+    originalState.fields = [
+      createField("text", "Field with Rules", {
+        validationRules: [
+          { id: "rule-1", ruleId: "required", config: {} },
+          { id: "rule-2", ruleId: "minLength", config: { value: 5 } },
+        ],
+        config: {
+          customSetting: true,
+          nestedConfig: { value: 42 },
+        },
+      }),
+    ];
+
+    const schema = exportSchema(originalState);
+    const json = serializeSchema(schema);
+    const result = validateSchema(json);
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      const importedState = schemaToCanvasState(result.schema);
+      const field = importedState.fields[0];
+      expect(field?.validationRules).toHaveLength(2);
+      expect(field?.config?.customSetting).toBe(true);
+      expect(field?.config?.nestedConfig?.value).toBe(42);
+    }
+  });
+});
+
+describe("Edge Cases", () => {
+  it("handles empty form title", () => {
+    const state = createEmptyCanvasState();
+    state.title = "";
+
+    const schema = exportSchema(state);
+    expect(schema.form.title).toBe("");
+
+    const json = serializeSchema(schema);
+    const result = validateSchema(json);
+    expect(result.valid).toBe(true);
+  });
+
+  it("handles very long content", () => {
+    const state = createEmptyCanvasState();
+    state.title = "A".repeat(10000);
+    state.description = "B".repeat(50000);
+
+    const schema = exportSchema(state);
+    const json = serializeSchema(schema);
+    const result = validateSchema(json);
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.schema.form.title.length).toBe(10000);
+    }
+  });
+
+  it("handles unicode characters", () => {
+    const state = createEmptyCanvasState();
+    state.title = "Form with Unicode Characters";
+    state.fields = [
+      createField("text", "Name with Unicode"),
+    ];
+
+    const schema = exportSchema(state);
+    const json = serializeSchema(schema);
+    const result = validateSchema(json);
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.schema.form.title).toContain("Unicode");
+    }
+  });
+
+  it("handles special characters in JSON", () => {
+    const state = createEmptyCanvasState();
+    state.title = 'Form with "quotes" and \\backslashes';
+    state.description = "Line1\nLine2\tTab";
+
+    const schema = exportSchema(state);
+    const json = serializeSchema(schema);
+    const result = validateSchema(json);
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.schema.form.title).toContain('"quotes"');
+      expect(result.schema.form.description).toContain("\n");
+    }
+  });
+
+  it("handles many fields", () => {
+    const state = createEmptyCanvasState();
+    state.fields = Array.from({ length: 100 }, (_, i) =>
+      createField("text", `Field ${i + 1}`)
+    );
+
+    const schema = exportSchema(state);
+    const json = serializeSchema(schema);
+    const result = validateSchema(json);
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.schema.form.fields).toHaveLength(100);
+    }
+  });
+});
+
+describe("Schema Format Documentation", () => {
+  it("exported schema follows documented format", () => {
+    const state = createEmptyCanvasState();
+    state.title = "Sample Form";
+    const schema = exportSchema(state);
+
+    // Version is semver format
+    expect(schema.version).toMatch(/^\d+\.\d+\.\d+$/);
+
+    // Metadata has required exportedAt
+    expect(schema.metadata.exportedAt).toBeTruthy();
+
+    // Form has required fields
+    expect(schema.form.id).toBeTruthy();
+    expect(typeof schema.form.title).toBe("string");
+    expect(Array.isArray(schema.form.fields)).toBe(true);
+
+    // Optional fields are present but may be undefined
+    expect("description" in schema.form || schema.form.description === undefined).toBe(true);
+  });
+});
+
+describe("Version Constants", () => {
+  it("SCHEMA_VERSION follows semver format", () => {
+    expect(SCHEMA_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it("MIN_SUPPORTED_VERSION follows semver format", () => {
+    expect(MIN_SUPPORTED_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it("MIN_SUPPORTED_VERSION is less than or equal to SCHEMA_VERSION", () => {
+    expect(compareVersions(MIN_SUPPORTED_VERSION, SCHEMA_VERSION)).toBeLessThanOrEqual(0);
+  });
+});
+
+describe("Integration", () => {
+  it("complete workflow: create form, export, modify, import", () => {
+    // Step 1: Create a form
+    const originalState = createEmptyCanvasState();
+    originalState.title = "Contact Form";
+    originalState.fields = [
+      createField("text", "Name"),
+      createField("email", "Email"),
+    ];
+
+    // Step 2: Export
+    const schema = exportSchema(originalState, {
+      exportedBy: "Test Suite",
+      notes: "Integration test export",
+    });
+
+    expect(schema.metadata.exportedBy).toBe("Test Suite");
+
+    // Step 3: Serialize and simulate file save/load
+    const json = serializeSchema(schema);
+    expect(typeof json).toBe("string");
+
+    // Step 4: Validate import
+    const validation = validateSchema(json);
+    expect(validation.valid).toBe(true);
+
+    if (validation.valid) {
+      // Step 5: Convert to canvas state
+      const importedState = schemaToCanvasState(validation.schema);
+
+      // Step 6: Verify
+      expect(importedState.title).toBe("Contact Form");
+      expect(importedState.fields).toHaveLength(2);
+      expect(importedState.selectedFieldId).toBeNull();
+      expect(importedState.isPreviewMode).toBe(false);
+    }
+  });
+
+  it("handles schema from different (but compatible) version", () => {
+    // Simulate importing from a schema with the current version
+    const json = JSON.stringify({
+      version: SCHEMA_VERSION,
+      metadata: {
+        exportedAt: "2024-01-01T00:00:00.000Z",
+        exportedBy: "Old App Version",
+      },
+      form: {
+        id: "legacy-form",
+        title: "Legacy Form",
+        fields: [
+          { id: "f1", inputType: "text", label: "Legacy Field" },
+        ],
+      },
+    });
+
+    const result = validateSchema(json);
+    expect(result.valid).toBe(true);
+
+    if (result.valid) {
+      const state = schemaToCanvasState(result.schema);
+      expect(state.title).toBe("Legacy Form");
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Implements schema export and import functionality for the form designer
- Export canvas state to downloadable JSON file with versioned format
- Import JSON file with validation before loading
- Schema version 1.0.0 for future compatibility tracking
- ExportImportProvider context for global access
- useExportImport hook for component integration
- Detailed error reporting for import validation failures

## Schema Format
```json
{
  "version": "1.0.0",
  "metadata": {
    "exportedAt": "ISO 8601 timestamp",
    "exportedBy": "Application name",
    "notes": "Optional notes"
  },
  "form": {
    "id": "form-id",
    "title": "Form Title",
    "description": "Optional description",
    "fields": [...]
  }
}
```

## Test plan
- [x] All 372 tests pass in packages/ui
- [x] Export produces valid JSON with correct structure
- [x] Import validates schema version
- [x] Import rejects invalid JSON and schema
- [x] Integration with existing canvas state

Closes #73

Generated with [Claude Code](https://claude.com/claude-code)