### PR TITLE
feat(ui): implement Form Templates (PZ-106)

### DIFF
--- a/packages/ui/src/designer/index.ts
+++ b/packages/ui/src/designer/index.ts
@@ -114,6 +114,46 @@ export type {
   SchemaImportErrorEvent,
 } from "./ExportImport";
 
+// Form Templates component and utilities (PZ-106)
+export {
+  TemplateSelector,
+  useTemplateSelector,
+  // Built-in templates
+  generalApplicationTemplate,
+  raidRecruitmentTemplate,
+  casualJoinTemplate,
+  builtInTemplates,
+  getBuiltInTemplate,
+  getBuiltInTemplatesByCategory,
+  // Registry
+  createInMemoryStorage,
+  createLocalStorage,
+  createTemplateRegistry,
+  createInMemoryRegistry,
+  createLocalStorageRegistry,
+  getDefaultRegistry,
+  resetDefaultRegistry,
+  // Apply functions
+  templateFieldToCanvasField,
+  applyTemplate,
+  canvasStateToTemplate,
+  mergeTemplateIntoCanvas,
+  validateTemplate,
+} from "./templates";
+export type {
+  TemplateSelectorProps,
+  TemplateCategory,
+  TemplateMetadata,
+  FormTemplate,
+  TemplateField,
+  TemplateSelectEvent,
+  TemplateSaveEvent,
+  TemplateDeleteEvent,
+  TemplateApplyResult,
+  TemplateStorage,
+  TemplateRegistry,
+} from "./templates";
+
 // Types and utilities
 export {
   // Schemas for runtime validation

--- a/packages/ui/src/designer/templates/TemplateSelector.tsx
+++ b/packages/ui/src/designer/templates/TemplateSelector.tsx
@@ -1,0 +1,807 @@
+/**
+ * Template Selector Component (PZ-106)
+ *
+ * UI for browsing and selecting form templates.
+ * Features:
+ * - "Start from template" option in form designer
+ * - Template preview before selection
+ * - Editable after selection (loads into canvas state)
+ * - Custom template management (save/delete)
+ */
+
+import {
+  type ReactNode,
+  useState,
+  useCallback,
+  useMemo,
+  useEffect,
+  createContext,
+  useContext,
+} from "react";
+import type { CanvasState } from "../types";
+import { applyTemplate, canvasStateToTemplate } from "./apply";
+import { builtInTemplates } from "./builtin";
+import { getDefaultRegistry, createInMemoryRegistry } from "./registry";
+import type {
+  FormTemplate,
+  TemplateCategory,
+  TemplateRegistry,
+  TemplateSelectEvent,
+  TemplateSaveEvent,
+  TemplateDeleteEvent,
+  TemplateApplyResult,
+} from "./types";
+
+// -----------------------------------------------------------------------------
+// Context
+// -----------------------------------------------------------------------------
+
+interface TemplateSelectorContextValue {
+  /** All available templates (built-in + custom) */
+  templates: FormTemplate[];
+  /** Currently selected template for preview */
+  previewTemplate: FormTemplate | null;
+  /** Whether templates are loading */
+  isLoading: boolean;
+  /** Current filter category */
+  filterCategory: TemplateCategory | "all";
+  /** Search query */
+  searchQuery: string;
+  /** Filtered templates based on category and search */
+  filteredTemplates: FormTemplate[];
+  /** Set the preview template */
+  setPreviewTemplate: (template: FormTemplate | null) => void;
+  /** Set the filter category */
+  setFilterCategory: (category: TemplateCategory | "all") => void;
+  /** Set the search query */
+  setSearchQuery: (query: string) => void;
+  /** Apply a template */
+  applyTemplate: (template: FormTemplate) => TemplateApplyResult;
+  /** Save current form as custom template */
+  saveAsTemplate: (
+    canvasState: CanvasState,
+    metadata: { name: string; description: string; category: TemplateCategory; icon: string }
+  ) => Promise<FormTemplate>;
+  /** Delete a custom template */
+  deleteTemplate: (templateId: string) => Promise<boolean>;
+  /** Refresh templates from registry */
+  refresh: () => Promise<void>;
+}
+
+const TemplateSelectorContext = createContext<TemplateSelectorContextValue | null>(null);
+
+/**
+ * Hook to access the TemplateSelector context.
+ * Must be used within a TemplateSelector component.
+ */
+export function useTemplateSelector(): TemplateSelectorContextValue {
+  const context = useContext(TemplateSelectorContext);
+  if (!context) {
+    throw new Error("useTemplateSelector must be used within a TemplateSelector component");
+  }
+  return context;
+}
+
+// -----------------------------------------------------------------------------
+// Icon Components
+// -----------------------------------------------------------------------------
+
+function TemplateIcon() {
+  return (
+    <svg
+      width="48"
+      height="48"
+      viewBox="0 0 48 48"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      aria-hidden="true"
+    >
+      <rect x="8" y="8" width="32" height="32" rx="2" />
+      <line x1="16" y1="16" x2="32" y2="16" />
+      <line x1="16" y1="24" x2="28" y2="24" />
+      <line x1="16" y1="32" x2="24" y2="32" />
+    </svg>
+  );
+}
+
+function SearchIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      aria-hidden="true"
+    >
+      <circle cx="7" cy="7" r="4" />
+      <line x1="10" y1="10" x2="14" y2="14" />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      aria-hidden="true"
+    >
+      <polyline points="2,8 6,12 14,4" />
+    </svg>
+  );
+}
+
+function TrashIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      aria-hidden="true"
+    >
+      <path d="M2 4h12" />
+      <path d="M5 4V2h6v2" />
+      <path d="M3 4v10a1 1 0 001 1h8a1 1 0 001-1V4" />
+    </svg>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// Sub-Components
+// -----------------------------------------------------------------------------
+
+interface CategoryFilterProps {
+  value: TemplateCategory | "all";
+  onChange: (category: TemplateCategory | "all") => void;
+}
+
+function CategoryFilter({ value, onChange }: CategoryFilterProps) {
+  const categories: Array<{ value: TemplateCategory | "all"; label: string }> = [
+    { value: "all", label: "All Templates" },
+    { value: "guild", label: "Guild" },
+    { value: "recruitment", label: "Recruitment" },
+    { value: "social", label: "Social" },
+    { value: "custom", label: "My Templates" },
+  ];
+
+  return (
+    <div data-testid="category-filter" role="group" aria-label="Filter by category">
+      {categories.map((cat) => (
+        <button
+          key={cat.value}
+          type="button"
+          data-testid={`category-${cat.value}`}
+          onClick={() => onChange(cat.value)}
+          aria-pressed={value === cat.value}
+        >
+          {cat.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+interface SearchInputProps {
+  value: string;
+  onChange: (query: string) => void;
+}
+
+function SearchInput({ value, onChange }: SearchInputProps) {
+  return (
+    <div data-testid="search-container">
+      <SearchIcon />
+      <input
+        type="search"
+        data-testid="template-search"
+        placeholder="Search templates..."
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        aria-label="Search templates"
+      />
+    </div>
+  );
+}
+
+interface TemplateCardProps {
+  template: FormTemplate;
+  isSelected: boolean;
+  onSelect: () => void;
+  onApply: () => void;
+  onDelete?: () => void;
+}
+
+function TemplateCard({ template, isSelected, onSelect, onApply, onDelete }: TemplateCardProps) {
+  return (
+    <article
+      data-testid={`template-card-${template.metadata.id}`}
+      aria-selected={isSelected}
+      onClick={onSelect}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onSelect();
+        }
+      }}
+      tabIndex={0}
+      role="option"
+    >
+      <header data-testid="template-card-header">
+        <h3 data-testid="template-name">{template.metadata.name}</h3>
+        {template.metadata.isBuiltIn && (
+          <span data-testid="builtin-badge" aria-label="Built-in template">
+            Built-in
+          </span>
+        )}
+      </header>
+      <p data-testid="template-description">{template.metadata.description}</p>
+      <footer data-testid="template-card-footer">
+        <span data-testid="field-count">{template.fields.length} fields</span>
+        <span data-testid="template-category">{template.metadata.category}</span>
+      </footer>
+      <div data-testid="template-actions">
+        <button
+          type="button"
+          data-testid="apply-template-btn"
+          onClick={(e) => {
+            e.stopPropagation();
+            onApply();
+          }}
+          aria-label={`Use ${template.metadata.name} template`}
+        >
+          <CheckIcon />
+          Use Template
+        </button>
+        {!template.metadata.isBuiltIn && onDelete && (
+          <button
+            type="button"
+            data-testid="delete-template-btn"
+            onClick={(e) => {
+              e.stopPropagation();
+              onDelete();
+            }}
+            aria-label={`Delete ${template.metadata.name} template`}
+          >
+            <TrashIcon />
+          </button>
+        )}
+      </div>
+    </article>
+  );
+}
+
+interface TemplatePreviewProps {
+  template: FormTemplate;
+  onApply: () => void;
+  onClose: () => void;
+}
+
+function TemplatePreview({ template, onApply, onClose }: TemplatePreviewProps) {
+  return (
+    <aside
+      data-testid="template-preview"
+      role="dialog"
+      aria-label={`Preview of ${template.metadata.name}`}
+    >
+      <header data-testid="preview-header">
+        <h2 data-testid="preview-title">{template.metadata.name}</h2>
+        <button
+          type="button"
+          data-testid="close-preview-btn"
+          onClick={onClose}
+          aria-label="Close preview"
+        >
+          Close
+        </button>
+      </header>
+
+      <div data-testid="preview-content">
+        <p data-testid="preview-description">{template.metadata.description}</p>
+
+        <section data-testid="preview-form" aria-label="Form preview">
+          <h3 data-testid="preview-form-title">{template.title}</h3>
+          {template.description && (
+            <p data-testid="preview-form-description">{template.description}</p>
+          )}
+
+          <ul data-testid="preview-fields" aria-label="Form fields">
+            {template.fields.map((field, index) => (
+              <li key={index} data-testid={`preview-field-${index}`}>
+                <span data-testid="field-label">
+                  {field.label}
+                  {field.required && <span aria-label="required"> *</span>}
+                </span>
+                <span data-testid="field-type">{field.inputType}</span>
+                {field.helpText && (
+                  <span data-testid="field-help">{field.helpText}</span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
+
+      <footer data-testid="preview-footer">
+        <button
+          type="button"
+          data-testid="apply-from-preview-btn"
+          onClick={onApply}
+        >
+          Use This Template
+        </button>
+      </footer>
+    </aside>
+  );
+}
+
+interface EmptyStateProps {
+  hasSearch: boolean;
+  category: TemplateCategory | "all";
+}
+
+function EmptyState({ hasSearch, category }: EmptyStateProps) {
+  const message = hasSearch
+    ? "No templates match your search."
+    : category === "custom"
+    ? "You haven't saved any custom templates yet."
+    : "No templates available in this category.";
+
+  return (
+    <div data-testid="empty-state" role="status">
+      <TemplateIcon />
+      <p>{message}</p>
+      {category === "custom" && !hasSearch && (
+        <p data-testid="empty-hint">
+          Create a form and save it as a template to reuse later.
+        </p>
+      )}
+    </div>
+  );
+}
+
+interface TemplateGridProps {
+  templates: FormTemplate[];
+  previewTemplate: FormTemplate | null;
+  onSelectPreview: (template: FormTemplate) => void;
+  onApply: (template: FormTemplate) => void;
+  onDelete: (templateId: string) => void;
+  hasSearch: boolean;
+  category: TemplateCategory | "all";
+}
+
+function TemplateGrid({
+  templates,
+  previewTemplate,
+  onSelectPreview,
+  onApply,
+  onDelete,
+  hasSearch,
+  category,
+}: TemplateGridProps) {
+  if (templates.length === 0) {
+    return <EmptyState hasSearch={hasSearch} category={category} />;
+  }
+
+  return (
+    <div
+      data-testid="template-grid"
+      role="listbox"
+      aria-label="Available templates"
+    >
+      {templates.map((template) => (
+        <TemplateCard
+          key={template.metadata.id}
+          template={template}
+          isSelected={previewTemplate?.metadata.id === template.metadata.id}
+          onSelect={() => onSelectPreview(template)}
+          onApply={() => onApply(template)}
+          onDelete={
+            template.metadata.isBuiltIn
+              ? undefined
+              : () => onDelete(template.metadata.id)
+          }
+        />
+      ))}
+    </div>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// Save Template Dialog
+// -----------------------------------------------------------------------------
+
+interface SaveTemplateDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (metadata: {
+    name: string;
+    description: string;
+    category: TemplateCategory;
+    icon: string;
+  }) => void;
+}
+
+function SaveTemplateDialog({ isOpen, onClose, onSave }: SaveTemplateDialogProps) {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [category, setCategory] = useState<TemplateCategory>("custom");
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      if (!name.trim()) return;
+
+      onSave({
+        name: name.trim(),
+        description: description.trim(),
+        category,
+        icon: "file-plus",
+      });
+
+      // Reset form
+      setName("");
+      setDescription("");
+      setCategory("custom");
+      onClose();
+    },
+    [name, description, category, onSave, onClose]
+  );
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      data-testid="save-template-dialog"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="save-dialog-title"
+    >
+      <form onSubmit={handleSubmit}>
+        <h2 id="save-dialog-title" data-testid="save-dialog-title">
+          Save as Template
+        </h2>
+
+        <div data-testid="save-form-fields">
+          <label htmlFor="template-name">Template Name *</label>
+          <input
+            id="template-name"
+            type="text"
+            data-testid="template-name-input"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="My Custom Template"
+            required
+            aria-required="true"
+          />
+
+          <label htmlFor="template-description">Description</label>
+          <textarea
+            id="template-description"
+            data-testid="template-description-input"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Describe what this template is for..."
+            rows={3}
+          />
+
+          <label htmlFor="template-category">Category</label>
+          <select
+            id="template-category"
+            data-testid="template-category-select"
+            value={category}
+            onChange={(e) => setCategory(e.target.value as TemplateCategory)}
+          >
+            <option value="guild">Guild</option>
+            <option value="recruitment">Recruitment</option>
+            <option value="social">Social</option>
+            <option value="custom">Custom</option>
+          </select>
+        </div>
+
+        <div data-testid="save-dialog-actions">
+          <button
+            type="button"
+            data-testid="cancel-save-btn"
+            onClick={onClose}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            data-testid="confirm-save-btn"
+            disabled={!name.trim()}
+          >
+            Save Template
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// Main Component
+// -----------------------------------------------------------------------------
+
+export interface TemplateSelectorProps {
+  /** Template registry to use (defaults to localStorage-backed registry) */
+  registry?: TemplateRegistry;
+  /** Callback when a template is applied */
+  onApply?: (result: TemplateApplyResult) => void;
+  /** Callback when a template is saved */
+  onSave?: (template: FormTemplate) => void;
+  /** Callback when a template is deleted */
+  onDelete?: (templateId: string) => void;
+  /** Current canvas state (for saving as template) */
+  canvasState?: CanvasState;
+  /** Whether to show the save as template option */
+  showSaveOption?: boolean;
+  /** Additional class name */
+  className?: string;
+  /** Children to render (e.g., custom header) */
+  children?: ReactNode;
+}
+
+/**
+ * TemplateSelector is a component for browsing and selecting form templates.
+ *
+ * Features:
+ * - Browse built-in templates
+ * - Filter by category
+ * - Search templates
+ * - Preview templates before applying
+ * - Save custom templates
+ * - Delete custom templates
+ */
+export function TemplateSelector({
+  registry,
+  onApply,
+  onSave,
+  onDelete,
+  canvasState,
+  showSaveOption = true,
+  className,
+  children,
+}: TemplateSelectorProps) {
+  // Use provided registry or default
+  const templateRegistry = useMemo(
+    () => registry ?? getDefaultRegistry(),
+    [registry]
+  );
+
+  // State
+  const [templates, setTemplates] = useState<FormTemplate[]>(builtInTemplates);
+  const [isLoading, setIsLoading] = useState(true);
+  const [previewTemplate, setPreviewTemplate] = useState<FormTemplate | null>(null);
+  const [filterCategory, setFilterCategory] = useState<TemplateCategory | "all">("all");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [showSaveDialog, setShowSaveDialog] = useState(false);
+
+  // Load templates on mount
+  useEffect(() => {
+    let mounted = true;
+
+    async function loadTemplates() {
+      setIsLoading(true);
+      try {
+        const all = await templateRegistry.getAll();
+        if (mounted) {
+          setTemplates(all);
+        }
+      } catch {
+        // Fall back to built-in only
+        if (mounted) {
+          setTemplates(builtInTemplates);
+        }
+      } finally {
+        if (mounted) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    void loadTemplates();
+
+    return () => {
+      mounted = false;
+    };
+  }, [templateRegistry]);
+
+  // Filter templates
+  const filteredTemplates = useMemo(() => {
+    let result = templates;
+
+    // Filter by category
+    if (filterCategory !== "all") {
+      result = result.filter((t) => t.metadata.category === filterCategory);
+    }
+
+    // Filter by search query
+    if (searchQuery.trim()) {
+      const query = searchQuery.toLowerCase();
+      result = result.filter(
+        (t) =>
+          t.metadata.name.toLowerCase().includes(query) ||
+          t.metadata.description.toLowerCase().includes(query) ||
+          t.title.toLowerCase().includes(query)
+      );
+    }
+
+    return result;
+  }, [templates, filterCategory, searchQuery]);
+
+  // Apply a template
+  const handleApplyTemplate = useCallback(
+    (template: FormTemplate) => {
+      const result = applyTemplate(template);
+      onApply?.(result);
+      return result;
+    },
+    [onApply]
+  );
+
+  // Save as template
+  const handleSaveAsTemplate = useCallback(
+    async (
+      state: CanvasState,
+      metadata: { name: string; description: string; category: TemplateCategory; icon: string }
+    ) => {
+      const templateData = canvasStateToTemplate(state, metadata);
+      const saved = await templateRegistry.saveCustom(templateData);
+
+      // Refresh templates
+      const all = await templateRegistry.getAll();
+      setTemplates(all);
+
+      onSave?.(saved);
+      return saved;
+    },
+    [templateRegistry, onSave]
+  );
+
+  // Delete template
+  const handleDeleteTemplate = useCallback(
+    async (templateId: string) => {
+      const deleted = await templateRegistry.deleteCustom(templateId);
+      if (deleted) {
+        // Refresh templates
+        const all = await templateRegistry.getAll();
+        setTemplates(all);
+
+        // Clear preview if deleted template was being previewed
+        if (previewTemplate?.metadata.id === templateId) {
+          setPreviewTemplate(null);
+        }
+
+        onDelete?.(templateId);
+      }
+      return deleted;
+    },
+    [templateRegistry, previewTemplate, onDelete]
+  );
+
+  // Refresh templates
+  const handleRefresh = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const all = await templateRegistry.getAll();
+      setTemplates(all);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [templateRegistry]);
+
+  // Context value
+  const contextValue = useMemo<TemplateSelectorContextValue>(
+    () => ({
+      templates,
+      previewTemplate,
+      isLoading,
+      filterCategory,
+      searchQuery,
+      filteredTemplates,
+      setPreviewTemplate,
+      setFilterCategory,
+      setSearchQuery,
+      applyTemplate: handleApplyTemplate,
+      saveAsTemplate: handleSaveAsTemplate,
+      deleteTemplate: handleDeleteTemplate,
+      refresh: handleRefresh,
+    }),
+    [
+      templates,
+      previewTemplate,
+      isLoading,
+      filterCategory,
+      searchQuery,
+      filteredTemplates,
+      handleApplyTemplate,
+      handleSaveAsTemplate,
+      handleDeleteTemplate,
+      handleRefresh,
+    ]
+  );
+
+  return (
+    <TemplateSelectorContext.Provider value={contextValue}>
+      <section
+        data-testid="template-selector"
+        className={className}
+        role="region"
+        aria-label="Form templates"
+      >
+        {children && (
+          <div data-testid="template-selector-header">{children}</div>
+        )}
+
+        <div data-testid="template-controls">
+          <SearchInput value={searchQuery} onChange={setSearchQuery} />
+          <CategoryFilter value={filterCategory} onChange={setFilterCategory} />
+          {showSaveOption && canvasState && canvasState.fields.length > 0 && (
+            <button
+              type="button"
+              data-testid="save-as-template-btn"
+              onClick={() => setShowSaveDialog(true)}
+              aria-label="Save current form as template"
+            >
+              Save as Template
+            </button>
+          )}
+        </div>
+
+        {isLoading ? (
+          <div data-testid="loading-indicator" role="status" aria-live="polite">
+            Loading templates...
+          </div>
+        ) : (
+          <div data-testid="template-content">
+            <TemplateGrid
+              templates={filteredTemplates}
+              previewTemplate={previewTemplate}
+              onSelectPreview={setPreviewTemplate}
+              onApply={handleApplyTemplate}
+              onDelete={handleDeleteTemplate}
+              hasSearch={searchQuery.trim().length > 0}
+              category={filterCategory}
+            />
+
+            {previewTemplate && (
+              <TemplatePreview
+                template={previewTemplate}
+                onApply={() => handleApplyTemplate(previewTemplate)}
+                onClose={() => setPreviewTemplate(null)}
+              />
+            )}
+          </div>
+        )}
+
+        {canvasState && (
+          <SaveTemplateDialog
+            isOpen={showSaveDialog}
+            onClose={() => setShowSaveDialog(false)}
+            onSave={(metadata) => handleSaveAsTemplate(canvasState, metadata)}
+          />
+        )}
+      </section>
+    </TemplateSelectorContext.Provider>
+  );
+}
+
+// Export sub-components for flexibility
+TemplateSelector.CategoryFilter = CategoryFilter;
+TemplateSelector.SearchInput = SearchInput;
+TemplateSelector.TemplateCard = TemplateCard;
+TemplateSelector.TemplatePreview = TemplatePreview;
+TemplateSelector.TemplateGrid = TemplateGrid;
+TemplateSelector.SaveTemplateDialog = SaveTemplateDialog;
+TemplateSelector.EmptyState = EmptyState;
+TemplateSelector.TemplateIcon = TemplateIcon;

--- a/packages/ui/src/designer/templates/apply.ts
+++ b/packages/ui/src/designer/templates/apply.ts
@@ -1,0 +1,161 @@
+/**
+ * Template Application (PZ-106)
+ *
+ * Functions for applying templates to create canvas state.
+ */
+
+import { generateUUIDv7, type CanvasField, type CanvasState } from "../types";
+import type { FormTemplate, TemplateApplyResult, TemplateField } from "./types";
+
+/**
+ * Converts a template field to a canvas field.
+ * Generates a new UUIDv7 for the field.
+ */
+export function templateFieldToCanvasField(templateField: TemplateField): CanvasField {
+  return {
+    id: generateUUIDv7(),
+    inputType: templateField.inputType,
+    label: templateField.label,
+    name: templateField.name,
+    placeholder: templateField.placeholder,
+    helpText: templateField.helpText,
+    required: templateField.required,
+    validationRules: [],
+    options: templateField.options,
+    defaultValue: templateField.defaultValue,
+    config: templateField.config,
+  };
+}
+
+/**
+ * Applies a template to create a new canvas state.
+ * All field IDs are freshly generated.
+ */
+export function applyTemplate(template: FormTemplate): TemplateApplyResult {
+  const fields = template.fields.map(templateFieldToCanvasField);
+
+  const canvasState: CanvasState = {
+    id: generateUUIDv7(),
+    title: template.title,
+    description: template.description,
+    fields,
+    selectedFieldId: null,
+    isPreviewMode: false,
+  };
+
+  return {
+    canvasState,
+    fieldCount: fields.length,
+  };
+}
+
+/**
+ * Converts a canvas state to a form template.
+ * Used when saving a custom template from the current form.
+ */
+export function canvasStateToTemplate(
+  canvasState: CanvasState,
+  metadata: {
+    name: string;
+    description: string;
+    category: FormTemplate["metadata"]["category"];
+    icon: string;
+  }
+): Omit<FormTemplate, "metadata"> & {
+  metadata: Omit<FormTemplate["metadata"], "id" | "createdAt" | "updatedAt" | "isBuiltIn">;
+} {
+  const fields: TemplateField[] = canvasState.fields.map((field) => ({
+    inputType: field.inputType,
+    label: field.label,
+    name: field.name,
+    placeholder: field.placeholder,
+    helpText: field.helpText,
+    required: field.required,
+    options: field.options,
+    defaultValue: field.defaultValue,
+    config: field.config,
+  }));
+
+  return {
+    metadata: {
+      name: metadata.name,
+      description: metadata.description,
+      category: metadata.category,
+      icon: metadata.icon,
+    },
+    title: canvasState.title,
+    description: canvasState.description,
+    fields,
+  };
+}
+
+/**
+ * Merges a template into an existing canvas state.
+ * Appends template fields after existing fields.
+ */
+export function mergeTemplateIntoCanvas(
+  canvasState: CanvasState,
+  template: FormTemplate
+): CanvasState {
+  const newFields = template.fields.map(templateFieldToCanvasField);
+
+  return {
+    ...canvasState,
+    fields: [...canvasState.fields, ...newFields],
+  };
+}
+
+/**
+ * Validates that a template has the minimum required structure.
+ */
+export function validateTemplate(template: unknown): template is FormTemplate {
+  if (!template || typeof template !== "object") {
+    return false;
+  }
+
+  const t = template as Record<string, unknown>;
+
+  // Check metadata
+  if (!t.metadata || typeof t.metadata !== "object") {
+    return false;
+  }
+
+  const metadata = t.metadata as Record<string, unknown>;
+  if (
+    typeof metadata.id !== "string" ||
+    typeof metadata.name !== "string" ||
+    typeof metadata.description !== "string" ||
+    typeof metadata.category !== "string" ||
+    typeof metadata.icon !== "string" ||
+    typeof metadata.isBuiltIn !== "boolean"
+  ) {
+    return false;
+  }
+
+  // Check title
+  if (typeof t.title !== "string") {
+    return false;
+  }
+
+  // Check fields
+  if (!Array.isArray(t.fields)) {
+    return false;
+  }
+
+  // Validate each field has minimum structure
+  for (const field of t.fields) {
+    if (!field || typeof field !== "object") {
+      return false;
+    }
+    const f = field as Record<string, unknown>;
+    if (
+      typeof f.inputType !== "string" ||
+      typeof f.label !== "string" ||
+      typeof f.required !== "boolean"
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/packages/ui/src/designer/templates/builtin.ts
+++ b/packages/ui/src/designer/templates/builtin.ts
@@ -1,0 +1,289 @@
+/**
+ * Built-in Form Templates (PZ-106)
+ *
+ * Pre-built templates for common guild application needs.
+ */
+
+import type { FormTemplate, TemplateField } from "./types";
+
+// -----------------------------------------------------------------------------
+// Common Field Definitions
+// -----------------------------------------------------------------------------
+
+const characterNameField: TemplateField = {
+  inputType: "text",
+  label: "Character Name",
+  name: "characterName",
+  placeholder: "Enter your main character name",
+  helpText: "Your primary character that you'll be playing",
+  required: true,
+};
+
+const serverField: TemplateField = {
+  inputType: "text",
+  label: "Server/Realm",
+  name: "server",
+  placeholder: "e.g., Area 52, Illidan, Stormrage",
+  helpText: "The server your character is on",
+  required: true,
+};
+
+const classField: TemplateField = {
+  inputType: "select",
+  label: "Class",
+  name: "class",
+  helpText: "Select your character class",
+  required: true,
+  options: [
+    { value: "warrior", label: "Warrior" },
+    { value: "paladin", label: "Paladin" },
+    { value: "hunter", label: "Hunter" },
+    { value: "rogue", label: "Rogue" },
+    { value: "priest", label: "Priest" },
+    { value: "shaman", label: "Shaman" },
+    { value: "mage", label: "Mage" },
+    { value: "warlock", label: "Warlock" },
+    { value: "monk", label: "Monk" },
+    { value: "druid", label: "Druid" },
+    { value: "demon_hunter", label: "Demon Hunter" },
+    { value: "death_knight", label: "Death Knight" },
+    { value: "evoker", label: "Evoker" },
+  ],
+};
+
+const roleField: TemplateField = {
+  inputType: "select",
+  label: "Primary Role",
+  name: "role",
+  helpText: "The role you prefer to play",
+  required: true,
+  options: [
+    { value: "tank", label: "Tank" },
+    { value: "healer", label: "Healer" },
+    { value: "melee_dps", label: "Melee DPS" },
+    { value: "ranged_dps", label: "Ranged DPS" },
+  ],
+};
+
+const scheduleField: TemplateField = {
+  inputType: "multiselect",
+  label: "Available Days",
+  name: "schedule",
+  helpText: "Select all days you're typically available to play",
+  required: true,
+  options: [
+    { value: "monday", label: "Monday" },
+    { value: "tuesday", label: "Tuesday" },
+    { value: "wednesday", label: "Wednesday" },
+    { value: "thursday", label: "Thursday" },
+    { value: "friday", label: "Friday" },
+    { value: "saturday", label: "Saturday" },
+    { value: "sunday", label: "Sunday" },
+  ],
+};
+
+const whyJoinField: TemplateField = {
+  inputType: "textarea",
+  label: "Why do you want to join?",
+  name: "whyJoin",
+  placeholder: "Tell us about yourself and why you'd like to join our guild",
+  helpText: "Help us get to know you better",
+  required: true,
+};
+
+// -----------------------------------------------------------------------------
+// General Application Template
+// -----------------------------------------------------------------------------
+
+/**
+ * General Application template for guild recruitment.
+ * Fields: Character, Server, Class, Role, Schedule, Why Join
+ */
+export const generalApplicationTemplate: FormTemplate = {
+  metadata: {
+    id: "general-application",
+    name: "General Application",
+    description: "A versatile application form suitable for most guilds. Collects character info, role preferences, and availability.",
+    category: "guild",
+    icon: "file-text",
+    isBuiltIn: true,
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z",
+  },
+  title: "Guild Application",
+  description: "Apply to join our guild! Please fill out all required fields.",
+  fields: [
+    characterNameField,
+    serverField,
+    classField,
+    roleField,
+    scheduleField,
+    whyJoinField,
+  ],
+};
+
+// -----------------------------------------------------------------------------
+// Raid Recruitment Template
+// -----------------------------------------------------------------------------
+
+const raidExperienceField: TemplateField = {
+  inputType: "textarea",
+  label: "Raid Experience",
+  name: "raidExperience",
+  placeholder: "List your previous raid experience and progression",
+  helpText: "Include bosses killed, difficulty levels (Normal/Heroic/Mythic), and any notable achievements",
+  required: true,
+};
+
+const logsLinkField: TemplateField = {
+  inputType: "text",
+  label: "Warcraft Logs Link",
+  name: "logsLink",
+  placeholder: "https://www.warcraftlogs.com/character/...",
+  helpText: "Link to your Warcraft Logs profile (optional but highly recommended)",
+  required: false,
+};
+
+const mythicPlusScoreField: TemplateField = {
+  inputType: "number",
+  label: "Mythic+ Score",
+  name: "mythicPlusScore",
+  placeholder: "e.g., 2500",
+  helpText: "Your current Mythic+ rating (Raider.IO score)",
+  required: false,
+  config: {
+    min: 0,
+    max: 5000,
+  },
+};
+
+const raidTimesField: TemplateField = {
+  inputType: "textarea",
+  label: "Raid Availability",
+  name: "raidTimes",
+  placeholder: "e.g., Tues/Wed/Thurs 8pm-11pm EST",
+  helpText: "Our raid times are [times]. Can you make these consistently?",
+  required: true,
+};
+
+/**
+ * Raid Recruitment template for competitive guilds.
+ * Fields: All general fields + Raid Experience, Logs Link, M+ Score
+ */
+export const raidRecruitmentTemplate: FormTemplate = {
+  metadata: {
+    id: "raid-recruitment",
+    name: "Raid Recruitment",
+    description: "Detailed application for raiding guilds. Includes performance metrics and raid experience.",
+    category: "recruitment",
+    icon: "swords",
+    isBuiltIn: true,
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z",
+  },
+  title: "Raid Team Application",
+  description: "Apply to join our raid team! We review all applications and logs carefully.",
+  fields: [
+    characterNameField,
+    serverField,
+    classField,
+    roleField,
+    raidExperienceField,
+    logsLinkField,
+    mythicPlusScoreField,
+    raidTimesField,
+    whyJoinField,
+  ],
+};
+
+// -----------------------------------------------------------------------------
+// Casual Join Template
+// -----------------------------------------------------------------------------
+
+const gamesPlayedField: TemplateField = {
+  inputType: "multiselect",
+  label: "Games You Play",
+  name: "gamesPlayed",
+  helpText: "Select all games you're currently playing",
+  required: true,
+  options: [
+    { value: "wow_retail", label: "WoW Retail" },
+    { value: "wow_classic", label: "WoW Classic" },
+    { value: "ff14", label: "Final Fantasy XIV" },
+    { value: "eso", label: "Elder Scrolls Online" },
+    { value: "gw2", label: "Guild Wars 2" },
+    { value: "lost_ark", label: "Lost Ark" },
+    { value: "other", label: "Other" },
+  ],
+};
+
+const aboutYourselfField: TemplateField = {
+  inputType: "textarea",
+  label: "Tell us about yourself",
+  name: "aboutYourself",
+  placeholder: "What do you enjoy doing in-game? What are you looking for in a guild?",
+  helpText: "We're a casual community, so no pressure! Just tell us a bit about yourself.",
+  required: true,
+};
+
+const discordUsernameField: TemplateField = {
+  inputType: "text",
+  label: "Discord Username",
+  name: "discordUsername",
+  placeholder: "username#1234 or just username",
+  helpText: "So we can reach out to you",
+  required: false,
+};
+
+/**
+ * Casual Join template for social/casual guilds.
+ * Fields: Character, Server, Games, About Yourself
+ */
+export const casualJoinTemplate: FormTemplate = {
+  metadata: {
+    id: "casual-join",
+    name: "Casual Join",
+    description: "Simple form for casual/social guilds. Low barrier to entry, focused on getting to know new members.",
+    category: "social",
+    icon: "users",
+    isBuiltIn: true,
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z",
+  },
+  title: "Join Our Community",
+  description: "Welcome! We're happy you're interested in joining. Just fill out this quick form.",
+  fields: [
+    { ...characterNameField, helpText: "Your in-game name (optional if you play multiple games)", required: false },
+    { ...serverField, required: false, helpText: "If applicable" },
+    gamesPlayedField,
+    aboutYourselfField,
+    discordUsernameField,
+  ],
+};
+
+// -----------------------------------------------------------------------------
+// Exports
+// -----------------------------------------------------------------------------
+
+/**
+ * All built-in templates.
+ */
+export const builtInTemplates: FormTemplate[] = [
+  generalApplicationTemplate,
+  raidRecruitmentTemplate,
+  casualJoinTemplate,
+];
+
+/**
+ * Get a built-in template by ID.
+ */
+export function getBuiltInTemplate(id: string): FormTemplate | undefined {
+  return builtInTemplates.find((t) => t.metadata.id === id);
+}
+
+/**
+ * Get built-in templates by category.
+ */
+export function getBuiltInTemplatesByCategory(category: FormTemplate["metadata"]["category"]): FormTemplate[] {
+  return builtInTemplates.filter((t) => t.metadata.category === category);
+}

--- a/packages/ui/src/designer/templates/index.ts
+++ b/packages/ui/src/designer/templates/index.ts
@@ -1,0 +1,53 @@
+/**
+ * Form Templates (PZ-106)
+ *
+ * Pre-built form templates for common guild needs.
+ */
+
+// Types
+export type {
+  TemplateCategory,
+  TemplateMetadata,
+  FormTemplate,
+  TemplateField,
+  TemplateSelectEvent,
+  TemplateSaveEvent,
+  TemplateDeleteEvent,
+  TemplateApplyResult,
+  TemplateStorage,
+  TemplateRegistry,
+} from "./types";
+
+// Built-in templates
+export {
+  generalApplicationTemplate,
+  raidRecruitmentTemplate,
+  casualJoinTemplate,
+  builtInTemplates,
+  getBuiltInTemplate,
+  getBuiltInTemplatesByCategory,
+} from "./builtin";
+
+// Registry
+export {
+  createInMemoryStorage,
+  createLocalStorage,
+  createTemplateRegistry,
+  createInMemoryRegistry,
+  createLocalStorageRegistry,
+  getDefaultRegistry,
+  resetDefaultRegistry,
+} from "./registry";
+
+// Apply functions
+export {
+  templateFieldToCanvasField,
+  applyTemplate,
+  canvasStateToTemplate,
+  mergeTemplateIntoCanvas,
+  validateTemplate,
+} from "./apply";
+
+// Component and hook
+export { TemplateSelector, useTemplateSelector } from "./TemplateSelector";
+export type { TemplateSelectorProps } from "./TemplateSelector";

--- a/packages/ui/src/designer/templates/registry.ts
+++ b/packages/ui/src/designer/templates/registry.ts
@@ -1,0 +1,223 @@
+/**
+ * Template Registry (PZ-106)
+ *
+ * Manages built-in and custom templates.
+ */
+
+import { generateUUIDv7 } from "../types";
+import { builtInTemplates, getBuiltInTemplate } from "./builtin";
+import type {
+  FormTemplate,
+  TemplateCategory,
+  TemplateMetadata,
+  TemplateRegistry,
+  TemplateStorage,
+} from "./types";
+
+// -----------------------------------------------------------------------------
+// In-Memory Storage (Default)
+// -----------------------------------------------------------------------------
+
+/**
+ * Creates an in-memory template storage.
+ * Useful for testing or when persistence isn't needed.
+ */
+export function createInMemoryStorage(): TemplateStorage {
+  const templates = new Map<string, FormTemplate>();
+
+  return {
+    async getAll(): Promise<FormTemplate[]> {
+      return Array.from(templates.values());
+    },
+
+    async save(template: FormTemplate): Promise<void> {
+      templates.set(template.metadata.id, template);
+    },
+
+    async delete(templateId: string): Promise<boolean> {
+      return templates.delete(templateId);
+    },
+
+    async clear(): Promise<void> {
+      templates.clear();
+    },
+  };
+}
+
+// -----------------------------------------------------------------------------
+// LocalStorage Storage
+// -----------------------------------------------------------------------------
+
+const STORAGE_KEY = "phantom-zone-custom-templates";
+
+/**
+ * Creates a localStorage-based template storage.
+ * Templates persist across browser sessions.
+ */
+export function createLocalStorage(): TemplateStorage {
+  function readFromStorage(): Map<string, FormTemplate> {
+    try {
+      if (typeof window === "undefined" || !window.localStorage) {
+        return new Map();
+      }
+      const data = localStorage.getItem(STORAGE_KEY);
+      if (!data) {
+        return new Map();
+      }
+      const parsed = JSON.parse(data) as FormTemplate[];
+      return new Map(parsed.map((t) => [t.metadata.id, t]));
+    } catch {
+      return new Map();
+    }
+  }
+
+  function writeToStorage(templates: Map<string, FormTemplate>): void {
+    try {
+      if (typeof window === "undefined" || !window.localStorage) {
+        return;
+      }
+      const data = Array.from(templates.values());
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    } catch {
+      // Silently fail if storage is full or unavailable
+    }
+  }
+
+  return {
+    async getAll(): Promise<FormTemplate[]> {
+      return Array.from(readFromStorage().values());
+    },
+
+    async save(template: FormTemplate): Promise<void> {
+      const templates = readFromStorage();
+      templates.set(template.metadata.id, template);
+      writeToStorage(templates);
+    },
+
+    async delete(templateId: string): Promise<boolean> {
+      const templates = readFromStorage();
+      const deleted = templates.delete(templateId);
+      if (deleted) {
+        writeToStorage(templates);
+      }
+      return deleted;
+    },
+
+    async clear(): Promise<void> {
+      if (typeof window !== "undefined" && window.localStorage) {
+        localStorage.removeItem(STORAGE_KEY);
+      }
+    },
+  };
+}
+
+// -----------------------------------------------------------------------------
+// Template Registry
+// -----------------------------------------------------------------------------
+
+/**
+ * Creates a template registry with the specified storage backend.
+ */
+export function createTemplateRegistry(storage: TemplateStorage): TemplateRegistry {
+  return {
+    getBuiltIn(): FormTemplate[] {
+      return [...builtInTemplates];
+    },
+
+    async getCustom(): Promise<FormTemplate[]> {
+      return storage.getAll();
+    },
+
+    async getAll(): Promise<FormTemplate[]> {
+      const custom = await storage.getAll();
+      return [...builtInTemplates, ...custom];
+    },
+
+    async get(templateId: string): Promise<FormTemplate | undefined> {
+      // Check built-in first
+      const builtIn = getBuiltInTemplate(templateId);
+      if (builtIn) {
+        return builtIn;
+      }
+
+      // Check custom templates
+      const customTemplates = await storage.getAll();
+      return customTemplates.find((t) => t.metadata.id === templateId);
+    },
+
+    async getByCategory(category: TemplateCategory): Promise<FormTemplate[]> {
+      const all = await this.getAll();
+      return all.filter((t) => t.metadata.category === category);
+    },
+
+    async saveCustom(
+      template: Omit<FormTemplate, "metadata"> & {
+        metadata: Omit<TemplateMetadata, "id" | "createdAt" | "updatedAt" | "isBuiltIn">;
+      }
+    ): Promise<FormTemplate> {
+      const now = new Date().toISOString();
+      const fullTemplate: FormTemplate = {
+        ...template,
+        metadata: {
+          ...template.metadata,
+          id: generateUUIDv7(),
+          isBuiltIn: false,
+          createdAt: now,
+          updatedAt: now,
+        },
+      };
+
+      await storage.save(fullTemplate);
+      return fullTemplate;
+    },
+
+    async deleteCustom(templateId: string): Promise<boolean> {
+      // Cannot delete built-in templates
+      const builtIn = getBuiltInTemplate(templateId);
+      if (builtIn) {
+        return false;
+      }
+
+      return storage.delete(templateId);
+    },
+  };
+}
+
+/**
+ * Creates a template registry with in-memory storage.
+ */
+export function createInMemoryRegistry(): TemplateRegistry {
+  return createTemplateRegistry(createInMemoryStorage());
+}
+
+/**
+ * Creates a template registry with localStorage.
+ */
+export function createLocalStorageRegistry(): TemplateRegistry {
+  return createTemplateRegistry(createLocalStorage());
+}
+
+// -----------------------------------------------------------------------------
+// Default Registry
+// -----------------------------------------------------------------------------
+
+let defaultRegistry: TemplateRegistry | null = null;
+
+/**
+ * Gets the default template registry (localStorage-backed).
+ * Creates it on first access.
+ */
+export function getDefaultRegistry(): TemplateRegistry {
+  if (!defaultRegistry) {
+    defaultRegistry = createLocalStorageRegistry();
+  }
+  return defaultRegistry;
+}
+
+/**
+ * Resets the default registry.
+ * Primarily useful for testing.
+ */
+export function resetDefaultRegistry(): void {
+  defaultRegistry = null;
+}

--- a/packages/ui/src/designer/templates/types.ts
+++ b/packages/ui/src/designer/templates/types.ts
@@ -1,0 +1,148 @@
+/**
+ * Form Templates Types (PZ-106)
+ *
+ * Type definitions for the form templates system.
+ */
+
+import type { z } from "zod";
+import type { CanvasField, CanvasState } from "../types";
+
+/**
+ * Template category for grouping templates.
+ */
+export type TemplateCategory = "guild" | "recruitment" | "social" | "custom";
+
+/**
+ * Metadata for a form template.
+ */
+export interface TemplateMetadata {
+  /** Unique identifier for this template */
+  id: string;
+  /** Display name shown in the selector */
+  name: string;
+  /** Description of what this template is for */
+  description: string;
+  /** Template category for grouping */
+  category: TemplateCategory;
+  /** Icon identifier (e.g., Lucide icon name) */
+  icon: string;
+  /** Whether this is a built-in template (cannot be deleted) */
+  isBuiltIn: boolean;
+  /** When the template was created (ISO date string) */
+  createdAt: string;
+  /** When the template was last updated (ISO date string) */
+  updatedAt: string;
+}
+
+/**
+ * A complete form template including metadata and fields.
+ */
+export interface FormTemplate {
+  /** Template metadata */
+  metadata: TemplateMetadata;
+  /** Form title to use when applying template */
+  title: string;
+  /** Form description to use when applying template */
+  description?: string;
+  /** Template fields (without IDs - they will be generated on apply) */
+  fields: TemplateField[];
+}
+
+/**
+ * A field definition within a template.
+ * Similar to CanvasField but without the id (generated on apply).
+ */
+export interface TemplateField {
+  /** The input type from the registry */
+  inputType: string;
+  /** Field label displayed to users */
+  label: string;
+  /** Optional field name (defaults to auto-generated from label) */
+  name?: string;
+  /** Placeholder text */
+  placeholder?: string;
+  /** Help text shown below the field */
+  helpText?: string;
+  /** Whether the field is required */
+  required: boolean;
+  /** Options for select/multiselect fields */
+  options?: Array<{
+    value: string;
+    label: string;
+    disabled?: boolean;
+  }>;
+  /** Default value */
+  defaultValue?: unknown;
+  /** Additional field-specific configuration */
+  config?: Record<string, unknown>;
+}
+
+/**
+ * Event emitted when a template is selected.
+ */
+export interface TemplateSelectEvent {
+  /** The selected template */
+  template: FormTemplate;
+}
+
+/**
+ * Event emitted when a custom template is saved.
+ */
+export interface TemplateSaveEvent {
+  /** The template metadata (id auto-generated if new) */
+  metadata: Omit<TemplateMetadata, "id" | "createdAt" | "updatedAt" | "isBuiltIn">;
+  /** Current canvas state to save as template */
+  canvasState: CanvasState;
+}
+
+/**
+ * Event emitted when a custom template is deleted.
+ */
+export interface TemplateDeleteEvent {
+  /** The template ID to delete */
+  templateId: string;
+}
+
+/**
+ * Result of applying a template to the canvas.
+ */
+export interface TemplateApplyResult {
+  /** The generated canvas state */
+  canvasState: CanvasState;
+  /** Number of fields created */
+  fieldCount: number;
+}
+
+/**
+ * Storage interface for custom templates.
+ */
+export interface TemplateStorage {
+  /** Get all custom templates */
+  getAll(): Promise<FormTemplate[]>;
+  /** Save a custom template (creates or updates) */
+  save(template: FormTemplate): Promise<void>;
+  /** Delete a custom template */
+  delete(templateId: string): Promise<boolean>;
+  /** Clear all custom templates */
+  clear(): Promise<void>;
+}
+
+/**
+ * Template registry for managing built-in and custom templates.
+ */
+export interface TemplateRegistry {
+  /** Get all built-in templates */
+  getBuiltIn(): FormTemplate[];
+  /** Get all custom templates */
+  getCustom(): Promise<FormTemplate[]>;
+  /** Get all templates (built-in + custom) */
+  getAll(): Promise<FormTemplate[]>;
+  /** Get a template by ID */
+  get(templateId: string): Promise<FormTemplate | undefined>;
+  /** Get templates by category */
+  getByCategory(category: TemplateCategory): Promise<FormTemplate[]>;
+  /** Save a custom template */
+  saveCustom(template: Omit<FormTemplate, "metadata"> & { metadata: Omit<TemplateMetadata, "id" | "createdAt" | "updatedAt" | "isBuiltIn"> }): Promise<FormTemplate>;
+  /** Delete a custom template */
+  deleteCustom(templateId: string): Promise<boolean>;
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -78,6 +78,47 @@ export type {
   SchemaImportErrorEvent,
 } from "./designer";
 
+// Form Templates (PZ-106)
+export {
+  TemplateSelector,
+  useTemplateSelector,
+  // Built-in templates
+  generalApplicationTemplate,
+  raidRecruitmentTemplate,
+  casualJoinTemplate,
+  builtInTemplates,
+  getBuiltInTemplate,
+  getBuiltInTemplatesByCategory,
+  // Registry
+  createInMemoryStorage,
+  createLocalStorage,
+  createTemplateRegistry,
+  createInMemoryRegistry,
+  createLocalStorageRegistry,
+  getDefaultRegistry,
+  resetDefaultRegistry,
+  // Apply functions
+  templateFieldToCanvasField,
+  applyTemplate,
+  canvasStateToTemplate,
+  mergeTemplateIntoCanvas,
+  validateTemplate,
+} from "./designer";
+
+export type {
+  TemplateSelectorProps,
+  TemplateCategory,
+  TemplateMetadata,
+  FormTemplate,
+  TemplateField,
+  TemplateSelectEvent,
+  TemplateSaveEvent,
+  TemplateDeleteEvent,
+  TemplateApplyResult,
+  TemplateStorage,
+  TemplateRegistry,
+} from "./designer";
+
 // Placeholder - full designer to be completed in Phase 2
 export function FormDesigner(): never {
   throw new Error("Not implemented - see PZ-100: https://github.com/ezmode-games/phantom-zone/issues/34");

--- a/packages/ui/test/designer/templates/TemplateSelector.test.ts
+++ b/packages/ui/test/designer/templates/TemplateSelector.test.ts
@@ -1,0 +1,334 @@
+/**
+ * TemplateSelector Component Tests (PZ-106)
+ *
+ * Tests for the TemplateSelector component.
+ * Note: These tests are limited since we use node environment.
+ * Full component testing would require jsdom environment and @testing-library/react.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  TemplateSelector,
+  useTemplateSelector,
+  builtInTemplates,
+  createInMemoryRegistry,
+  applyTemplate,
+  generalApplicationTemplate,
+} from "../../../src/designer/templates";
+import type { TemplateSelectorProps } from "../../../src/designer/templates";
+import { createEmptyCanvasState } from "../../../src/designer/types";
+
+describe("TemplateSelector", () => {
+  describe("exports", () => {
+    it("TemplateSelector is exported as a function", () => {
+      expect(typeof TemplateSelector).toBe("function");
+    });
+
+    it("useTemplateSelector is exported as a function", () => {
+      expect(typeof useTemplateSelector).toBe("function");
+    });
+  });
+
+  describe("TemplateSelector component", () => {
+    it("is a valid React component function", () => {
+      expect(TemplateSelector.length).toBeGreaterThanOrEqual(0);
+    });
+
+    it("has sub-components attached", () => {
+      expect(TemplateSelector.CategoryFilter).toBeDefined();
+      expect(TemplateSelector.SearchInput).toBeDefined();
+      expect(TemplateSelector.TemplateCard).toBeDefined();
+      expect(TemplateSelector.TemplatePreview).toBeDefined();
+      expect(TemplateSelector.TemplateGrid).toBeDefined();
+      expect(TemplateSelector.SaveTemplateDialog).toBeDefined();
+      expect(TemplateSelector.EmptyState).toBeDefined();
+      expect(TemplateSelector.TemplateIcon).toBeDefined();
+    });
+  });
+
+  describe("useTemplateSelector hook", () => {
+    it("is exported as a function", () => {
+      // Note: We cannot test the actual hook behavior in node environment
+      // since React hooks require a React component context.
+      expect(typeof useTemplateSelector).toBe("function");
+    });
+  });
+});
+
+describe("TemplateSelector Type Tests", () => {
+  it("TemplateSelectorProps interface is correct", () => {
+    const registry = createInMemoryRegistry();
+    const canvasState = createEmptyCanvasState();
+
+    const props: TemplateSelectorProps = {
+      registry,
+      onApply: () => {},
+      onSave: () => {},
+      onDelete: () => {},
+      canvasState,
+      showSaveOption: true,
+      className: "test-class",
+      children: null,
+    };
+
+    expect(props.registry).toBe(registry);
+    expect(typeof props.onApply).toBe("function");
+    expect(typeof props.onSave).toBe("function");
+    expect(typeof props.onDelete).toBe("function");
+    expect(props.canvasState).toBe(canvasState);
+    expect(props.showSaveOption).toBe(true);
+    expect(props.className).toBe("test-class");
+  });
+
+  it("TemplateSelectorProps supports minimal configuration", () => {
+    const props: TemplateSelectorProps = {};
+
+    expect(props.registry).toBeUndefined();
+    expect(props.onApply).toBeUndefined();
+    expect(props.canvasState).toBeUndefined();
+  });
+});
+
+describe("TemplateSelector Integration Scenarios", () => {
+  describe("applying a template", () => {
+    it("applies template and calls onApply callback", () => {
+      let appliedResult: unknown = null;
+
+      const props: TemplateSelectorProps = {
+        onApply: (result) => {
+          appliedResult = result;
+        },
+      };
+
+      // Simulate template application
+      const result = applyTemplate(generalApplicationTemplate);
+      props.onApply?.(result);
+
+      expect(appliedResult).toEqual(result);
+      expect(result.canvasState.title).toBe("Guild Application");
+      expect(result.fieldCount).toBe(generalApplicationTemplate.fields.length);
+    });
+
+    it("generates unique IDs on each apply", () => {
+      const result1 = applyTemplate(generalApplicationTemplate);
+      const result2 = applyTemplate(generalApplicationTemplate);
+
+      expect(result1.canvasState.id).not.toBe(result2.canvasState.id);
+      expect(result1.canvasState.fields[0]!.id).not.toBe(
+        result2.canvasState.fields[0]!.id
+      );
+    });
+  });
+
+  describe("saving a custom template", () => {
+    it("saves custom template with metadata", async () => {
+      const registry = createInMemoryRegistry();
+      const canvasState = createEmptyCanvasState();
+      canvasState.title = "My Custom Form";
+      canvasState.fields = [
+        {
+          id: "field-1",
+          inputType: "text",
+          label: "Name",
+          required: true,
+          validationRules: [],
+        },
+      ];
+
+      const saved = await registry.saveCustom({
+        metadata: {
+          name: "My Template",
+          description: "A custom template",
+          category: "custom",
+          icon: "file",
+        },
+        title: canvasState.title,
+        fields: canvasState.fields.map((f) => ({
+          inputType: f.inputType,
+          label: f.label,
+          required: f.required,
+        })),
+      });
+
+      expect(saved.metadata.id).toBeTruthy();
+      expect(saved.metadata.name).toBe("My Template");
+      expect(saved.metadata.isBuiltIn).toBe(false);
+      expect(saved.title).toBe("My Custom Form");
+      expect(saved.fields).toHaveLength(1);
+    });
+  });
+
+  describe("deleting a custom template", () => {
+    it("deletes custom template from registry", async () => {
+      const registry = createInMemoryRegistry();
+
+      const saved = await registry.saveCustom({
+        metadata: {
+          name: "To Delete",
+          description: "Will be deleted",
+          category: "custom",
+          icon: "file",
+        },
+        title: "Delete Me",
+        fields: [],
+      });
+
+      let deletedId: string | null = null;
+      const props: TemplateSelectorProps = {
+        registry,
+        onDelete: (id) => {
+          deletedId = id;
+        },
+      };
+
+      const deleted = await registry.deleteCustom(saved.metadata.id);
+      props.onDelete?.(saved.metadata.id);
+
+      expect(deleted).toBe(true);
+      expect(deletedId).toBe(saved.metadata.id);
+
+      const template = await registry.get(saved.metadata.id);
+      expect(template).toBeUndefined();
+    });
+
+    it("cannot delete built-in templates", async () => {
+      const registry = createInMemoryRegistry();
+
+      const deleted = await registry.deleteCustom("general-application");
+      expect(deleted).toBe(false);
+
+      const template = await registry.get("general-application");
+      expect(template).toBeDefined();
+    });
+  });
+
+  describe("filtering templates", () => {
+    it("filters by category", async () => {
+      const registry = createInMemoryRegistry();
+
+      const all = await registry.getAll();
+      const guild = await registry.getByCategory("guild");
+      const recruitment = await registry.getByCategory("recruitment");
+      const social = await registry.getByCategory("social");
+
+      expect(all.length).toBe(builtInTemplates.length);
+      expect(guild.every((t) => t.metadata.category === "guild")).toBe(true);
+      expect(recruitment.every((t) => t.metadata.category === "recruitment")).toBe(true);
+      expect(social.every((t) => t.metadata.category === "social")).toBe(true);
+    });
+
+    it("includes custom templates in category filter", async () => {
+      const registry = createInMemoryRegistry();
+
+      await registry.saveCustom({
+        metadata: {
+          name: "Custom Guild",
+          description: "Custom guild template",
+          category: "guild",
+          icon: "file",
+        },
+        title: "Custom Guild Form",
+        fields: [],
+      });
+
+      const guild = await registry.getByCategory("guild");
+      expect(guild.some((t) => t.metadata.name === "Custom Guild")).toBe(true);
+    });
+  });
+
+  describe("searching templates", () => {
+    it("simulates search filtering", () => {
+      const searchQuery = "raid";
+      const filteredTemplates = builtInTemplates.filter(
+        (t) =>
+          t.metadata.name.toLowerCase().includes(searchQuery) ||
+          t.metadata.description.toLowerCase().includes(searchQuery) ||
+          t.title.toLowerCase().includes(searchQuery)
+      );
+
+      expect(filteredTemplates.some((t) => t.metadata.id === "raid-recruitment")).toBe(
+        true
+      );
+    });
+
+    it("returns empty for non-matching search", () => {
+      const searchQuery = "nonexistent-xyz-template";
+      const filteredTemplates = builtInTemplates.filter(
+        (t) =>
+          t.metadata.name.toLowerCase().includes(searchQuery) ||
+          t.metadata.description.toLowerCase().includes(searchQuery)
+      );
+
+      expect(filteredTemplates).toHaveLength(0);
+    });
+  });
+});
+
+describe("TemplateSelector Edge Cases", () => {
+  it("handles empty canvas state for save option", () => {
+    const canvasState = createEmptyCanvasState();
+    const props: TemplateSelectorProps = {
+      canvasState,
+      showSaveOption: true,
+    };
+
+    // Save option should not be available for empty form
+    expect(props.canvasState?.fields).toHaveLength(0);
+    expect(props.showSaveOption).toBe(true);
+  });
+
+  it("handles canvas state with fields for save option", () => {
+    const canvasState = createEmptyCanvasState();
+    canvasState.fields = [
+      {
+        id: "field-1",
+        inputType: "text",
+        label: "Name",
+        required: true,
+        validationRules: [],
+      },
+    ];
+
+    const props: TemplateSelectorProps = {
+      canvasState,
+      showSaveOption: true,
+    };
+
+    expect(props.canvasState?.fields.length).toBeGreaterThan(0);
+  });
+
+  it("handles missing registry (uses default)", () => {
+    const props: TemplateSelectorProps = {};
+    expect(props.registry).toBeUndefined();
+    // Component would use getDefaultRegistry() internally
+  });
+});
+
+describe("TemplateSelector All Templates Access", () => {
+  it("provides access to all built-in templates", async () => {
+    const registry = createInMemoryRegistry();
+    const all = await registry.getAll();
+
+    expect(all).toHaveLength(builtInTemplates.length);
+
+    for (const template of builtInTemplates) {
+      expect(all.some((t) => t.metadata.id === template.metadata.id)).toBe(true);
+    }
+  });
+
+  it("provides access to individual templates by id", async () => {
+    const registry = createInMemoryRegistry();
+
+    const general = await registry.get("general-application");
+    expect(general).toBeDefined();
+    expect(general?.metadata.name).toBe("General Application");
+
+    const raid = await registry.get("raid-recruitment");
+    expect(raid).toBeDefined();
+    expect(raid?.metadata.name).toBe("Raid Recruitment");
+
+    const casual = await registry.get("casual-join");
+    expect(casual).toBeDefined();
+    expect(casual?.metadata.name).toBe("Casual Join");
+  });
+});

--- a/packages/ui/test/designer/templates/apply.test.ts
+++ b/packages/ui/test/designer/templates/apply.test.ts
@@ -1,0 +1,522 @@
+/**
+ * Template Apply Tests (PZ-106)
+ *
+ * Tests for applying templates to create canvas state.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  templateFieldToCanvasField,
+  applyTemplate,
+  canvasStateToTemplate,
+  mergeTemplateIntoCanvas,
+  validateTemplate,
+  generalApplicationTemplate,
+  raidRecruitmentTemplate,
+  casualJoinTemplate,
+} from "../../../src/designer/templates";
+import { createEmptyCanvasState, createField } from "../../../src/designer/types";
+import type { FormTemplate, TemplateField } from "../../../src/designer/templates";
+
+describe("templateFieldToCanvasField", () => {
+  it("generates a unique id", () => {
+    const templateField: TemplateField = {
+      inputType: "text",
+      label: "Name",
+      required: true,
+    };
+
+    const canvasField1 = templateFieldToCanvasField(templateField);
+    const canvasField2 = templateFieldToCanvasField(templateField);
+
+    expect(canvasField1.id).toBeTruthy();
+    expect(canvasField2.id).toBeTruthy();
+    expect(canvasField1.id).not.toBe(canvasField2.id);
+  });
+
+  it("preserves all template field properties", () => {
+    const templateField: TemplateField = {
+      inputType: "select",
+      label: "Class",
+      name: "characterClass",
+      placeholder: "Select your class",
+      helpText: "Choose wisely",
+      required: true,
+      options: [
+        { value: "warrior", label: "Warrior" },
+        { value: "mage", label: "Mage" },
+      ],
+      defaultValue: "warrior",
+      config: { searchable: true },
+    };
+
+    const canvasField = templateFieldToCanvasField(templateField);
+
+    expect(canvasField.inputType).toBe("select");
+    expect(canvasField.label).toBe("Class");
+    expect(canvasField.name).toBe("characterClass");
+    expect(canvasField.placeholder).toBe("Select your class");
+    expect(canvasField.helpText).toBe("Choose wisely");
+    expect(canvasField.required).toBe(true);
+    expect(canvasField.options).toEqual(templateField.options);
+    expect(canvasField.defaultValue).toBe("warrior");
+    expect(canvasField.config).toEqual({ searchable: true });
+  });
+
+  it("initializes validationRules as empty array", () => {
+    const templateField: TemplateField = {
+      inputType: "text",
+      label: "Name",
+      required: true,
+    };
+
+    const canvasField = templateFieldToCanvasField(templateField);
+    expect(canvasField.validationRules).toEqual([]);
+  });
+
+  it("handles minimal template field", () => {
+    const templateField: TemplateField = {
+      inputType: "text",
+      label: "Name",
+      required: false,
+    };
+
+    const canvasField = templateFieldToCanvasField(templateField);
+
+    expect(canvasField.id).toBeTruthy();
+    expect(canvasField.inputType).toBe("text");
+    expect(canvasField.label).toBe("Name");
+    expect(canvasField.required).toBe(false);
+    expect(canvasField.name).toBeUndefined();
+    expect(canvasField.placeholder).toBeUndefined();
+    expect(canvasField.helpText).toBeUndefined();
+  });
+});
+
+describe("applyTemplate", () => {
+  it("creates canvas state from general application template", () => {
+    const result = applyTemplate(generalApplicationTemplate);
+
+    expect(result.canvasState.id).toBeTruthy();
+    expect(result.canvasState.title).toBe("Guild Application");
+    expect(result.canvasState.description).toBeTruthy();
+    expect(result.canvasState.fields).toHaveLength(generalApplicationTemplate.fields.length);
+    expect(result.fieldCount).toBe(generalApplicationTemplate.fields.length);
+  });
+
+  it("creates canvas state from raid recruitment template", () => {
+    const result = applyTemplate(raidRecruitmentTemplate);
+
+    expect(result.canvasState.title).toBe("Raid Team Application");
+    expect(result.fieldCount).toBe(raidRecruitmentTemplate.fields.length);
+  });
+
+  it("creates canvas state from casual join template", () => {
+    const result = applyTemplate(casualJoinTemplate);
+
+    expect(result.canvasState.title).toBe("Join Our Community");
+    expect(result.fieldCount).toBe(casualJoinTemplate.fields.length);
+  });
+
+  it("generates unique IDs for each field", () => {
+    const result = applyTemplate(generalApplicationTemplate);
+
+    const ids = result.canvasState.fields.map((f) => f.id);
+    const uniqueIds = new Set(ids);
+
+    expect(uniqueIds.size).toBe(ids.length);
+  });
+
+  it("generates unique canvas state ID each time", () => {
+    const result1 = applyTemplate(generalApplicationTemplate);
+    const result2 = applyTemplate(generalApplicationTemplate);
+
+    expect(result1.canvasState.id).not.toBe(result2.canvasState.id);
+  });
+
+  it("sets selectedFieldId to null", () => {
+    const result = applyTemplate(generalApplicationTemplate);
+    expect(result.canvasState.selectedFieldId).toBeNull();
+  });
+
+  it("sets isPreviewMode to false", () => {
+    const result = applyTemplate(generalApplicationTemplate);
+    expect(result.canvasState.isPreviewMode).toBe(false);
+  });
+
+  it("handles template with no description", () => {
+    const template: FormTemplate = {
+      metadata: {
+        id: "no-desc",
+        name: "No Description",
+        description: "Template metadata description",
+        category: "custom",
+        icon: "file",
+        isBuiltIn: false,
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+      title: "Form Without Description",
+      fields: [],
+    };
+
+    const result = applyTemplate(template);
+    expect(result.canvasState.description).toBeUndefined();
+  });
+
+  it("handles template with empty fields", () => {
+    const template: FormTemplate = {
+      metadata: {
+        id: "empty",
+        name: "Empty",
+        description: "Empty template",
+        category: "custom",
+        icon: "file",
+        isBuiltIn: false,
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+      title: "Empty Form",
+      description: "No fields",
+      fields: [],
+    };
+
+    const result = applyTemplate(template);
+
+    expect(result.canvasState.fields).toHaveLength(0);
+    expect(result.fieldCount).toBe(0);
+  });
+});
+
+describe("canvasStateToTemplate", () => {
+  it("converts canvas state to template data", () => {
+    const canvasState = createEmptyCanvasState();
+    canvasState.title = "My Form";
+    canvasState.description = "A test form";
+    canvasState.fields = [
+      createField("text", "Name", { required: true }),
+      createField("textarea", "Bio", { required: false }),
+    ];
+
+    const templateData = canvasStateToTemplate(canvasState, {
+      name: "My Template",
+      description: "A reusable template",
+      category: "custom",
+      icon: "file",
+    });
+
+    expect(templateData.metadata.name).toBe("My Template");
+    expect(templateData.metadata.description).toBe("A reusable template");
+    expect(templateData.metadata.category).toBe("custom");
+    expect(templateData.metadata.icon).toBe("file");
+    expect(templateData.title).toBe("My Form");
+    expect(templateData.description).toBe("A test form");
+    expect(templateData.fields).toHaveLength(2);
+  });
+
+  it("strips field IDs from template fields", () => {
+    const canvasState = createEmptyCanvasState();
+    canvasState.fields = [createField("text", "Name", { required: true })];
+
+    const templateData = canvasStateToTemplate(canvasState, {
+      name: "Test",
+      description: "Test",
+      category: "custom",
+      icon: "file",
+    });
+
+    // Template fields should not have IDs (they get generated on apply)
+    const field = templateData.fields[0];
+    expect(field).not.toHaveProperty("id");
+    expect(field!.inputType).toBe("text");
+    expect(field!.label).toBe("Name");
+  });
+
+  it("preserves field options", () => {
+    const canvasState = createEmptyCanvasState();
+    canvasState.fields = [
+      createField("select", "Class", {
+        required: true,
+        options: [
+          { value: "warrior", label: "Warrior" },
+          { value: "mage", label: "Mage" },
+        ],
+      }),
+    ];
+
+    const templateData = canvasStateToTemplate(canvasState, {
+      name: "Test",
+      description: "Test",
+      category: "custom",
+      icon: "file",
+    });
+
+    expect(templateData.fields[0]!.options).toHaveLength(2);
+    expect(templateData.fields[0]!.options![0]!.value).toBe("warrior");
+  });
+
+  it("handles empty canvas state", () => {
+    const canvasState = createEmptyCanvasState();
+
+    const templateData = canvasStateToTemplate(canvasState, {
+      name: "Empty",
+      description: "Empty template",
+      category: "custom",
+      icon: "file",
+    });
+
+    expect(templateData.fields).toHaveLength(0);
+    expect(templateData.title).toBe("Untitled Form");
+  });
+});
+
+describe("mergeTemplateIntoCanvas", () => {
+  it("appends template fields to existing canvas state", () => {
+    const canvasState = createEmptyCanvasState();
+    canvasState.fields = [createField("text", "Existing Field", { required: true })];
+
+    const template: FormTemplate = {
+      metadata: {
+        id: "test",
+        name: "Test",
+        description: "Test",
+        category: "custom",
+        icon: "file",
+        isBuiltIn: false,
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+      title: "Test",
+      fields: [
+        { inputType: "text", label: "New Field 1", required: true },
+        { inputType: "text", label: "New Field 2", required: false },
+      ],
+    };
+
+    const result = mergeTemplateIntoCanvas(canvasState, template);
+
+    expect(result.fields).toHaveLength(3);
+    expect(result.fields[0]!.label).toBe("Existing Field");
+    expect(result.fields[1]!.label).toBe("New Field 1");
+    expect(result.fields[2]!.label).toBe("New Field 2");
+  });
+
+  it("preserves canvas state id", () => {
+    const canvasState = createEmptyCanvasState();
+    const originalId = canvasState.id;
+
+    const template: FormTemplate = {
+      metadata: {
+        id: "test",
+        name: "Test",
+        description: "Test",
+        category: "custom",
+        icon: "file",
+        isBuiltIn: false,
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+      title: "Test",
+      fields: [{ inputType: "text", label: "New Field", required: true }],
+    };
+
+    const result = mergeTemplateIntoCanvas(canvasState, template);
+
+    expect(result.id).toBe(originalId);
+  });
+
+  it("preserves canvas state title and description", () => {
+    const canvasState = createEmptyCanvasState();
+    canvasState.title = "My Form";
+    canvasState.description = "My Description";
+
+    const template: FormTemplate = {
+      metadata: {
+        id: "test",
+        name: "Test",
+        description: "Test",
+        category: "custom",
+        icon: "file",
+        isBuiltIn: false,
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+      title: "Different Title",
+      description: "Different Description",
+      fields: [],
+    };
+
+    const result = mergeTemplateIntoCanvas(canvasState, template);
+
+    expect(result.title).toBe("My Form");
+    expect(result.description).toBe("My Description");
+  });
+
+  it("generates new IDs for merged fields", () => {
+    const canvasState = createEmptyCanvasState();
+
+    const template: FormTemplate = {
+      metadata: {
+        id: "test",
+        name: "Test",
+        description: "Test",
+        category: "custom",
+        icon: "file",
+        isBuiltIn: false,
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+      title: "Test",
+      fields: [{ inputType: "text", label: "Field", required: true }],
+    };
+
+    const result1 = mergeTemplateIntoCanvas(canvasState, template);
+    const result2 = mergeTemplateIntoCanvas(canvasState, template);
+
+    expect(result1.fields[0]!.id).not.toBe(result2.fields[0]!.id);
+  });
+});
+
+describe("validateTemplate", () => {
+  it("returns true for valid template", () => {
+    expect(validateTemplate(generalApplicationTemplate)).toBe(true);
+    expect(validateTemplate(raidRecruitmentTemplate)).toBe(true);
+    expect(validateTemplate(casualJoinTemplate)).toBe(true);
+  });
+
+  it("returns true for minimal valid template", () => {
+    const template = {
+      metadata: {
+        id: "test",
+        name: "Test",
+        description: "Test",
+        category: "custom",
+        icon: "file",
+        isBuiltIn: false,
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+      title: "Test",
+      fields: [],
+    };
+
+    expect(validateTemplate(template)).toBe(true);
+  });
+
+  it("returns false for null", () => {
+    expect(validateTemplate(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(validateTemplate(undefined)).toBe(false);
+  });
+
+  it("returns false for non-object", () => {
+    expect(validateTemplate("string")).toBe(false);
+    expect(validateTemplate(123)).toBe(false);
+    expect(validateTemplate([])).toBe(false);
+  });
+
+  it("returns false for missing metadata", () => {
+    const template = {
+      title: "Test",
+      fields: [],
+    };
+
+    expect(validateTemplate(template)).toBe(false);
+  });
+
+  it("returns false for missing metadata.id", () => {
+    const template = {
+      metadata: {
+        name: "Test",
+        description: "Test",
+        category: "custom",
+        icon: "file",
+        isBuiltIn: false,
+      },
+      title: "Test",
+      fields: [],
+    };
+
+    expect(validateTemplate(template)).toBe(false);
+  });
+
+  it("returns false for missing title", () => {
+    const template = {
+      metadata: {
+        id: "test",
+        name: "Test",
+        description: "Test",
+        category: "custom",
+        icon: "file",
+        isBuiltIn: false,
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+      fields: [],
+    };
+
+    expect(validateTemplate(template)).toBe(false);
+  });
+
+  it("returns false for non-array fields", () => {
+    const template = {
+      metadata: {
+        id: "test",
+        name: "Test",
+        description: "Test",
+        category: "custom",
+        icon: "file",
+        isBuiltIn: false,
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+      title: "Test",
+      fields: "not an array",
+    };
+
+    expect(validateTemplate(template)).toBe(false);
+  });
+
+  it("returns false for invalid field in fields array", () => {
+    const template = {
+      metadata: {
+        id: "test",
+        name: "Test",
+        description: "Test",
+        category: "custom",
+        icon: "file",
+        isBuiltIn: false,
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+      title: "Test",
+      fields: [
+        { inputType: "text", label: "Valid", required: true },
+        { inputType: "text" }, // Missing label and required
+      ],
+    };
+
+    expect(validateTemplate(template)).toBe(false);
+  });
+
+  it("returns false for null field in fields array", () => {
+    const template = {
+      metadata: {
+        id: "test",
+        name: "Test",
+        description: "Test",
+        category: "custom",
+        icon: "file",
+        isBuiltIn: false,
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+      title: "Test",
+      fields: [null],
+    };
+
+    expect(validateTemplate(template)).toBe(false);
+  });
+});

--- a/packages/ui/test/designer/templates/builtin.test.ts
+++ b/packages/ui/test/designer/templates/builtin.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Built-in Templates Tests (PZ-106)
+ *
+ * Tests for the pre-built form templates.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  generalApplicationTemplate,
+  raidRecruitmentTemplate,
+  casualJoinTemplate,
+  builtInTemplates,
+  getBuiltInTemplate,
+  getBuiltInTemplatesByCategory,
+} from "../../../src/designer/templates";
+
+describe("Built-in Templates", () => {
+  describe("generalApplicationTemplate", () => {
+    it("has correct metadata", () => {
+      expect(generalApplicationTemplate.metadata.id).toBe("general-application");
+      expect(generalApplicationTemplate.metadata.name).toBe("General Application");
+      expect(generalApplicationTemplate.metadata.category).toBe("guild");
+      expect(generalApplicationTemplate.metadata.isBuiltIn).toBe(true);
+      expect(generalApplicationTemplate.metadata.icon).toBe("file-text");
+    });
+
+    it("has correct form title and description", () => {
+      expect(generalApplicationTemplate.title).toBe("Guild Application");
+      expect(generalApplicationTemplate.description).toBeTruthy();
+    });
+
+    it("has required fields", () => {
+      const fieldLabels = generalApplicationTemplate.fields.map((f) => f.label);
+
+      expect(fieldLabels).toContain("Character Name");
+      expect(fieldLabels).toContain("Server/Realm");
+      expect(fieldLabels).toContain("Class");
+      expect(fieldLabels).toContain("Primary Role");
+      expect(fieldLabels).toContain("Available Days");
+      expect(fieldLabels).toContain("Why do you want to join?");
+    });
+
+    it("has 6 fields", () => {
+      expect(generalApplicationTemplate.fields).toHaveLength(6);
+    });
+
+    it("character name field is required", () => {
+      const charField = generalApplicationTemplate.fields.find(
+        (f) => f.label === "Character Name"
+      );
+      expect(charField?.required).toBe(true);
+      expect(charField?.inputType).toBe("text");
+    });
+
+    it("class field has options", () => {
+      const classField = generalApplicationTemplate.fields.find((f) => f.label === "Class");
+      expect(classField?.inputType).toBe("select");
+      expect(classField?.options).toBeDefined();
+      expect(classField?.options?.length).toBeGreaterThan(0);
+    });
+
+    it("role field has tank, healer, and dps options", () => {
+      const roleField = generalApplicationTemplate.fields.find(
+        (f) => f.label === "Primary Role"
+      );
+      expect(roleField?.options).toBeDefined();
+
+      const values = roleField?.options?.map((o) => o.value) ?? [];
+      expect(values).toContain("tank");
+      expect(values).toContain("healer");
+      expect(values).toContain("melee_dps");
+      expect(values).toContain("ranged_dps");
+    });
+
+    it("schedule field uses multiselect for days", () => {
+      const scheduleField = generalApplicationTemplate.fields.find(
+        (f) => f.label === "Available Days"
+      );
+      expect(scheduleField?.inputType).toBe("multiselect");
+      expect(scheduleField?.options).toHaveLength(7);
+    });
+  });
+
+  describe("raidRecruitmentTemplate", () => {
+    it("has correct metadata", () => {
+      expect(raidRecruitmentTemplate.metadata.id).toBe("raid-recruitment");
+      expect(raidRecruitmentTemplate.metadata.name).toBe("Raid Recruitment");
+      expect(raidRecruitmentTemplate.metadata.category).toBe("recruitment");
+      expect(raidRecruitmentTemplate.metadata.isBuiltIn).toBe(true);
+    });
+
+    it("includes raid-specific fields", () => {
+      const fieldLabels = raidRecruitmentTemplate.fields.map((f) => f.label);
+
+      expect(fieldLabels).toContain("Raid Experience");
+      expect(fieldLabels).toContain("Warcraft Logs Link");
+      expect(fieldLabels).toContain("Mythic+ Score");
+      expect(fieldLabels).toContain("Raid Availability");
+    });
+
+    it("has more fields than general application", () => {
+      expect(raidRecruitmentTemplate.fields.length).toBeGreaterThan(
+        generalApplicationTemplate.fields.length
+      );
+    });
+
+    it("logs link field is optional", () => {
+      const logsField = raidRecruitmentTemplate.fields.find(
+        (f) => f.label === "Warcraft Logs Link"
+      );
+      expect(logsField?.required).toBe(false);
+    });
+
+    it("mythic plus score uses number input", () => {
+      const scoreField = raidRecruitmentTemplate.fields.find(
+        (f) => f.label === "Mythic+ Score"
+      );
+      expect(scoreField?.inputType).toBe("number");
+      expect(scoreField?.required).toBe(false);
+    });
+
+    it("raid experience uses textarea", () => {
+      const expField = raidRecruitmentTemplate.fields.find(
+        (f) => f.label === "Raid Experience"
+      );
+      expect(expField?.inputType).toBe("textarea");
+      expect(expField?.required).toBe(true);
+    });
+  });
+
+  describe("casualJoinTemplate", () => {
+    it("has correct metadata", () => {
+      expect(casualJoinTemplate.metadata.id).toBe("casual-join");
+      expect(casualJoinTemplate.metadata.name).toBe("Casual Join");
+      expect(casualJoinTemplate.metadata.category).toBe("social");
+      expect(casualJoinTemplate.metadata.isBuiltIn).toBe(true);
+    });
+
+    it("has fewer required fields", () => {
+      const requiredFields = casualJoinTemplate.fields.filter((f) => f.required);
+      expect(requiredFields.length).toBeLessThan(
+        generalApplicationTemplate.fields.filter((f) => f.required).length
+      );
+    });
+
+    it("includes games played field", () => {
+      const gamesField = casualJoinTemplate.fields.find(
+        (f) => f.label === "Games You Play"
+      );
+      expect(gamesField).toBeDefined();
+      expect(gamesField?.inputType).toBe("multiselect");
+      expect(gamesField?.options?.length).toBeGreaterThan(0);
+    });
+
+    it("includes about yourself field", () => {
+      const aboutField = casualJoinTemplate.fields.find(
+        (f) => f.label === "Tell us about yourself"
+      );
+      expect(aboutField).toBeDefined();
+      expect(aboutField?.inputType).toBe("textarea");
+    });
+
+    it("character name is optional", () => {
+      const charField = casualJoinTemplate.fields.find(
+        (f) => f.label === "Character Name"
+      );
+      expect(charField?.required).toBe(false);
+    });
+
+    it("includes discord username field", () => {
+      const discordField = casualJoinTemplate.fields.find(
+        (f) => f.label === "Discord Username"
+      );
+      expect(discordField).toBeDefined();
+      expect(discordField?.inputType).toBe("text");
+      expect(discordField?.required).toBe(false);
+    });
+  });
+
+  describe("builtInTemplates", () => {
+    it("contains all three templates", () => {
+      expect(builtInTemplates).toHaveLength(3);
+    });
+
+    it("includes general application", () => {
+      expect(builtInTemplates).toContain(generalApplicationTemplate);
+    });
+
+    it("includes raid recruitment", () => {
+      expect(builtInTemplates).toContain(raidRecruitmentTemplate);
+    });
+
+    it("includes casual join", () => {
+      expect(builtInTemplates).toContain(casualJoinTemplate);
+    });
+
+    it("all templates have unique IDs", () => {
+      const ids = builtInTemplates.map((t) => t.metadata.id);
+      const uniqueIds = new Set(ids);
+      expect(uniqueIds.size).toBe(ids.length);
+    });
+
+    it("all templates are marked as built-in", () => {
+      for (const template of builtInTemplates) {
+        expect(template.metadata.isBuiltIn).toBe(true);
+      }
+    });
+  });
+
+  describe("getBuiltInTemplate", () => {
+    it("returns general application by id", () => {
+      const template = getBuiltInTemplate("general-application");
+      expect(template).toBe(generalApplicationTemplate);
+    });
+
+    it("returns raid recruitment by id", () => {
+      const template = getBuiltInTemplate("raid-recruitment");
+      expect(template).toBe(raidRecruitmentTemplate);
+    });
+
+    it("returns casual join by id", () => {
+      const template = getBuiltInTemplate("casual-join");
+      expect(template).toBe(casualJoinTemplate);
+    });
+
+    it("returns undefined for unknown id", () => {
+      const template = getBuiltInTemplate("unknown-template");
+      expect(template).toBeUndefined();
+    });
+
+    it("returns undefined for empty id", () => {
+      const template = getBuiltInTemplate("");
+      expect(template).toBeUndefined();
+    });
+  });
+
+  describe("getBuiltInTemplatesByCategory", () => {
+    it("returns guild templates", () => {
+      const templates = getBuiltInTemplatesByCategory("guild");
+      expect(templates).toContain(generalApplicationTemplate);
+      expect(templates.every((t) => t.metadata.category === "guild")).toBe(true);
+    });
+
+    it("returns recruitment templates", () => {
+      const templates = getBuiltInTemplatesByCategory("recruitment");
+      expect(templates).toContain(raidRecruitmentTemplate);
+      expect(templates.every((t) => t.metadata.category === "recruitment")).toBe(true);
+    });
+
+    it("returns social templates", () => {
+      const templates = getBuiltInTemplatesByCategory("social");
+      expect(templates).toContain(casualJoinTemplate);
+      expect(templates.every((t) => t.metadata.category === "social")).toBe(true);
+    });
+
+    it("returns empty array for custom category", () => {
+      const templates = getBuiltInTemplatesByCategory("custom");
+      expect(templates).toHaveLength(0);
+    });
+  });
+});
+
+describe("Template Field Validation", () => {
+  it("all template fields have valid input types", () => {
+    const validInputTypes = [
+      "text",
+      "textarea",
+      "number",
+      "checkbox",
+      "select",
+      "multiselect",
+      "date",
+      "file",
+    ];
+
+    for (const template of builtInTemplates) {
+      for (const field of template.fields) {
+        expect(validInputTypes).toContain(field.inputType);
+      }
+    }
+  });
+
+  it("all template fields have labels", () => {
+    for (const template of builtInTemplates) {
+      for (const field of template.fields) {
+        expect(field.label).toBeTruthy();
+        expect(typeof field.label).toBe("string");
+      }
+    }
+  });
+
+  it("select/multiselect fields have options", () => {
+    for (const template of builtInTemplates) {
+      for (const field of template.fields) {
+        if (field.inputType === "select" || field.inputType === "multiselect") {
+          expect(field.options).toBeDefined();
+          expect(Array.isArray(field.options)).toBe(true);
+          expect(field.options!.length).toBeGreaterThan(0);
+        }
+      }
+    }
+  });
+
+  it("all options have value and label", () => {
+    for (const template of builtInTemplates) {
+      for (const field of template.fields) {
+        if (field.options) {
+          for (const option of field.options) {
+            expect(option.value).toBeTruthy();
+            expect(option.label).toBeTruthy();
+          }
+        }
+      }
+    }
+  });
+});

--- a/packages/ui/test/designer/templates/registry.test.ts
+++ b/packages/ui/test/designer/templates/registry.test.ts
@@ -1,0 +1,535 @@
+/**
+ * Template Registry Tests (PZ-106)
+ *
+ * Tests for the template registry and storage.
+ */
+
+import { describe, expect, it, beforeEach } from "vitest";
+import {
+  createInMemoryStorage,
+  createTemplateRegistry,
+  createInMemoryRegistry,
+  builtInTemplates,
+  getDefaultRegistry,
+  resetDefaultRegistry,
+} from "../../../src/designer/templates";
+import type { FormTemplate, TemplateStorage } from "../../../src/designer/templates";
+
+describe("createInMemoryStorage", () => {
+  let storage: TemplateStorage;
+
+  beforeEach(() => {
+    storage = createInMemoryStorage();
+  });
+
+  it("initially returns empty array", async () => {
+    const templates = await storage.getAll();
+    expect(templates).toEqual([]);
+  });
+
+  it("can save and retrieve a template", async () => {
+    const template: FormTemplate = {
+      metadata: {
+        id: "test-1",
+        name: "Test Template",
+        description: "A test template",
+        category: "custom",
+        icon: "file",
+        isBuiltIn: false,
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+      title: "Test Form",
+      fields: [],
+    };
+
+    await storage.save(template);
+    const templates = await storage.getAll();
+
+    expect(templates).toHaveLength(1);
+    expect(templates[0]).toEqual(template);
+  });
+
+  it("can save multiple templates", async () => {
+    const template1: FormTemplate = {
+      metadata: {
+        id: "test-1",
+        name: "Template 1",
+        description: "First template",
+        category: "custom",
+        icon: "file",
+        isBuiltIn: false,
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+      title: "Form 1",
+      fields: [],
+    };
+
+    const template2: FormTemplate = {
+      metadata: {
+        id: "test-2",
+        name: "Template 2",
+        description: "Second template",
+        category: "guild",
+        icon: "file",
+        isBuiltIn: false,
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+      title: "Form 2",
+      fields: [],
+    };
+
+    await storage.save(template1);
+    await storage.save(template2);
+
+    const templates = await storage.getAll();
+    expect(templates).toHaveLength(2);
+  });
+
+  it("can update an existing template", async () => {
+    const template: FormTemplate = {
+      metadata: {
+        id: "test-1",
+        name: "Original Name",
+        description: "Original description",
+        category: "custom",
+        icon: "file",
+        isBuiltIn: false,
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+      title: "Original Form",
+      fields: [],
+    };
+
+    await storage.save(template);
+
+    const updated: FormTemplate = {
+      ...template,
+      metadata: {
+        ...template.metadata,
+        name: "Updated Name",
+        updatedAt: "2024-01-02T00:00:00.000Z",
+      },
+      title: "Updated Form",
+    };
+
+    await storage.save(updated);
+
+    const templates = await storage.getAll();
+    expect(templates).toHaveLength(1);
+    expect(templates[0]!.metadata.name).toBe("Updated Name");
+    expect(templates[0]!.title).toBe("Updated Form");
+  });
+
+  it("can delete a template", async () => {
+    const template: FormTemplate = {
+      metadata: {
+        id: "test-1",
+        name: "Test Template",
+        description: "A test template",
+        category: "custom",
+        icon: "file",
+        isBuiltIn: false,
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+      title: "Test Form",
+      fields: [],
+    };
+
+    await storage.save(template);
+    const deleted = await storage.delete("test-1");
+
+    expect(deleted).toBe(true);
+
+    const templates = await storage.getAll();
+    expect(templates).toHaveLength(0);
+  });
+
+  it("returns false when deleting non-existent template", async () => {
+    const deleted = await storage.delete("non-existent");
+    expect(deleted).toBe(false);
+  });
+
+  it("can clear all templates", async () => {
+    const template1: FormTemplate = {
+      metadata: {
+        id: "test-1",
+        name: "Template 1",
+        description: "First template",
+        category: "custom",
+        icon: "file",
+        isBuiltIn: false,
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+      title: "Form 1",
+      fields: [],
+    };
+
+    const template2: FormTemplate = {
+      metadata: {
+        id: "test-2",
+        name: "Template 2",
+        description: "Second template",
+        category: "guild",
+        icon: "file",
+        isBuiltIn: false,
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+      title: "Form 2",
+      fields: [],
+    };
+
+    await storage.save(template1);
+    await storage.save(template2);
+    await storage.clear();
+
+    const templates = await storage.getAll();
+    expect(templates).toHaveLength(0);
+  });
+});
+
+describe("createTemplateRegistry", () => {
+  let storage: TemplateStorage;
+
+  beforeEach(() => {
+    storage = createInMemoryStorage();
+  });
+
+  describe("getBuiltIn", () => {
+    it("returns all built-in templates", () => {
+      const registry = createTemplateRegistry(storage);
+      const templates = registry.getBuiltIn();
+
+      expect(templates).toHaveLength(builtInTemplates.length);
+      expect(templates).toEqual(builtInTemplates);
+    });
+
+    it("returns a copy, not the original array", () => {
+      const registry = createTemplateRegistry(storage);
+      const templates1 = registry.getBuiltIn();
+      const templates2 = registry.getBuiltIn();
+
+      expect(templates1).not.toBe(templates2);
+      expect(templates1).toEqual(templates2);
+    });
+  });
+
+  describe("getCustom", () => {
+    it("initially returns empty array", async () => {
+      const registry = createTemplateRegistry(storage);
+      const templates = await registry.getCustom();
+
+      expect(templates).toEqual([]);
+    });
+
+    it("returns saved custom templates", async () => {
+      const registry = createTemplateRegistry(storage);
+
+      await registry.saveCustom({
+        metadata: {
+          name: "My Template",
+          description: "A custom template",
+          category: "custom",
+          icon: "file",
+        },
+        title: "My Form",
+        fields: [],
+      });
+
+      const templates = await registry.getCustom();
+      expect(templates).toHaveLength(1);
+      expect(templates[0]!.metadata.name).toBe("My Template");
+    });
+  });
+
+  describe("getAll", () => {
+    it("returns built-in templates when no custom exist", async () => {
+      const registry = createTemplateRegistry(storage);
+      const templates = await registry.getAll();
+
+      expect(templates).toHaveLength(builtInTemplates.length);
+    });
+
+    it("returns both built-in and custom templates", async () => {
+      const registry = createTemplateRegistry(storage);
+
+      await registry.saveCustom({
+        metadata: {
+          name: "My Template",
+          description: "A custom template",
+          category: "custom",
+          icon: "file",
+        },
+        title: "My Form",
+        fields: [],
+      });
+
+      const templates = await registry.getAll();
+      expect(templates).toHaveLength(builtInTemplates.length + 1);
+    });
+  });
+
+  describe("get", () => {
+    it("returns built-in template by id", async () => {
+      const registry = createTemplateRegistry(storage);
+      const template = await registry.get("general-application");
+
+      expect(template).toBeDefined();
+      expect(template?.metadata.id).toBe("general-application");
+    });
+
+    it("returns custom template by id", async () => {
+      const registry = createTemplateRegistry(storage);
+
+      const saved = await registry.saveCustom({
+        metadata: {
+          name: "My Template",
+          description: "A custom template",
+          category: "custom",
+          icon: "file",
+        },
+        title: "My Form",
+        fields: [],
+      });
+
+      const template = await registry.get(saved.metadata.id);
+
+      expect(template).toBeDefined();
+      expect(template?.metadata.id).toBe(saved.metadata.id);
+    });
+
+    it("returns undefined for unknown id", async () => {
+      const registry = createTemplateRegistry(storage);
+      const template = await registry.get("unknown-id");
+
+      expect(template).toBeUndefined();
+    });
+
+    it("prefers built-in over custom with same id (edge case)", async () => {
+      const registry = createTemplateRegistry(storage);
+      const template = await registry.get("general-application");
+
+      expect(template?.metadata.isBuiltIn).toBe(true);
+    });
+  });
+
+  describe("getByCategory", () => {
+    it("returns templates filtered by category", async () => {
+      const registry = createTemplateRegistry(storage);
+
+      const guildTemplates = await registry.getByCategory("guild");
+      expect(guildTemplates.every((t) => t.metadata.category === "guild")).toBe(true);
+
+      const recruitmentTemplates = await registry.getByCategory("recruitment");
+      expect(recruitmentTemplates.every((t) => t.metadata.category === "recruitment")).toBe(true);
+    });
+
+    it("includes custom templates in category filter", async () => {
+      const registry = createTemplateRegistry(storage);
+
+      await registry.saveCustom({
+        metadata: {
+          name: "Custom Guild Template",
+          description: "A custom guild template",
+          category: "guild",
+          icon: "file",
+        },
+        title: "Custom Guild Form",
+        fields: [],
+      });
+
+      const guildTemplates = await registry.getByCategory("guild");
+      expect(guildTemplates.some((t) => t.metadata.name === "Custom Guild Template")).toBe(true);
+    });
+
+    it("returns empty array for category with no templates", async () => {
+      const registry = createTemplateRegistry(storage);
+      const templates = await registry.getByCategory("custom");
+
+      expect(templates).toHaveLength(0);
+    });
+  });
+
+  describe("saveCustom", () => {
+    it("generates id for new template", async () => {
+      const registry = createTemplateRegistry(storage);
+
+      const saved = await registry.saveCustom({
+        metadata: {
+          name: "My Template",
+          description: "A custom template",
+          category: "custom",
+          icon: "file",
+        },
+        title: "My Form",
+        fields: [],
+      });
+
+      expect(saved.metadata.id).toBeTruthy();
+      expect(typeof saved.metadata.id).toBe("string");
+    });
+
+    it("sets isBuiltIn to false", async () => {
+      const registry = createTemplateRegistry(storage);
+
+      const saved = await registry.saveCustom({
+        metadata: {
+          name: "My Template",
+          description: "A custom template",
+          category: "custom",
+          icon: "file",
+        },
+        title: "My Form",
+        fields: [],
+      });
+
+      expect(saved.metadata.isBuiltIn).toBe(false);
+    });
+
+    it("sets createdAt and updatedAt timestamps", async () => {
+      const registry = createTemplateRegistry(storage);
+
+      const before = new Date().toISOString();
+
+      const saved = await registry.saveCustom({
+        metadata: {
+          name: "My Template",
+          description: "A custom template",
+          category: "custom",
+          icon: "file",
+        },
+        title: "My Form",
+        fields: [],
+      });
+
+      const after = new Date().toISOString();
+
+      expect(saved.metadata.createdAt).toBeTruthy();
+      expect(saved.metadata.updatedAt).toBeTruthy();
+      expect(saved.metadata.createdAt >= before).toBe(true);
+      expect(saved.metadata.createdAt <= after).toBe(true);
+    });
+
+    it("preserves template fields", async () => {
+      const registry = createTemplateRegistry(storage);
+
+      const saved = await registry.saveCustom({
+        metadata: {
+          name: "My Template",
+          description: "A custom template",
+          category: "custom",
+          icon: "file",
+        },
+        title: "My Form",
+        fields: [
+          { inputType: "text", label: "Name", required: true },
+          { inputType: "textarea", label: "Bio", required: false },
+        ],
+      });
+
+      expect(saved.fields).toHaveLength(2);
+      expect(saved.fields[0]!.label).toBe("Name");
+      expect(saved.fields[1]!.label).toBe("Bio");
+    });
+  });
+
+  describe("deleteCustom", () => {
+    it("deletes custom template", async () => {
+      const registry = createTemplateRegistry(storage);
+
+      const saved = await registry.saveCustom({
+        metadata: {
+          name: "My Template",
+          description: "A custom template",
+          category: "custom",
+          icon: "file",
+        },
+        title: "My Form",
+        fields: [],
+      });
+
+      const deleted = await registry.deleteCustom(saved.metadata.id);
+      expect(deleted).toBe(true);
+
+      const template = await registry.get(saved.metadata.id);
+      expect(template).toBeUndefined();
+    });
+
+    it("cannot delete built-in template", async () => {
+      const registry = createTemplateRegistry(storage);
+
+      const deleted = await registry.deleteCustom("general-application");
+      expect(deleted).toBe(false);
+
+      const template = await registry.get("general-application");
+      expect(template).toBeDefined();
+    });
+
+    it("returns false for non-existent template", async () => {
+      const registry = createTemplateRegistry(storage);
+
+      const deleted = await registry.deleteCustom("non-existent");
+      expect(deleted).toBe(false);
+    });
+  });
+});
+
+describe("createInMemoryRegistry", () => {
+  it("creates a registry with in-memory storage", async () => {
+    const registry = createInMemoryRegistry();
+
+    // Should have built-in templates
+    expect(registry.getBuiltIn()).toHaveLength(builtInTemplates.length);
+
+    // Should be able to save and retrieve custom templates
+    const saved = await registry.saveCustom({
+      metadata: {
+        name: "Test",
+        description: "Test",
+        category: "custom",
+        icon: "file",
+      },
+      title: "Test",
+      fields: [],
+    });
+
+    const custom = await registry.getCustom();
+    expect(custom).toHaveLength(1);
+    expect(custom[0]!.metadata.id).toBe(saved.metadata.id);
+  });
+});
+
+describe("getDefaultRegistry", () => {
+  beforeEach(() => {
+    resetDefaultRegistry();
+  });
+
+  it("returns a registry instance", () => {
+    const registry = getDefaultRegistry();
+
+    expect(registry).toBeDefined();
+    expect(typeof registry.getBuiltIn).toBe("function");
+    expect(typeof registry.getCustom).toBe("function");
+  });
+
+  it("returns the same instance on multiple calls", () => {
+    const registry1 = getDefaultRegistry();
+    const registry2 = getDefaultRegistry();
+
+    expect(registry1).toBe(registry2);
+  });
+
+  it("resetDefaultRegistry creates new instance", () => {
+    const registry1 = getDefaultRegistry();
+    resetDefaultRegistry();
+    const registry2 = getDefaultRegistry();
+
+    expect(registry1).not.toBe(registry2);
+  });
+});

--- a/packages/ui/test/designer/templates/types.test.ts
+++ b/packages/ui/test/designer/templates/types.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Template Types Tests (PZ-106)
+ *
+ * Tests for template type definitions and interfaces.
+ */
+
+import { describe, expect, it } from "vitest";
+import type {
+  TemplateCategory,
+  TemplateMetadata,
+  FormTemplate,
+  TemplateField,
+  TemplateSelectEvent,
+  TemplateSaveEvent,
+  TemplateDeleteEvent,
+  TemplateApplyResult,
+  TemplateStorage,
+  TemplateRegistry,
+} from "../../../src/designer/templates";
+
+describe("Template Types", () => {
+  describe("TemplateCategory", () => {
+    it("accepts valid category values", () => {
+      const categories: TemplateCategory[] = ["guild", "recruitment", "social", "custom"];
+
+      for (const category of categories) {
+        expect(category).toBeTruthy();
+      }
+    });
+  });
+
+  describe("TemplateMetadata", () => {
+    it("has correct structure", () => {
+      const metadata: TemplateMetadata = {
+        id: "test-template",
+        name: "Test Template",
+        description: "A test template for testing",
+        category: "guild",
+        icon: "file-text",
+        isBuiltIn: false,
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      };
+
+      expect(metadata.id).toBe("test-template");
+      expect(metadata.name).toBe("Test Template");
+      expect(metadata.description).toBe("A test template for testing");
+      expect(metadata.category).toBe("guild");
+      expect(metadata.icon).toBe("file-text");
+      expect(metadata.isBuiltIn).toBe(false);
+      expect(metadata.createdAt).toBe("2024-01-01T00:00:00.000Z");
+      expect(metadata.updatedAt).toBe("2024-01-01T00:00:00.000Z");
+    });
+
+    it("supports all category values", () => {
+      const categories: TemplateCategory[] = ["guild", "recruitment", "social", "custom"];
+
+      for (const category of categories) {
+        const metadata: TemplateMetadata = {
+          id: `test-${category}`,
+          name: `Test ${category}`,
+          description: "Description",
+          category,
+          icon: "file",
+          isBuiltIn: true,
+          createdAt: "2024-01-01T00:00:00.000Z",
+          updatedAt: "2024-01-01T00:00:00.000Z",
+        };
+
+        expect(metadata.category).toBe(category);
+      }
+    });
+  });
+
+  describe("TemplateField", () => {
+    it("has correct minimal structure", () => {
+      const field: TemplateField = {
+        inputType: "text",
+        label: "Name",
+        required: true,
+      };
+
+      expect(field.inputType).toBe("text");
+      expect(field.label).toBe("Name");
+      expect(field.required).toBe(true);
+    });
+
+    it("supports all optional properties", () => {
+      const field: TemplateField = {
+        inputType: "select",
+        label: "Class",
+        name: "characterClass",
+        placeholder: "Select your class",
+        helpText: "Choose your character class",
+        required: true,
+        options: [
+          { value: "warrior", label: "Warrior" },
+          { value: "mage", label: "Mage" },
+        ],
+        defaultValue: "warrior",
+        config: { searchable: true },
+      };
+
+      expect(field.name).toBe("characterClass");
+      expect(field.placeholder).toBe("Select your class");
+      expect(field.helpText).toBe("Choose your character class");
+      expect(field.options).toHaveLength(2);
+      expect(field.defaultValue).toBe("warrior");
+      expect(field.config).toEqual({ searchable: true });
+    });
+
+    it("supports different input types", () => {
+      const inputTypes = ["text", "textarea", "number", "checkbox", "select", "multiselect", "date", "file"];
+
+      for (const inputType of inputTypes) {
+        const field: TemplateField = {
+          inputType,
+          label: `Test ${inputType}`,
+          required: false,
+        };
+
+        expect(field.inputType).toBe(inputType);
+      }
+    });
+  });
+
+  describe("FormTemplate", () => {
+    it("has correct structure", () => {
+      const template: FormTemplate = {
+        metadata: {
+          id: "test-template",
+          name: "Test Template",
+          description: "A test template",
+          category: "guild",
+          icon: "file-text",
+          isBuiltIn: false,
+          createdAt: "2024-01-01T00:00:00.000Z",
+          updatedAt: "2024-01-01T00:00:00.000Z",
+        },
+        title: "Test Form",
+        description: "A test form description",
+        fields: [
+          { inputType: "text", label: "Name", required: true },
+          { inputType: "textarea", label: "Bio", required: false },
+        ],
+      };
+
+      expect(template.metadata.id).toBe("test-template");
+      expect(template.title).toBe("Test Form");
+      expect(template.description).toBe("A test form description");
+      expect(template.fields).toHaveLength(2);
+    });
+
+    it("supports optional description", () => {
+      const template: FormTemplate = {
+        metadata: {
+          id: "test",
+          name: "Test",
+          description: "Test description",
+          category: "guild",
+          icon: "file",
+          isBuiltIn: true,
+          createdAt: "2024-01-01T00:00:00.000Z",
+          updatedAt: "2024-01-01T00:00:00.000Z",
+        },
+        title: "Test Form",
+        fields: [],
+      };
+
+      expect(template.description).toBeUndefined();
+    });
+
+    it("supports empty fields array", () => {
+      const template: FormTemplate = {
+        metadata: {
+          id: "empty",
+          name: "Empty Template",
+          description: "No fields",
+          category: "custom",
+          icon: "file",
+          isBuiltIn: false,
+          createdAt: "2024-01-01T00:00:00.000Z",
+          updatedAt: "2024-01-01T00:00:00.000Z",
+        },
+        title: "Empty Form",
+        fields: [],
+      };
+
+      expect(template.fields).toHaveLength(0);
+    });
+  });
+
+  describe("TemplateSelectEvent", () => {
+    it("has correct structure", () => {
+      const template: FormTemplate = {
+        metadata: {
+          id: "test",
+          name: "Test",
+          description: "Test",
+          category: "guild",
+          icon: "file",
+          isBuiltIn: true,
+          createdAt: "2024-01-01T00:00:00.000Z",
+          updatedAt: "2024-01-01T00:00:00.000Z",
+        },
+        title: "Test",
+        fields: [],
+      };
+
+      const event: TemplateSelectEvent = {
+        template,
+      };
+
+      expect(event.template).toBe(template);
+    });
+  });
+
+  describe("TemplateDeleteEvent", () => {
+    it("has correct structure", () => {
+      const event: TemplateDeleteEvent = {
+        templateId: "template-123",
+      };
+
+      expect(event.templateId).toBe("template-123");
+    });
+  });
+
+  describe("TemplateApplyResult", () => {
+    it("has correct structure", () => {
+      const result: TemplateApplyResult = {
+        canvasState: {
+          id: "canvas-123",
+          title: "Test Form",
+          description: "A test form",
+          fields: [],
+          selectedFieldId: null,
+          isPreviewMode: false,
+        },
+        fieldCount: 5,
+      };
+
+      expect(result.canvasState.id).toBe("canvas-123");
+      expect(result.fieldCount).toBe(5);
+    });
+  });
+});
+
+describe("Interface Contract Tests", () => {
+  it("TemplateStorage interface has required methods", () => {
+    // This tests that the interface is correctly defined
+    const mockStorage: TemplateStorage = {
+      getAll: async () => [],
+      save: async () => {},
+      delete: async () => true,
+      clear: async () => {},
+    };
+
+    expect(typeof mockStorage.getAll).toBe("function");
+    expect(typeof mockStorage.save).toBe("function");
+    expect(typeof mockStorage.delete).toBe("function");
+    expect(typeof mockStorage.clear).toBe("function");
+  });
+
+  it("TemplateRegistry interface has required methods", () => {
+    const mockRegistry: TemplateRegistry = {
+      getBuiltIn: () => [],
+      getCustom: async () => [],
+      getAll: async () => [],
+      get: async () => undefined,
+      getByCategory: async () => [],
+      saveCustom: async () => ({
+        metadata: {
+          id: "new",
+          name: "New",
+          description: "New",
+          category: "custom",
+          icon: "file",
+          isBuiltIn: false,
+          createdAt: "2024-01-01T00:00:00.000Z",
+          updatedAt: "2024-01-01T00:00:00.000Z",
+        },
+        title: "New Form",
+        fields: [],
+      }),
+      deleteCustom: async () => true,
+    };
+
+    expect(typeof mockRegistry.getBuiltIn).toBe("function");
+    expect(typeof mockRegistry.getCustom).toBe("function");
+    expect(typeof mockRegistry.getAll).toBe("function");
+    expect(typeof mockRegistry.get).toBe("function");
+    expect(typeof mockRegistry.getByCategory).toBe("function");
+    expect(typeof mockRegistry.saveCustom).toBe("function");
+    expect(typeof mockRegistry.deleteCustom).toBe("function");
+  });
+});


### PR DESCRIPTION
## Summary
- Add pre-built form templates for common guild application needs (General Application, Raid Recruitment, Casual Join)
- Implement TemplateSelector component for browsing and selecting templates with preview
- Create template registry for managing built-in and custom templates with localStorage persistence
- Add utility functions for applying, merging, and validating templates

## Test plan
- [ ] Verify all 137 new template tests pass (`pnpm test:unit`)
- [ ] Verify TypeScript types are correct (`pnpm typecheck`)
- [ ] Verify build succeeds (`pnpm build`)
- [ ] Test template preview shows correct field information
- [ ] Test applying a template creates proper canvas state with unique IDs
- [ ] Test saving custom templates persists to localStorage
- [ ] Test deleting custom templates works (but built-in cannot be deleted)

Closes #38

Generated with [Claude Code](https://claude.com/claude-code)