### PR TITLE
feat(ui): implement Live Preview (PZ-107)

### DIFF
--- a/packages/ui/src/designer/Preview.tsx
+++ b/packages/ui/src/designer/Preview.tsx
@@ -1,0 +1,1092 @@
+/**
+ * Live Preview (PZ-107)
+ *
+ * Real-time preview of form as applicants will see it.
+ * Features:
+ * - Split view: editor left, preview right
+ * - Preview updates as fields are edited
+ * - Interactive preview (can type in fields)
+ * - Shows validation errors in preview
+ * - Mobile preview toggle (simulate mobile viewport)
+ */
+
+import {
+  type ReactNode,
+  useState,
+  useCallback,
+  useMemo,
+  createContext,
+  useContext,
+  useEffect,
+} from "react";
+import { z } from "zod";
+
+import type { CanvasField, CanvasState } from "./types";
+
+// -----------------------------------------------------------------------------
+// Types
+// -----------------------------------------------------------------------------
+
+/**
+ * Viewport mode for the preview.
+ */
+export type ViewportMode = "desktop" | "mobile";
+
+/**
+ * Validation error for a field in the preview.
+ */
+export interface PreviewFieldError {
+  /** Field ID with the error */
+  fieldId: string;
+  /** Error message */
+  message: string;
+}
+
+/**
+ * Form values being entered in the preview.
+ */
+export type PreviewFormValues = Record<string, unknown>;
+
+/**
+ * Event emitted when a field value changes in the preview.
+ */
+export interface PreviewValueChangeEvent {
+  /** The field ID that changed */
+  fieldId: string;
+  /** The new value */
+  value: unknown;
+}
+
+/**
+ * Event emitted when validation is triggered.
+ */
+export interface PreviewValidationEvent {
+  /** Whether the form is valid */
+  isValid: boolean;
+  /** Validation errors if any */
+  errors: PreviewFieldError[];
+}
+
+// -----------------------------------------------------------------------------
+// Validation Functions
+// -----------------------------------------------------------------------------
+
+/**
+ * Validates a single field value based on field configuration.
+ */
+export function validateFieldValue(
+  field: CanvasField,
+  value: unknown
+): string | null {
+  // Required validation
+  if (field.required) {
+    if (value === undefined || value === null || value === "") {
+      return "This field is required";
+    }
+    if (Array.isArray(value) && value.length === 0) {
+      return "This field is required";
+    }
+  }
+
+  // Skip further validation if empty (and not required)
+  if (value === undefined || value === null || value === "") {
+    return null;
+  }
+
+  // Apply validation rules
+  for (const rule of field.validationRules) {
+    const error = applyValidationRule(field, rule, value);
+    if (error) {
+      return error;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Applies a single validation rule and returns error message if failed.
+ */
+function applyValidationRule(
+  field: CanvasField,
+  rule: { id: string; ruleId: string; config: Record<string, unknown> },
+  value: unknown
+): string | null {
+  const { ruleId, config } = rule;
+
+  switch (ruleId) {
+    case "minLength": {
+      const min = config.min as number | undefined;
+      if (min !== undefined && typeof value === "string" && value.length < min) {
+        return `Must be at least ${min} characters`;
+      }
+      break;
+    }
+
+    case "maxLength": {
+      const max = config.max as number | undefined;
+      if (max !== undefined && typeof value === "string" && value.length > max) {
+        return `Must be at most ${max} characters`;
+      }
+      break;
+    }
+
+    case "pattern": {
+      const pattern = config.pattern as string | undefined;
+      if (pattern && typeof value === "string") {
+        try {
+          const regex = new RegExp(pattern);
+          if (!regex.test(value)) {
+            return config.message as string | undefined ?? "Invalid format";
+          }
+        } catch {
+          // Invalid regex, skip validation
+        }
+      }
+      break;
+    }
+
+    case "email": {
+      if (typeof value === "string" && value) {
+        const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        if (!emailPattern.test(value)) {
+          return "Please enter a valid email address";
+        }
+      }
+      break;
+    }
+
+    case "url": {
+      if (typeof value === "string" && value) {
+        try {
+          const parsed = new URL(value);
+          if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+            return "URL must start with http:// or https://";
+          }
+        } catch {
+          return "Please enter a valid URL";
+        }
+      }
+      break;
+    }
+
+    case "min": {
+      const min = config.min as number | undefined;
+      if (min !== undefined && typeof value === "number" && value < min) {
+        return `Must be at least ${min}`;
+      }
+      break;
+    }
+
+    case "max": {
+      const max = config.max as number | undefined;
+      if (max !== undefined && typeof value === "number" && value > max) {
+        return `Must be at most ${max}`;
+      }
+      break;
+    }
+
+    case "minItems": {
+      const min = config.min as number | undefined;
+      if (min !== undefined && Array.isArray(value) && value.length < min) {
+        return `Select at least ${min} items`;
+      }
+      break;
+    }
+
+    case "maxItems": {
+      const max = config.max as number | undefined;
+      if (max !== undefined && Array.isArray(value) && value.length > max) {
+        return `Select at most ${max} items`;
+      }
+      break;
+    }
+
+    case "integer": {
+      if (typeof value === "number" && !Number.isInteger(value)) {
+        return "Must be a whole number";
+      }
+      break;
+    }
+
+    case "positive": {
+      if (typeof value === "number" && value <= 0) {
+        return "Must be a positive number";
+      }
+      break;
+    }
+
+    case "negative": {
+      if (typeof value === "number" && value >= 0) {
+        return "Must be a negative number";
+      }
+      break;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Validates all fields in the form and returns errors.
+ */
+export function validateForm(
+  fields: CanvasField[],
+  values: PreviewFormValues
+): PreviewFieldError[] {
+  const errors: PreviewFieldError[] = [];
+
+  for (const field of fields) {
+    const value = values[field.id];
+    const error = validateFieldValue(field, value);
+    if (error) {
+      errors.push({ fieldId: field.id, message: error });
+    }
+  }
+
+  return errors;
+}
+
+/**
+ * Gets the initial value for a field based on its type and default value.
+ */
+export function getInitialFieldValue(field: CanvasField): unknown {
+  if (field.defaultValue !== undefined) {
+    return field.defaultValue;
+  }
+
+  switch (field.inputType) {
+    case "checkbox":
+      return false;
+    case "multiselect":
+      return [];
+    case "number":
+      return null;
+    case "date":
+      return null;
+    case "file":
+      return null;
+    default:
+      return "";
+  }
+}
+
+/**
+ * Creates initial form values from canvas fields.
+ */
+export function createInitialFormValues(fields: CanvasField[]): PreviewFormValues {
+  const values: PreviewFormValues = {};
+  for (const field of fields) {
+    values[field.id] = getInitialFieldValue(field);
+  }
+  return values;
+}
+
+// -----------------------------------------------------------------------------
+// Context
+// -----------------------------------------------------------------------------
+
+interface PreviewContextValue {
+  /** Current form state being previewed */
+  canvasState: CanvasState;
+  /** Current form values */
+  values: PreviewFormValues;
+  /** Validation errors */
+  errors: PreviewFieldError[];
+  /** Current viewport mode */
+  viewportMode: ViewportMode;
+  /** Update a field value */
+  onValueChange: (event: PreviewValueChangeEvent) => void;
+  /** Toggle viewport mode */
+  onViewportChange: (mode: ViewportMode) => void;
+  /** Validate the form */
+  onValidate: () => PreviewValidationEvent;
+  /** Reset form values */
+  onReset: () => void;
+  /** Get error for a specific field */
+  getFieldError: (fieldId: string) => string | undefined;
+  /** Check if a field has an error */
+  hasFieldError: (fieldId: string) => boolean;
+}
+
+const PreviewContext = createContext<PreviewContextValue | null>(null);
+
+/**
+ * Hook to access the Preview context.
+ * Must be used within a Preview component.
+ */
+export function usePreview(): PreviewContextValue {
+  const context = useContext(PreviewContext);
+  if (!context) {
+    throw new Error("usePreview must be used within a Preview component");
+  }
+  return context;
+}
+
+// -----------------------------------------------------------------------------
+// Field Input Components
+// -----------------------------------------------------------------------------
+
+interface FieldInputProps {
+  field: CanvasField;
+  value: unknown;
+  onChange: (value: unknown) => void;
+  error?: string;
+  disabled?: boolean;
+}
+
+function TextFieldInput({ field, value, onChange, error, disabled }: FieldInputProps) {
+  const stringValue = value as string ?? "";
+  const inputId = `preview-field-${field.id}`;
+  const errorId = `${inputId}-error`;
+
+  return (
+    <div data-testid={`preview-input-container-${field.id}`}>
+      <input
+        id={inputId}
+        type="text"
+        data-testid={`preview-input-${field.id}`}
+        value={stringValue}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={field.placeholder ?? `Enter ${field.label.toLowerCase()}`}
+        disabled={disabled}
+        aria-invalid={!!error}
+        aria-describedby={error ? errorId : undefined}
+      />
+    </div>
+  );
+}
+
+function TextAreaInput({ field, value, onChange, error, disabled }: FieldInputProps) {
+  const stringValue = value as string ?? "";
+  const inputId = `preview-field-${field.id}`;
+  const errorId = `${inputId}-error`;
+
+  return (
+    <div data-testid={`preview-input-container-${field.id}`}>
+      <textarea
+        id={inputId}
+        data-testid={`preview-input-${field.id}`}
+        value={stringValue}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={field.placeholder ?? `Enter ${field.label.toLowerCase()}`}
+        disabled={disabled}
+        rows={3}
+        aria-invalid={!!error}
+        aria-describedby={error ? errorId : undefined}
+      />
+    </div>
+  );
+}
+
+function NumberFieldInput({ field, value, onChange, error, disabled }: FieldInputProps) {
+  const numberValue = value as number | null ?? "";
+  const inputId = `preview-field-${field.id}`;
+  const errorId = `${inputId}-error`;
+
+  return (
+    <div data-testid={`preview-input-container-${field.id}`}>
+      <input
+        id={inputId}
+        type="number"
+        data-testid={`preview-input-${field.id}`}
+        value={numberValue}
+        onChange={(e) => {
+          const parsed = e.target.value === "" ? null : Number(e.target.value);
+          onChange(parsed);
+        }}
+        placeholder={field.placeholder ?? "Enter a number"}
+        disabled={disabled}
+        aria-invalid={!!error}
+        aria-describedby={error ? errorId : undefined}
+      />
+    </div>
+  );
+}
+
+function CheckboxInput({ field, value, onChange, error, disabled }: FieldInputProps) {
+  const boolValue = value as boolean ?? false;
+  const inputId = `preview-field-${field.id}`;
+  const errorId = `${inputId}-error`;
+
+  return (
+    <div data-testid={`preview-input-container-${field.id}`}>
+      <label htmlFor={inputId} data-testid={`preview-checkbox-label-${field.id}`}>
+        <input
+          id={inputId}
+          type="checkbox"
+          data-testid={`preview-input-${field.id}`}
+          checked={boolValue}
+          onChange={(e) => onChange(e.target.checked)}
+          disabled={disabled}
+          aria-invalid={!!error}
+          aria-describedby={error ? errorId : undefined}
+        />
+        {field.label}
+      </label>
+    </div>
+  );
+}
+
+function SelectInput({ field, value, onChange, error, disabled }: FieldInputProps) {
+  const stringValue = value as string ?? "";
+  const inputId = `preview-field-${field.id}`;
+  const errorId = `${inputId}-error`;
+
+  return (
+    <div data-testid={`preview-input-container-${field.id}`}>
+      <select
+        id={inputId}
+        data-testid={`preview-input-${field.id}`}
+        value={stringValue}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+        aria-invalid={!!error}
+        aria-describedby={error ? errorId : undefined}
+      >
+        <option value="">{field.placeholder ?? "Select an option"}</option>
+        {field.options?.map((option) => (
+          <option key={option.value} value={option.value} disabled={option.disabled}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+function MultiSelectInput({ field, value, onChange, error, disabled }: FieldInputProps) {
+  const arrayValue = value as string[] ?? [];
+  const inputId = `preview-field-${field.id}`;
+  const errorId = `${inputId}-error`;
+
+  const handleChange = useCallback(
+    (optionValue: string, checked: boolean) => {
+      const newValue = checked
+        ? [...arrayValue, optionValue]
+        : arrayValue.filter((v) => v !== optionValue);
+      onChange(newValue);
+    },
+    [arrayValue, onChange]
+  );
+
+  return (
+    <div
+      data-testid={`preview-input-container-${field.id}`}
+      role="group"
+      aria-labelledby={`preview-label-${field.id}`}
+      aria-invalid={!!error}
+      aria-describedby={error ? errorId : undefined}
+    >
+      {field.options?.map((option) => (
+        <label
+          key={option.value}
+          htmlFor={`${inputId}-${option.value}`}
+          data-testid={`preview-option-${field.id}-${option.value}`}
+        >
+          <input
+            id={`${inputId}-${option.value}`}
+            type="checkbox"
+            data-testid={`preview-input-${field.id}-${option.value}`}
+            checked={arrayValue.includes(option.value)}
+            onChange={(e) => handleChange(option.value, e.target.checked)}
+            disabled={disabled || option.disabled}
+          />
+          {option.label}
+        </label>
+      ))}
+    </div>
+  );
+}
+
+function DateInput({ field, value, onChange, error, disabled }: FieldInputProps) {
+  // Convert Date to string format for input
+  let stringValue = "";
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    stringValue = value.toISOString().split("T")[0] ?? "";
+  } else if (typeof value === "string") {
+    stringValue = value;
+  }
+
+  const inputId = `preview-field-${field.id}`;
+  const errorId = `${inputId}-error`;
+
+  return (
+    <div data-testid={`preview-input-container-${field.id}`}>
+      <input
+        id={inputId}
+        type="date"
+        data-testid={`preview-input-${field.id}`}
+        value={stringValue}
+        onChange={(e) => {
+          const dateValue = e.target.value ? new Date(e.target.value) : null;
+          onChange(dateValue);
+        }}
+        disabled={disabled}
+        aria-invalid={!!error}
+        aria-describedby={error ? errorId : undefined}
+      />
+    </div>
+  );
+}
+
+function FileInput({ field, value, onChange, error, disabled }: FieldInputProps) {
+  const inputId = `preview-field-${field.id}`;
+  const errorId = `${inputId}-error`;
+
+  // Get file name(s) for display
+  let displayText = "No file selected";
+  if (value instanceof File) {
+    displayText = value.name;
+  } else if (Array.isArray(value) && value.length > 0) {
+    displayText = `${value.length} file(s) selected`;
+  }
+
+  return (
+    <div data-testid={`preview-input-container-${field.id}`}>
+      <input
+        id={inputId}
+        type="file"
+        data-testid={`preview-input-${field.id}`}
+        onChange={(e) => {
+          const files = e.target.files;
+          if (files && files.length > 0) {
+            onChange(files.length === 1 ? files[0] : Array.from(files));
+          } else {
+            onChange(null);
+          }
+        }}
+        disabled={disabled}
+        multiple={field.config?.multiple as boolean ?? false}
+        aria-invalid={!!error}
+        aria-describedby={error ? errorId : undefined}
+      />
+      <span data-testid={`preview-file-display-${field.id}`}>{displayText}</span>
+    </div>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// FormPreview Component
+// -----------------------------------------------------------------------------
+
+interface FormPreviewFieldProps {
+  field: CanvasField;
+}
+
+function FormPreviewField({ field }: FormPreviewFieldProps) {
+  const { values, errors, onValueChange, getFieldError } = usePreview();
+
+  const value = values[field.id];
+  const error = getFieldError(field.id);
+
+  const handleChange = useCallback(
+    (newValue: unknown) => {
+      onValueChange({ fieldId: field.id, value: newValue });
+    },
+    [field.id, onValueChange]
+  );
+
+  const inputId = `preview-field-${field.id}`;
+  const errorId = `${inputId}-error`;
+  const helpId = `${inputId}-help`;
+
+  const InputComponent = useMemo(() => {
+    switch (field.inputType) {
+      case "textarea":
+        return TextAreaInput;
+      case "number":
+        return NumberFieldInput;
+      case "checkbox":
+        return CheckboxInput;
+      case "select":
+        return SelectInput;
+      case "multiselect":
+        return MultiSelectInput;
+      case "date":
+        return DateInput;
+      case "file":
+        return FileInput;
+      default:
+        return TextFieldInput;
+    }
+  }, [field.inputType]);
+
+  // Checkbox has its own label
+  const showLabel = field.inputType !== "checkbox";
+
+  return (
+    <div data-testid={`preview-field-${field.id}`} data-field-type={field.inputType}>
+      {showLabel && (
+        <label
+          htmlFor={inputId}
+          id={`preview-label-${field.id}`}
+          data-testid={`preview-label-${field.id}`}
+        >
+          {field.label}
+          {field.required && <span aria-hidden="true"> *</span>}
+        </label>
+      )}
+
+      <InputComponent
+        field={field}
+        value={value}
+        onChange={handleChange}
+        error={error}
+      />
+
+      {field.helpText && (
+        <p id={helpId} data-testid={`preview-help-${field.id}`}>
+          {field.helpText}
+        </p>
+      )}
+
+      {error && (
+        <p id={errorId} data-testid={`preview-error-${field.id}`} role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export interface FormPreviewProps {
+  /** Whether to show form header (title/description) */
+  showHeader?: boolean;
+  /** Submit button text */
+  submitButtonText?: string;
+  /** Callback when form is submitted */
+  onSubmit?: (values: PreviewFormValues) => void;
+  /** Additional class name */
+  className?: string;
+}
+
+/**
+ * FormPreview renders the form as users will see it.
+ * This component must be used within a Preview context.
+ */
+export function FormPreview({
+  showHeader = true,
+  submitButtonText = "Submit",
+  onSubmit,
+  className,
+}: FormPreviewProps) {
+  const { canvasState, values, errors, onValidate } = usePreview();
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      const result = onValidate();
+      if (result.isValid) {
+        onSubmit?.(values);
+      }
+    },
+    [onValidate, onSubmit, values]
+  );
+
+  const hasErrors = errors.length > 0;
+
+  return (
+    <form
+      data-testid="form-preview"
+      className={className}
+      onSubmit={handleSubmit}
+      noValidate
+      aria-label="Form preview"
+    >
+      {showHeader && (
+        <header data-testid="preview-form-header">
+          <h2 data-testid="preview-form-title">{canvasState.title}</h2>
+          {canvasState.description && (
+            <p data-testid="preview-form-description">{canvasState.description}</p>
+          )}
+        </header>
+      )}
+
+      <div data-testid="preview-form-fields">
+        {canvasState.fields.map((field) => (
+          <FormPreviewField key={field.id} field={field} />
+        ))}
+      </div>
+
+      {canvasState.fields.length === 0 && (
+        <div data-testid="preview-empty-state" role="status">
+          <p>No fields have been added to this form yet.</p>
+        </div>
+      )}
+
+      {canvasState.fields.length > 0 && (
+        <div data-testid="preview-form-actions">
+          <button
+            type="submit"
+            data-testid="preview-submit-button"
+            aria-disabled={hasErrors}
+          >
+            {submitButtonText}
+          </button>
+        </div>
+      )}
+    </form>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// Viewport Toggle Component
+// -----------------------------------------------------------------------------
+
+interface ViewportToggleProps {
+  mode: ViewportMode;
+  onChange: (mode: ViewportMode) => void;
+}
+
+function ViewportToggle({ mode, onChange }: ViewportToggleProps) {
+  return (
+    <div data-testid="viewport-toggle" role="group" aria-label="Viewport mode">
+      <button
+        type="button"
+        data-testid="viewport-desktop"
+        onClick={() => onChange("desktop")}
+        aria-pressed={mode === "desktop"}
+        aria-label="Desktop view"
+      >
+        <DesktopIcon />
+        Desktop
+      </button>
+      <button
+        type="button"
+        data-testid="viewport-mobile"
+        onClick={() => onChange("mobile")}
+        aria-pressed={mode === "mobile"}
+        aria-label="Mobile view"
+      >
+        <MobileIcon />
+        Mobile
+      </button>
+    </div>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// Icons
+// -----------------------------------------------------------------------------
+
+function DesktopIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      aria-hidden="true"
+    >
+      <rect x="1" y="2" width="14" height="9" rx="1" />
+      <path d="M5 14h6M8 11v3" />
+    </svg>
+  );
+}
+
+function MobileIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      aria-hidden="true"
+    >
+      <rect x="3" y="1" width="10" height="14" rx="2" />
+      <path d="M7 12h2" />
+    </svg>
+  );
+}
+
+function RefreshIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      aria-hidden="true"
+    >
+      <path d="M13.5 8a5.5 5.5 0 1 1-1.5-3.75M13.5 2v2.25h-2.5" />
+    </svg>
+  );
+}
+
+function SplitIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      aria-hidden="true"
+    >
+      <rect x="1" y="2" width="14" height="12" rx="1" />
+      <path d="M8 2v12" />
+    </svg>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// Preview Component
+// -----------------------------------------------------------------------------
+
+/**
+ * Mobile viewport width in pixels.
+ */
+export const MOBILE_VIEWPORT_WIDTH = 375;
+
+/**
+ * Desktop viewport width in pixels.
+ */
+export const DESKTOP_VIEWPORT_WIDTH = 1024;
+
+export interface PreviewProps {
+  /** The canvas state to preview */
+  canvasState: CanvasState;
+  /** Initial form values (optional) */
+  initialValues?: PreviewFormValues;
+  /** Initial viewport mode (defaults to desktop) */
+  initialViewportMode?: ViewportMode;
+  /** Whether to validate on change (defaults to false) */
+  validateOnChange?: boolean;
+  /** Callback when form values change */
+  onValuesChange?: (values: PreviewFormValues) => void;
+  /** Callback when validation state changes */
+  onValidationChange?: (event: PreviewValidationEvent) => void;
+  /** Custom content to render in the editor area (left side) */
+  editorContent?: ReactNode;
+  /** Whether to show split view (defaults to true) */
+  showSplitView?: boolean;
+  /** Additional class name */
+  className?: string;
+  /** Children to render (optional header content) */
+  children?: ReactNode;
+}
+
+/**
+ * Preview provides a real-time preview of the form as applicants will see it.
+ *
+ * Features:
+ * - Split view: editor left, preview right
+ * - Preview updates as fields are edited
+ * - Interactive preview (can type in fields)
+ * - Shows validation errors in preview
+ * - Mobile preview toggle (simulate mobile viewport)
+ */
+export function Preview({
+  canvasState,
+  initialValues,
+  initialViewportMode = "desktop",
+  validateOnChange = false,
+  onValuesChange,
+  onValidationChange,
+  editorContent,
+  showSplitView = true,
+  className,
+  children,
+}: PreviewProps) {
+  // Form values state
+  const [values, setValues] = useState<PreviewFormValues>(() =>
+    initialValues ?? createInitialFormValues(canvasState.fields)
+  );
+
+  // Validation errors state
+  const [errors, setErrors] = useState<PreviewFieldError[]>([]);
+
+  // Viewport mode state
+  const [viewportMode, setViewportMode] = useState<ViewportMode>(initialViewportMode);
+
+  // Sync values when canvas fields change
+  useEffect(() => {
+    setValues((prev) => {
+      const newValues = createInitialFormValues(canvasState.fields);
+      // Preserve existing values for fields that still exist
+      for (const field of canvasState.fields) {
+        if (prev[field.id] !== undefined) {
+          newValues[field.id] = prev[field.id];
+        }
+      }
+      return newValues;
+    });
+  }, [canvasState.fields]);
+
+  // Handle value change
+  const handleValueChange = useCallback(
+    (event: PreviewValueChangeEvent) => {
+      setValues((prev) => {
+        const newValues = { ...prev, [event.fieldId]: event.value };
+        onValuesChange?.(newValues);
+        return newValues;
+      });
+
+      // Validate on change if enabled
+      if (validateOnChange) {
+        setErrors((prev) => {
+          const field = canvasState.fields.find((f) => f.id === event.fieldId);
+          if (!field) return prev;
+
+          const error = validateFieldValue(field, event.value);
+          const filtered = prev.filter((e) => e.fieldId !== event.fieldId);
+
+          if (error) {
+            const newErrors = [...filtered, { fieldId: event.fieldId, message: error }];
+            onValidationChange?.({ isValid: newErrors.length === 0, errors: newErrors });
+            return newErrors;
+          }
+
+          onValidationChange?.({ isValid: filtered.length === 0, errors: filtered });
+          return filtered;
+        });
+      }
+    },
+    [canvasState.fields, validateOnChange, onValuesChange, onValidationChange]
+  );
+
+  // Handle viewport change
+  const handleViewportChange = useCallback((mode: ViewportMode) => {
+    setViewportMode(mode);
+  }, []);
+
+  // Validate form
+  const handleValidate = useCallback((): PreviewValidationEvent => {
+    const validationErrors = validateForm(canvasState.fields, values);
+    setErrors(validationErrors);
+    const event = {
+      isValid: validationErrors.length === 0,
+      errors: validationErrors,
+    };
+    onValidationChange?.(event);
+    return event;
+  }, [canvasState.fields, values, onValidationChange]);
+
+  // Reset form values
+  const handleReset = useCallback(() => {
+    const newValues = createInitialFormValues(canvasState.fields);
+    setValues(newValues);
+    setErrors([]);
+    onValuesChange?.(newValues);
+    onValidationChange?.({ isValid: true, errors: [] });
+  }, [canvasState.fields, onValuesChange, onValidationChange]);
+
+  // Get error for a specific field
+  const getFieldError = useCallback(
+    (fieldId: string): string | undefined => {
+      return errors.find((e) => e.fieldId === fieldId)?.message;
+    },
+    [errors]
+  );
+
+  // Check if a field has an error
+  const hasFieldError = useCallback(
+    (fieldId: string): boolean => {
+      return errors.some((e) => e.fieldId === fieldId);
+    },
+    [errors]
+  );
+
+  // Context value
+  const contextValue = useMemo<PreviewContextValue>(
+    () => ({
+      canvasState,
+      values,
+      errors,
+      viewportMode,
+      onValueChange: handleValueChange,
+      onViewportChange: handleViewportChange,
+      onValidate: handleValidate,
+      onReset: handleReset,
+      getFieldError,
+      hasFieldError,
+    }),
+    [
+      canvasState,
+      values,
+      errors,
+      viewportMode,
+      handleValueChange,
+      handleViewportChange,
+      handleValidate,
+      handleReset,
+      getFieldError,
+      hasFieldError,
+    ]
+  );
+
+  // Viewport styles
+  const previewStyles = useMemo(() => {
+    if (viewportMode === "mobile") {
+      return {
+        maxWidth: `${MOBILE_VIEWPORT_WIDTH}px`,
+        margin: "0 auto",
+      };
+    }
+    return {};
+  }, [viewportMode]);
+
+  return (
+    <PreviewContext.Provider value={contextValue}>
+      <div
+        data-testid="preview-container"
+        data-viewport={viewportMode}
+        data-split-view={showSplitView}
+        className={className}
+        role="region"
+        aria-label="Form preview"
+      >
+        {/* Header with controls */}
+        <header data-testid="preview-header">
+          {children}
+          <div data-testid="preview-controls">
+            <ViewportToggle mode={viewportMode} onChange={handleViewportChange} />
+            <button
+              type="button"
+              data-testid="preview-reset-button"
+              onClick={handleReset}
+              aria-label="Reset form"
+            >
+              <RefreshIcon />
+              Reset
+            </button>
+          </div>
+        </header>
+
+        {/* Main content area */}
+        <div data-testid="preview-content">
+          {showSplitView && editorContent && (
+            <div data-testid="preview-editor-pane" role="region" aria-label="Editor">
+              {editorContent}
+            </div>
+          )}
+
+          <div
+            data-testid="preview-preview-pane"
+            role="region"
+            aria-label="Preview"
+            style={previewStyles}
+          >
+            <FormPreview />
+          </div>
+        </div>
+      </div>
+    </PreviewContext.Provider>
+  );
+}
+
+// Export sub-components for flexibility
+Preview.FormPreview = FormPreview;
+Preview.ViewportToggle = ViewportToggle;
+Preview.DesktopIcon = DesktopIcon;
+Preview.MobileIcon = MobileIcon;
+Preview.RefreshIcon = RefreshIcon;
+Preview.SplitIcon = SplitIcon;

--- a/packages/ui/src/designer/index.ts
+++ b/packages/ui/src/designer/index.ts
@@ -114,6 +114,31 @@ export type {
   SchemaImportErrorEvent,
 } from "./ExportImport";
 
+// Live Preview component and hook (PZ-107)
+export {
+  Preview,
+  usePreview,
+  FormPreview,
+  // Validation functions
+  validateFieldValue,
+  validateForm,
+  getInitialFieldValue,
+  createInitialFormValues,
+  // Constants
+  MOBILE_VIEWPORT_WIDTH,
+  DESKTOP_VIEWPORT_WIDTH,
+} from "./Preview";
+export type {
+  PreviewProps,
+  FormPreviewProps,
+  ViewportMode,
+  PreviewFieldError,
+  PreviewFormValues,
+  PreviewValueChangeEvent,
+  PreviewValidationEvent,
+} from "./Preview";
+
+
 // Form Templates component and utilities (PZ-106)
 export {
   TemplateSelector,

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -78,6 +78,32 @@ export type {
   SchemaImportErrorEvent,
 } from "./designer";
 
+// Live Preview (PZ-107)
+export {
+  Preview,
+  usePreview,
+  FormPreview,
+  // Validation functions
+  validateFieldValue,
+  validateForm,
+  getInitialFieldValue,
+  createInitialFormValues,
+  // Constants
+  MOBILE_VIEWPORT_WIDTH,
+  DESKTOP_VIEWPORT_WIDTH,
+} from "./designer";
+
+export type {
+  PreviewProps,
+  FormPreviewProps,
+  ViewportMode,
+  PreviewFieldError,
+  PreviewFormValues,
+  PreviewValueChangeEvent,
+  PreviewValidationEvent,
+} from "./designer";
+
+
 // Form Templates (PZ-106)
 export {
   TemplateSelector,

--- a/packages/ui/test/designer/Preview.test.ts
+++ b/packages/ui/test/designer/Preview.test.ts
@@ -1,0 +1,824 @@
+/**
+ * Preview Tests (PZ-107)
+ *
+ * Note: These tests are limited since we use node environment.
+ * Full component testing would require jsdom environment and @testing-library/react.
+ * These tests verify types, exports, validation functions, and basic functionality.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  Preview,
+  usePreview,
+  FormPreview,
+  validateFieldValue,
+  validateForm,
+  getInitialFieldValue,
+  createInitialFormValues,
+  MOBILE_VIEWPORT_WIDTH,
+  DESKTOP_VIEWPORT_WIDTH,
+  createEmptyCanvasState,
+  createField,
+} from "../../src/designer";
+import type {
+  PreviewProps,
+  FormPreviewProps,
+  ViewportMode,
+  PreviewFieldError,
+  PreviewFormValues,
+  PreviewValueChangeEvent,
+  PreviewValidationEvent,
+  CanvasField,
+  CanvasState,
+} from "../../src/designer";
+
+describe("Preview", () => {
+  describe("exports", () => {
+    it("Preview is exported as a function", () => {
+      expect(typeof Preview).toBe("function");
+    });
+
+    it("usePreview is exported as a function", () => {
+      expect(typeof usePreview).toBe("function");
+    });
+
+    it("FormPreview is exported as a function", () => {
+      expect(typeof FormPreview).toBe("function");
+    });
+
+    it("validateFieldValue is exported as a function", () => {
+      expect(typeof validateFieldValue).toBe("function");
+    });
+
+    it("validateForm is exported as a function", () => {
+      expect(typeof validateForm).toBe("function");
+    });
+
+    it("getInitialFieldValue is exported as a function", () => {
+      expect(typeof getInitialFieldValue).toBe("function");
+    });
+
+    it("createInitialFormValues is exported as a function", () => {
+      expect(typeof createInitialFormValues).toBe("function");
+    });
+
+    it("MOBILE_VIEWPORT_WIDTH is exported as a number", () => {
+      expect(typeof MOBILE_VIEWPORT_WIDTH).toBe("number");
+      expect(MOBILE_VIEWPORT_WIDTH).toBe(375);
+    });
+
+    it("DESKTOP_VIEWPORT_WIDTH is exported as a number", () => {
+      expect(typeof DESKTOP_VIEWPORT_WIDTH).toBe("number");
+      expect(DESKTOP_VIEWPORT_WIDTH).toBe(1024);
+    });
+  });
+
+  describe("Preview component", () => {
+    it("is a valid React component function", () => {
+      expect(Preview.length).toBeGreaterThanOrEqual(0);
+    });
+
+    it("has sub-components attached", () => {
+      expect(Preview.FormPreview).toBeDefined();
+      expect(Preview.ViewportToggle).toBeDefined();
+      expect(Preview.DesktopIcon).toBeDefined();
+      expect(Preview.MobileIcon).toBeDefined();
+      expect(Preview.RefreshIcon).toBeDefined();
+      expect(Preview.SplitIcon).toBeDefined();
+    });
+  });
+
+  describe("usePreview hook", () => {
+    it("is exported as a function", () => {
+      // Note: We cannot test the actual hook behavior in node environment
+      // since React hooks require a React component context.
+      expect(typeof usePreview).toBe("function");
+    });
+  });
+});
+
+describe("Preview Type Tests", () => {
+  it("PreviewProps interface is correct", () => {
+    const canvasState = createEmptyCanvasState();
+    const props: PreviewProps = {
+      canvasState,
+      initialValues: {},
+      initialViewportMode: "desktop",
+      validateOnChange: true,
+      onValuesChange: (values: PreviewFormValues) => {
+        void values;
+      },
+      onValidationChange: (event: PreviewValidationEvent) => {
+        void event;
+      },
+      editorContent: null,
+      showSplitView: true,
+      className: "test-class",
+      children: null,
+    };
+
+    expect(props.canvasState).toBeDefined();
+    expect(props.initialViewportMode).toBe("desktop");
+    expect(props.validateOnChange).toBe(true);
+    expect(props.showSplitView).toBe(true);
+    expect(props.className).toBe("test-class");
+  });
+
+  it("PreviewProps supports minimal configuration", () => {
+    const canvasState = createEmptyCanvasState();
+    const props: PreviewProps = {
+      canvasState,
+    };
+
+    expect(props.canvasState).toBeDefined();
+    expect(props.initialValues).toBeUndefined();
+    expect(props.onValuesChange).toBeUndefined();
+  });
+
+  it("FormPreviewProps interface is correct", () => {
+    const props: FormPreviewProps = {
+      showHeader: true,
+      submitButtonText: "Submit",
+      onSubmit: (values: PreviewFormValues) => {
+        void values;
+      },
+      className: "test-class",
+    };
+
+    expect(props.showHeader).toBe(true);
+    expect(props.submitButtonText).toBe("Submit");
+    expect(typeof props.onSubmit).toBe("function");
+    expect(props.className).toBe("test-class");
+  });
+
+  it("ViewportMode type accepts valid values", () => {
+    const desktop: ViewportMode = "desktop";
+    const mobile: ViewportMode = "mobile";
+
+    expect(desktop).toBe("desktop");
+    expect(mobile).toBe("mobile");
+  });
+
+  it("PreviewFieldError type has correct structure", () => {
+    const error: PreviewFieldError = {
+      fieldId: "field-1",
+      message: "This field is required",
+    };
+
+    expect(error.fieldId).toBe("field-1");
+    expect(error.message).toBe("This field is required");
+  });
+
+  it("PreviewFormValues type accepts any field values", () => {
+    const values: PreviewFormValues = {
+      name: "John",
+      age: 30,
+      active: true,
+      tags: ["a", "b"],
+      date: new Date(),
+      file: null,
+    };
+
+    expect(values.name).toBe("John");
+    expect(values.age).toBe(30);
+    expect(values.active).toBe(true);
+  });
+
+  it("PreviewValueChangeEvent type has correct structure", () => {
+    const event: PreviewValueChangeEvent = {
+      fieldId: "field-1",
+      value: "new value",
+    };
+
+    expect(event.fieldId).toBe("field-1");
+    expect(event.value).toBe("new value");
+  });
+
+  it("PreviewValidationEvent type has correct structure", () => {
+    const event: PreviewValidationEvent = {
+      isValid: false,
+      errors: [{ fieldId: "field-1", message: "Required" }],
+    };
+
+    expect(event.isValid).toBe(false);
+    expect(event.errors).toHaveLength(1);
+    expect(event.errors[0]?.fieldId).toBe("field-1");
+  });
+});
+
+describe("validateFieldValue", () => {
+  describe("required validation", () => {
+    it("returns error for empty required field", () => {
+      const field = createField("text", "Name", { required: true });
+      expect(validateFieldValue(field, "")).toBe("This field is required");
+      expect(validateFieldValue(field, null)).toBe("This field is required");
+      expect(validateFieldValue(field, undefined)).toBe("This field is required");
+    });
+
+    it("returns error for empty required array field", () => {
+      const field = createField("multiselect", "Tags", {
+        required: true,
+        options: [{ value: "a", label: "A" }],
+      });
+      expect(validateFieldValue(field, [])).toBe("This field is required");
+    });
+
+    it("returns null for non-required empty field", () => {
+      const field = createField("text", "Name", { required: false });
+      expect(validateFieldValue(field, "")).toBeNull();
+      expect(validateFieldValue(field, null)).toBeNull();
+    });
+
+    it("returns null for valid required field", () => {
+      const field = createField("text", "Name", { required: true });
+      expect(validateFieldValue(field, "John")).toBeNull();
+    });
+  });
+
+  describe("minLength validation", () => {
+    it("returns error when value is too short", () => {
+      const field = createField("text", "Name", {
+        validationRules: [{ id: "rule-1", ruleId: "minLength", config: { min: 5 } }],
+      });
+      expect(validateFieldValue(field, "Hi")).toBe("Must be at least 5 characters");
+    });
+
+    it("returns null when value meets minimum length", () => {
+      const field = createField("text", "Name", {
+        validationRules: [{ id: "rule-1", ruleId: "minLength", config: { min: 3 } }],
+      });
+      expect(validateFieldValue(field, "Hello")).toBeNull();
+    });
+  });
+
+  describe("maxLength validation", () => {
+    it("returns error when value is too long", () => {
+      const field = createField("text", "Name", {
+        validationRules: [{ id: "rule-1", ruleId: "maxLength", config: { max: 5 } }],
+      });
+      expect(validateFieldValue(field, "Hello World")).toBe("Must be at most 5 characters");
+    });
+
+    it("returns null when value meets maximum length", () => {
+      const field = createField("text", "Name", {
+        validationRules: [{ id: "rule-1", ruleId: "maxLength", config: { max: 10 } }],
+      });
+      expect(validateFieldValue(field, "Hello")).toBeNull();
+    });
+  });
+
+  describe("email validation", () => {
+    it("returns error for invalid email", () => {
+      const field = createField("text", "Email", {
+        validationRules: [{ id: "rule-1", ruleId: "email", config: {} }],
+      });
+      expect(validateFieldValue(field, "invalid")).toBe("Please enter a valid email address");
+      expect(validateFieldValue(field, "test@")).toBe("Please enter a valid email address");
+      expect(validateFieldValue(field, "@example.com")).toBe("Please enter a valid email address");
+    });
+
+    it("returns null for valid email", () => {
+      const field = createField("text", "Email", {
+        validationRules: [{ id: "rule-1", ruleId: "email", config: {} }],
+      });
+      expect(validateFieldValue(field, "test@example.com")).toBeNull();
+      expect(validateFieldValue(field, "user+tag@domain.co.uk")).toBeNull();
+    });
+  });
+
+  describe("url validation", () => {
+    it("returns error for invalid URL", () => {
+      const field = createField("text", "Website", {
+        validationRules: [{ id: "rule-1", ruleId: "url", config: {} }],
+      });
+      expect(validateFieldValue(field, "invalid")).toBe("Please enter a valid URL");
+      expect(validateFieldValue(field, "example.com")).toBe("Please enter a valid URL");
+    });
+
+    it("returns error for non-http protocol", () => {
+      const field = createField("text", "Website", {
+        validationRules: [{ id: "rule-1", ruleId: "url", config: {} }],
+      });
+      expect(validateFieldValue(field, "ftp://example.com")).toBe("URL must start with http:// or https://");
+    });
+
+    it("returns null for valid URL", () => {
+      const field = createField("text", "Website", {
+        validationRules: [{ id: "rule-1", ruleId: "url", config: {} }],
+      });
+      expect(validateFieldValue(field, "https://example.com")).toBeNull();
+      expect(validateFieldValue(field, "http://example.com/path")).toBeNull();
+    });
+  });
+
+  describe("pattern validation", () => {
+    it("returns error when pattern does not match", () => {
+      const field = createField("text", "Code", {
+        validationRules: [
+          { id: "rule-1", ruleId: "pattern", config: { pattern: "^[A-Z]{3}$" } },
+        ],
+      });
+      expect(validateFieldValue(field, "ab")).toBe("Invalid format");
+    });
+
+    it("returns custom message when pattern does not match", () => {
+      const field = createField("text", "Code", {
+        validationRules: [
+          {
+            id: "rule-1",
+            ruleId: "pattern",
+            config: { pattern: "^[A-Z]{3}$", message: "Must be 3 uppercase letters" },
+          },
+        ],
+      });
+      expect(validateFieldValue(field, "ab")).toBe("Must be 3 uppercase letters");
+    });
+
+    it("returns null when pattern matches", () => {
+      const field = createField("text", "Code", {
+        validationRules: [
+          { id: "rule-1", ruleId: "pattern", config: { pattern: "^[A-Z]{3}$" } },
+        ],
+      });
+      expect(validateFieldValue(field, "ABC")).toBeNull();
+    });
+  });
+
+  describe("min/max number validation", () => {
+    it("returns error when number is below minimum", () => {
+      const field = createField("number", "Age", {
+        validationRules: [{ id: "rule-1", ruleId: "min", config: { min: 18 } }],
+      });
+      expect(validateFieldValue(field, 15)).toBe("Must be at least 18");
+    });
+
+    it("returns error when number is above maximum", () => {
+      const field = createField("number", "Age", {
+        validationRules: [{ id: "rule-1", ruleId: "max", config: { max: 100 } }],
+      });
+      expect(validateFieldValue(field, 150)).toBe("Must be at most 100");
+    });
+
+    it("returns null for valid number range", () => {
+      const field = createField("number", "Age", {
+        validationRules: [
+          { id: "rule-1", ruleId: "min", config: { min: 18 } },
+          { id: "rule-2", ruleId: "max", config: { max: 100 } },
+        ],
+      });
+      expect(validateFieldValue(field, 25)).toBeNull();
+    });
+  });
+
+  describe("minItems/maxItems validation", () => {
+    it("returns error when array has too few items", () => {
+      const field = createField("multiselect", "Tags", {
+        validationRules: [{ id: "rule-1", ruleId: "minItems", config: { min: 2 } }],
+      });
+      expect(validateFieldValue(field, ["one"])).toBe("Select at least 2 items");
+    });
+
+    it("returns error when array has too many items", () => {
+      const field = createField("multiselect", "Tags", {
+        validationRules: [{ id: "rule-1", ruleId: "maxItems", config: { max: 3 } }],
+      });
+      expect(validateFieldValue(field, ["a", "b", "c", "d"])).toBe("Select at most 3 items");
+    });
+
+    it("returns null for valid array length", () => {
+      const field = createField("multiselect", "Tags", {
+        validationRules: [
+          { id: "rule-1", ruleId: "minItems", config: { min: 1 } },
+          { id: "rule-2", ruleId: "maxItems", config: { max: 5 } },
+        ],
+      });
+      expect(validateFieldValue(field, ["a", "b"])).toBeNull();
+    });
+  });
+
+  describe("integer validation", () => {
+    it("returns error for non-integer number", () => {
+      const field = createField("number", "Count", {
+        validationRules: [{ id: "rule-1", ruleId: "integer", config: {} }],
+      });
+      expect(validateFieldValue(field, 3.5)).toBe("Must be a whole number");
+    });
+
+    it("returns null for integer number", () => {
+      const field = createField("number", "Count", {
+        validationRules: [{ id: "rule-1", ruleId: "integer", config: {} }],
+      });
+      expect(validateFieldValue(field, 5)).toBeNull();
+    });
+  });
+
+  describe("positive/negative validation", () => {
+    it("returns error for non-positive number", () => {
+      const field = createField("number", "Amount", {
+        validationRules: [{ id: "rule-1", ruleId: "positive", config: {} }],
+      });
+      expect(validateFieldValue(field, 0)).toBe("Must be a positive number");
+      expect(validateFieldValue(field, -5)).toBe("Must be a positive number");
+    });
+
+    it("returns error for non-negative number", () => {
+      const field = createField("number", "Adjustment", {
+        validationRules: [{ id: "rule-1", ruleId: "negative", config: {} }],
+      });
+      expect(validateFieldValue(field, 0)).toBe("Must be a negative number");
+      expect(validateFieldValue(field, 5)).toBe("Must be a negative number");
+    });
+
+    it("returns null for valid positive/negative numbers", () => {
+      const positiveField = createField("number", "Amount", {
+        validationRules: [{ id: "rule-1", ruleId: "positive", config: {} }],
+      });
+      expect(validateFieldValue(positiveField, 10)).toBeNull();
+
+      const negativeField = createField("number", "Adjustment", {
+        validationRules: [{ id: "rule-1", ruleId: "negative", config: {} }],
+      });
+      expect(validateFieldValue(negativeField, -10)).toBeNull();
+    });
+  });
+
+  describe("multiple validation rules", () => {
+    it("applies all rules and returns first error", () => {
+      const field = createField("text", "Name", {
+        required: true,
+        validationRules: [
+          { id: "rule-1", ruleId: "minLength", config: { min: 3 } },
+          { id: "rule-2", ruleId: "maxLength", config: { max: 10 } },
+        ],
+      });
+
+      // Required check fails first
+      expect(validateFieldValue(field, "")).toBe("This field is required");
+      // Min length fails
+      expect(validateFieldValue(field, "Hi")).toBe("Must be at least 3 characters");
+      // Max length fails
+      expect(validateFieldValue(field, "Hello World!")).toBe("Must be at most 10 characters");
+      // Valid
+      expect(validateFieldValue(field, "Hello")).toBeNull();
+    });
+  });
+});
+
+describe("validateForm", () => {
+  it("returns empty array for valid form", () => {
+    const fields = [
+      createField("text", "Name", { required: true }),
+      createField("text", "Email", {
+        validationRules: [{ id: "rule-1", ruleId: "email", config: {} }],
+      }),
+    ];
+    const values = {
+      [fields[0]!.id]: "John",
+      [fields[1]!.id]: "john@example.com",
+    };
+
+    const errors = validateForm(fields, values);
+    expect(errors).toEqual([]);
+  });
+
+  it("returns errors for invalid fields", () => {
+    const fields = [
+      createField("text", "Name", { required: true }),
+      createField("text", "Email", {
+        validationRules: [{ id: "rule-1", ruleId: "email", config: {} }],
+      }),
+    ];
+    const values = {
+      [fields[0]!.id]: "",
+      [fields[1]!.id]: "invalid-email",
+    };
+
+    const errors = validateForm(fields, values);
+    expect(errors).toHaveLength(2);
+    expect(errors.map((e) => e.fieldId)).toContain(fields[0]!.id);
+    expect(errors.map((e) => e.fieldId)).toContain(fields[1]!.id);
+  });
+
+  it("returns empty array for empty form", () => {
+    const errors = validateForm([], {});
+    expect(errors).toEqual([]);
+  });
+});
+
+describe("getInitialFieldValue", () => {
+  it("returns default value if provided", () => {
+    const field = createField("text", "Name", { defaultValue: "Default" });
+    expect(getInitialFieldValue(field)).toBe("Default");
+  });
+
+  it("returns false for checkbox", () => {
+    const field = createField("checkbox", "Accept");
+    expect(getInitialFieldValue(field)).toBe(false);
+  });
+
+  it("returns empty array for multiselect", () => {
+    const field = createField("multiselect", "Tags");
+    expect(getInitialFieldValue(field)).toEqual([]);
+  });
+
+  it("returns null for number", () => {
+    const field = createField("number", "Age");
+    expect(getInitialFieldValue(field)).toBeNull();
+  });
+
+  it("returns null for date", () => {
+    const field = createField("date", "Birthday");
+    expect(getInitialFieldValue(field)).toBeNull();
+  });
+
+  it("returns null for file", () => {
+    const field = createField("file", "Document");
+    expect(getInitialFieldValue(field)).toBeNull();
+  });
+
+  it("returns empty string for text fields", () => {
+    const textField = createField("text", "Name");
+    expect(getInitialFieldValue(textField)).toBe("");
+
+    const textareaField = createField("textarea", "Description");
+    expect(getInitialFieldValue(textareaField)).toBe("");
+  });
+});
+
+describe("createInitialFormValues", () => {
+  it("creates values for all fields", () => {
+    const fields = [
+      createField("text", "Name"),
+      createField("checkbox", "Accept"),
+      createField("number", "Age"),
+    ];
+
+    const values = createInitialFormValues(fields);
+
+    expect(Object.keys(values)).toHaveLength(3);
+    expect(values[fields[0]!.id]).toBe("");
+    expect(values[fields[1]!.id]).toBe(false);
+    expect(values[fields[2]!.id]).toBeNull();
+  });
+
+  it("uses default values when provided", () => {
+    const fields = [
+      createField("text", "Name", { defaultValue: "John" }),
+      createField("checkbox", "Accept", { defaultValue: true }),
+    ];
+
+    const values = createInitialFormValues(fields);
+
+    expect(values[fields[0]!.id]).toBe("John");
+    expect(values[fields[1]!.id]).toBe(true);
+  });
+
+  it("returns empty object for empty fields array", () => {
+    const values = createInitialFormValues([]);
+    expect(values).toEqual({});
+  });
+});
+
+describe("Preview Integration", () => {
+  describe("complete workflow", () => {
+    it("supports full form preview workflow", () => {
+      // 1. Create canvas state with fields
+      const state = createEmptyCanvasState();
+      const nameField = createField("text", "Name", { required: true });
+      const emailField = createField("text", "Email", {
+        validationRules: [{ id: "rule-1", ruleId: "email", config: {} }],
+      });
+
+      const canvasState: CanvasState = {
+        ...state,
+        fields: [nameField, emailField],
+      };
+
+      // 2. Create initial form values
+      const values = createInitialFormValues(canvasState.fields);
+      expect(values[nameField.id]).toBe("");
+      expect(values[emailField.id]).toBe("");
+
+      // 3. Simulate user input
+      values[nameField.id] = "John Doe";
+      values[emailField.id] = "john@example.com";
+
+      // 4. Validate form
+      const errors = validateForm(canvasState.fields, values);
+      expect(errors).toEqual([]);
+    });
+
+    it("detects validation errors in workflow", () => {
+      // Create form with required fields
+      const state = createEmptyCanvasState();
+      const nameField = createField("text", "Name", { required: true });
+      const ageField = createField("number", "Age", {
+        validationRules: [
+          { id: "rule-1", ruleId: "min", config: { min: 18 } },
+        ],
+      });
+
+      const canvasState: CanvasState = {
+        ...state,
+        fields: [nameField, ageField],
+      };
+
+      // User submits with errors
+      const values: PreviewFormValues = {
+        [nameField.id]: "", // Empty required field
+        [ageField.id]: 15, // Below minimum
+      };
+
+      const errors = validateForm(canvasState.fields, values);
+      expect(errors).toHaveLength(2);
+
+      const nameError = errors.find((e) => e.fieldId === nameField.id);
+      expect(nameError?.message).toBe("This field is required");
+
+      const ageError = errors.find((e) => e.fieldId === ageField.id);
+      expect(ageError?.message).toBe("Must be at least 18");
+    });
+  });
+
+  describe("viewport modes", () => {
+    it("supports desktop and mobile viewport modes", () => {
+      const desktopMode: ViewportMode = "desktop";
+      const mobileMode: ViewportMode = "mobile";
+
+      expect(desktopMode).toBe("desktop");
+      expect(mobileMode).toBe("mobile");
+    });
+
+    it("has correct viewport widths", () => {
+      expect(MOBILE_VIEWPORT_WIDTH).toBe(375);
+      expect(DESKTOP_VIEWPORT_WIDTH).toBe(1024);
+    });
+  });
+
+  describe("event handling", () => {
+    it("PreviewValueChangeEvent captures field changes", () => {
+      const event: PreviewValueChangeEvent = {
+        fieldId: "field-123",
+        value: "new value",
+      };
+
+      expect(event.fieldId).toBe("field-123");
+      expect(event.value).toBe("new value");
+    });
+
+    it("PreviewValidationEvent reports validation state", () => {
+      const validEvent: PreviewValidationEvent = {
+        isValid: true,
+        errors: [],
+      };
+
+      const invalidEvent: PreviewValidationEvent = {
+        isValid: false,
+        errors: [
+          { fieldId: "field-1", message: "Required" },
+          { fieldId: "field-2", message: "Invalid email" },
+        ],
+      };
+
+      expect(validEvent.isValid).toBe(true);
+      expect(validEvent.errors).toHaveLength(0);
+
+      expect(invalidEvent.isValid).toBe(false);
+      expect(invalidEvent.errors).toHaveLength(2);
+    });
+  });
+});
+
+describe("Preview Edge Cases", () => {
+  it("handles fields with no validation rules", () => {
+    const field = createField("text", "Name");
+    expect(validateFieldValue(field, "Any value")).toBeNull();
+    expect(validateFieldValue(field, "")).toBeNull();
+  });
+
+  it("handles unknown validation rule gracefully", () => {
+    const field = createField("text", "Name", {
+      validationRules: [{ id: "rule-1", ruleId: "unknownRule" as never, config: {} }],
+    });
+    // Should not throw, just return null (unknown rule is skipped)
+    expect(validateFieldValue(field, "value")).toBeNull();
+  });
+
+  it("handles invalid regex pattern gracefully", () => {
+    const field = createField("text", "Code", {
+      validationRules: [
+        { id: "rule-1", ruleId: "pattern", config: { pattern: "[invalid(" } },
+      ],
+    });
+    // Should not throw, just skip the invalid regex
+    expect(validateFieldValue(field, "any value")).toBeNull();
+  });
+
+  it("handles very long string values", () => {
+    const longString = "a".repeat(10000);
+    const field = createField("text", "Content", {
+      validationRules: [{ id: "rule-1", ruleId: "maxLength", config: { max: 5000 } }],
+    });
+    expect(validateFieldValue(field, longString)).toBe("Must be at most 5000 characters");
+  });
+
+  it("handles special characters in values", () => {
+    const field = createField("text", "Name", {
+      validationRules: [{ id: "rule-1", ruleId: "minLength", config: { min: 2 } }],
+    });
+    expect(validateFieldValue(field, "!@#$%")).toBeNull();
+  });
+
+  it("handles undefined config values gracefully", () => {
+    const field = createField("text", "Name", {
+      validationRules: [{ id: "rule-1", ruleId: "minLength", config: {} }],
+    });
+    // Should not throw when min is undefined
+    expect(validateFieldValue(field, "Hi")).toBeNull();
+  });
+});
+
+describe("Preview All Field Types", () => {
+  const fieldTypes = [
+    "text",
+    "textarea",
+    "number",
+    "checkbox",
+    "select",
+    "multiselect",
+    "date",
+    "file",
+  ] as const;
+
+  it("creates initial values for all field types", () => {
+    for (const fieldType of fieldTypes) {
+      const field = createField(fieldType, `${fieldType} field`);
+      const value = getInitialFieldValue(field);
+      expect(value).toBeDefined();
+    }
+  });
+
+  it("validates required for all field types", () => {
+    for (const fieldType of fieldTypes) {
+      const field = createField(fieldType, `${fieldType} field`, { required: true });
+
+      // Empty/null values should fail required validation
+      const emptyValue = fieldType === "checkbox" ? false :
+                         fieldType === "multiselect" ? [] : "";
+
+      // Checkbox with false is considered "not required" in many form systems
+      // but our validation treats empty string/null/undefined/empty array as required errors
+      if (fieldType !== "checkbox") {
+        const error = validateFieldValue(field, emptyValue);
+        expect(error).toBe("This field is required");
+      }
+    }
+  });
+});
+
+describe("Preview Props Variations", () => {
+  it("supports props with custom submit button text", () => {
+    const props: FormPreviewProps = {
+      submitButtonText: "Send Application",
+    };
+    expect(props.submitButtonText).toBe("Send Application");
+  });
+
+  it("supports props without header", () => {
+    const props: FormPreviewProps = {
+      showHeader: false,
+    };
+    expect(props.showHeader).toBe(false);
+  });
+
+  it("supports full PreviewProps configuration", () => {
+    const canvasState = createEmptyCanvasState();
+
+    let capturedValues: PreviewFormValues | null = null;
+    let capturedValidation: PreviewValidationEvent | null = null;
+
+    const props: PreviewProps = {
+      canvasState,
+      initialValues: { "field-1": "initial" },
+      initialViewportMode: "mobile",
+      validateOnChange: true,
+      onValuesChange: (values) => {
+        capturedValues = values;
+      },
+      onValidationChange: (event) => {
+        capturedValidation = event;
+      },
+      showSplitView: false,
+      className: "custom-preview",
+    };
+
+    // Simulate callbacks
+    props.onValuesChange?.({ "field-1": "updated" });
+    props.onValidationChange?.({ isValid: true, errors: [] });
+
+    expect(capturedValues).toEqual({ "field-1": "updated" });
+    expect(capturedValidation).toEqual({ isValid: true, errors: [] });
+    expect(props.initialViewportMode).toBe("mobile");
+    expect(props.showSplitView).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Implement real-time preview of form as applicants will see it
- Add split view with editor on left, preview on right
- Create interactive preview where users can type in fields
- Show validation errors in preview
- Add mobile preview toggle to simulate mobile viewport (375px width)

## Features
- [x] Split view: editor left, preview right
- [x] Preview updates as fields are edited
- [x] Interactive preview (can type in fields)
- [x] Shows validation errors in preview
- [x] Mobile preview toggle (simulate mobile viewport)

## Technical Details
- `Preview` component provides context for preview state management
- `FormPreview` renders the form as users will see it
- `ViewportToggle` switches between desktop and mobile views
- Comprehensive field validation supporting all rules (required, minLength, maxLength, email, url, pattern, min, max, minItems, maxItems, integer, positive, negative)
- Support for all field types (text, textarea, number, checkbox, select, multiselect, date, file)

## Test plan
- [x] All 78 new tests pass
- [x] All existing 425 tests continue to pass
- [x] TypeScript type check passes
- [ ] Manual testing of preview functionality in browser

Closes #39

---
Generated with [Claude Code](https://claude.com/claude-code)