### PR TITLE
fix: address Copilot review comments from PRs #102-105

### DIFF
--- a/packages/edit/src/components/property-editor/PropertyEditor.tsx
+++ b/packages/edit/src/components/property-editor/PropertyEditor.tsx
@@ -81,18 +81,15 @@ export function PropertyEditor({
 
   // Local state for form values (allows editing before commit)
   const [localValues, setLocalValues] = useState<Record<string, unknown>>({});
-  const [initialized, setInitialized] = useState(false);
 
   // Sync local values with selected block props
   useEffect(() => {
     if (selectedBlock) {
       // Cast to Record<string, unknown> since BlockProps extends an interface
       setLocalValues(selectedBlock.props as Record<string, unknown>);
-      setInitialized(true);
       clearErrors();
     } else {
       setLocalValues({});
-      setInitialized(false);
       clearErrors();
     }
   }, [selectedBlock?.id]);

--- a/packages/edit/src/components/property-editor/state.ts
+++ b/packages/edit/src/components/property-editor/state.ts
@@ -6,7 +6,7 @@
  */
 
 import { atom, computed, type ReadableAtom, type WritableAtom } from "nanostores";
-import { $document, $selectedBlockId, findBlockById, findBlockIndex, findParentBlock } from "../../model/document";
+import { $document, findBlockById } from "../../model/document";
 import type { Block } from "../../model/types";
 import { getComponentBlockRegistry } from "../../registry/blocks";
 import type { BaseComponentBlockDefinition } from "../../registry/types";

--- a/packages/edit/test/components/property-editor/FormField.test.tsx
+++ b/packages/edit/test/components/property-editor/FormField.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { FormField } from "../../../src/components/property-editor/FormField";
 import type { FieldMeta, FieldError } from "../../../src/components/property-editor/types";

--- a/packages/edit/test/components/property-editor/PropertyEditor.test.tsx
+++ b/packages/edit/test/components/property-editor/PropertyEditor.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { uuidv7 } from "uuidv7";
 import { PropertyEditor } from "../../../src/components/property-editor/PropertyEditor";

--- a/packages/ui/src/designer/Preview.tsx
+++ b/packages/ui/src/designer/Preview.tsx
@@ -19,7 +19,6 @@ import {
   useContext,
   useEffect,
 } from "react";
-import { z } from "zod";
 
 import type { CanvasField, CanvasState } from "./types";
 
@@ -336,9 +335,11 @@ interface FieldInputProps {
 }
 
 function TextFieldInput({ field, value, onChange, error, disabled }: FieldInputProps) {
-  const stringValue = value as string ?? "";
+  const stringValue = (value ?? "") as string;
   const inputId = `preview-field-${field.id}`;
   const errorId = `${inputId}-error`;
+  const helpId = `${inputId}-help`;
+  const describedBy = [error ? errorId : null, field.helpText ? helpId : null].filter(Boolean).join(" ") || undefined;
 
   return (
     <div data-testid={`preview-input-container-${field.id}`}>
@@ -351,16 +352,18 @@ function TextFieldInput({ field, value, onChange, error, disabled }: FieldInputP
         placeholder={field.placeholder ?? `Enter ${field.label.toLowerCase()}`}
         disabled={disabled}
         aria-invalid={!!error}
-        aria-describedby={error ? errorId : undefined}
+        aria-describedby={describedBy}
       />
     </div>
   );
 }
 
 function TextAreaInput({ field, value, onChange, error, disabled }: FieldInputProps) {
-  const stringValue = value as string ?? "";
+  const stringValue = (value ?? "") as string;
   const inputId = `preview-field-${field.id}`;
   const errorId = `${inputId}-error`;
+  const helpId = `${inputId}-help`;
+  const describedBy = [error ? errorId : null, field.helpText ? helpId : null].filter(Boolean).join(" ") || undefined;
 
   return (
     <div data-testid={`preview-input-container-${field.id}`}>
@@ -373,16 +376,19 @@ function TextAreaInput({ field, value, onChange, error, disabled }: FieldInputPr
         disabled={disabled}
         rows={3}
         aria-invalid={!!error}
-        aria-describedby={error ? errorId : undefined}
+        aria-describedby={describedBy}
       />
     </div>
   );
 }
 
 function NumberFieldInput({ field, value, onChange, error, disabled }: FieldInputProps) {
-  const numberValue = value as number | null ?? "";
+  // Convert null to empty string for the input value
+  const numberValue = value === null || value === undefined ? "" : (value as number);
   const inputId = `preview-field-${field.id}`;
   const errorId = `${inputId}-error`;
+  const helpId = `${inputId}-help`;
+  const describedBy = [error ? errorId : null, field.helpText ? helpId : null].filter(Boolean).join(" ") || undefined;
 
   return (
     <div data-testid={`preview-input-container-${field.id}`}>
@@ -398,16 +404,18 @@ function NumberFieldInput({ field, value, onChange, error, disabled }: FieldInpu
         placeholder={field.placeholder ?? "Enter a number"}
         disabled={disabled}
         aria-invalid={!!error}
-        aria-describedby={error ? errorId : undefined}
+        aria-describedby={describedBy}
       />
     </div>
   );
 }
 
 function CheckboxInput({ field, value, onChange, error, disabled }: FieldInputProps) {
-  const boolValue = value as boolean ?? false;
+  const boolValue = (value ?? false) as boolean;
   const inputId = `preview-field-${field.id}`;
   const errorId = `${inputId}-error`;
+  const helpId = `${inputId}-help`;
+  const describedBy = [error ? errorId : null, field.helpText ? helpId : null].filter(Boolean).join(" ") || undefined;
 
   return (
     <div data-testid={`preview-input-container-${field.id}`}>
@@ -420,7 +428,7 @@ function CheckboxInput({ field, value, onChange, error, disabled }: FieldInputPr
           onChange={(e) => onChange(e.target.checked)}
           disabled={disabled}
           aria-invalid={!!error}
-          aria-describedby={error ? errorId : undefined}
+          aria-describedby={describedBy}
         />
         {field.label}
       </label>
@@ -429,9 +437,11 @@ function CheckboxInput({ field, value, onChange, error, disabled }: FieldInputPr
 }
 
 function SelectInput({ field, value, onChange, error, disabled }: FieldInputProps) {
-  const stringValue = value as string ?? "";
+  const stringValue = (value ?? "") as string;
   const inputId = `preview-field-${field.id}`;
   const errorId = `${inputId}-error`;
+  const helpId = `${inputId}-help`;
+  const describedBy = [error ? errorId : null, field.helpText ? helpId : null].filter(Boolean).join(" ") || undefined;
 
   return (
     <div data-testid={`preview-input-container-${field.id}`}>
@@ -442,7 +452,7 @@ function SelectInput({ field, value, onChange, error, disabled }: FieldInputProp
         onChange={(e) => onChange(e.target.value)}
         disabled={disabled}
         aria-invalid={!!error}
-        aria-describedby={error ? errorId : undefined}
+        aria-describedby={describedBy}
       >
         <option value="">{field.placeholder ?? "Select an option"}</option>
         {field.options?.map((option) => (
@@ -456,9 +466,11 @@ function SelectInput({ field, value, onChange, error, disabled }: FieldInputProp
 }
 
 function MultiSelectInput({ field, value, onChange, error, disabled }: FieldInputProps) {
-  const arrayValue = value as string[] ?? [];
+  const arrayValue = (value ?? []) as string[];
   const inputId = `preview-field-${field.id}`;
   const errorId = `${inputId}-error`;
+  const helpId = `${inputId}-help`;
+  const describedBy = [error ? errorId : null, field.helpText ? helpId : null].filter(Boolean).join(" ") || undefined;
 
   const handleChange = useCallback(
     (optionValue: string, checked: boolean) => {
@@ -476,7 +488,7 @@ function MultiSelectInput({ field, value, onChange, error, disabled }: FieldInpu
       role="group"
       aria-labelledby={`preview-label-${field.id}`}
       aria-invalid={!!error}
-      aria-describedby={error ? errorId : undefined}
+      aria-describedby={describedBy}
     >
       {field.options?.map((option) => (
         <label
@@ -510,6 +522,8 @@ function DateInput({ field, value, onChange, error, disabled }: FieldInputProps)
 
   const inputId = `preview-field-${field.id}`;
   const errorId = `${inputId}-error`;
+  const helpId = `${inputId}-help`;
+  const describedBy = [error ? errorId : null, field.helpText ? helpId : null].filter(Boolean).join(" ") || undefined;
 
   return (
     <div data-testid={`preview-input-container-${field.id}`}>
@@ -524,7 +538,7 @@ function DateInput({ field, value, onChange, error, disabled }: FieldInputProps)
         }}
         disabled={disabled}
         aria-invalid={!!error}
-        aria-describedby={error ? errorId : undefined}
+        aria-describedby={describedBy}
       />
     </div>
   );
@@ -533,6 +547,8 @@ function DateInput({ field, value, onChange, error, disabled }: FieldInputProps)
 function FileInput({ field, value, onChange, error, disabled }: FieldInputProps) {
   const inputId = `preview-field-${field.id}`;
   const errorId = `${inputId}-error`;
+  const helpId = `${inputId}-help`;
+  const describedBy = [error ? errorId : null, field.helpText ? helpId : null].filter(Boolean).join(" ") || undefined;
 
   // Get file name(s) for display
   let displayText = "No file selected";
@@ -557,9 +573,9 @@ function FileInput({ field, value, onChange, error, disabled }: FieldInputProps)
           }
         }}
         disabled={disabled}
-        multiple={field.config?.multiple as boolean ?? false}
+        multiple={(field.config?.multiple ?? false) as boolean}
         aria-invalid={!!error}
-        aria-describedby={error ? errorId : undefined}
+        aria-describedby={describedBy}
       />
       <span data-testid={`preview-file-display-${field.id}`}>{displayText}</span>
     </div>
@@ -575,7 +591,7 @@ interface FormPreviewFieldProps {
 }
 
 function FormPreviewField({ field }: FormPreviewFieldProps) {
-  const { values, errors, onValueChange, getFieldError } = usePreview();
+  const { values, onValueChange, getFieldError } = usePreview();
 
   const value = values[field.id];
   const error = getFieldError(field.id);

--- a/packages/ui/src/designer/templates/TemplateSelector.tsx
+++ b/packages/ui/src/designer/templates/TemplateSelector.tsx
@@ -21,7 +21,7 @@ import {
 import type { CanvasState } from "../types";
 import { applyTemplate, canvasStateToTemplate } from "./apply";
 import { builtInTemplates } from "./builtin";
-import { getDefaultRegistry, createInMemoryRegistry } from "./registry";
+import { getDefaultRegistry } from "./registry";
 import type {
   FormTemplate,
   TemplateCategory,
@@ -290,6 +290,7 @@ function TemplatePreview({ template, onApply, onClose }: TemplatePreviewProps) {
     <aside
       data-testid="template-preview"
       role="dialog"
+      aria-modal="true"
       aria-label={`Preview of ${template.metadata.name}`}
     >
       <header data-testid="preview-header">


### PR DESCRIPTION
## Summary

This PR addresses code review comments from GitHub Copilot across recently merged PRs:

**PR #102 (Block Property Editor):**
- Remove unused `initialized` state variable in PropertyEditor.tsx
- Remove unused imports (`$selectedBlockId`, `findBlockIndex`, `findParentBlock`) from state.ts
- Remove unused `fireEvent` import from test files

**PR #104 (Live Preview):**
- Remove unused `z` import from zod
- Remove unused `errors` variable in FormPreviewField
- Fix type cast order for nullish coalescing (use `(value ?? "") as Type` instead of `value as Type ?? ""`)
- Improve aria-describedby to reference both error and help text IDs for better accessibility

**PR #105 (Form Templates):**
- Remove unused `createInMemoryRegistry` import
- Add `aria-modal="true"` to TemplatePreview dialog for proper accessibility

## Test plan

- [x] All 861 tests pass in @phantom-zone/edit
- [x] All 587 tests pass in @phantom-zone/ui
- [x] TypeScript type checking passes for both packages

Generated with [Claude Code](https://claude.com/claude-code)