### PR TITLE
feat: add FormDescriptor to Zod v4 source codegen

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,3 +40,12 @@ export {
   findMatchingRule,
   resolveField,
 } from "./mapping";
+
+// Schema writer types
+export type {
+  SchemaWriterOptions,
+  SchemaWriterResult,
+} from "./schema-writer";
+
+// Schema writer functions
+export { emitField, writeSchema } from "./schema-writer";

--- a/src/schema-writer/index.ts
+++ b/src/schema-writer/index.ts
@@ -1,0 +1,3 @@
+export { emitField } from "./field-emitter";
+export type { SchemaWriterOptions, SchemaWriterResult } from "./types";
+export { writeSchema } from "./writer";

--- a/src/schema-writer/types.ts
+++ b/src/schema-writer/types.ts
@@ -1,0 +1,13 @@
+import type { FormDescriptor } from "../introspection";
+
+export interface SchemaWriterOptions {
+  /** The FormDescriptor to convert */
+  form: FormDescriptor;
+}
+
+export interface SchemaWriterResult {
+  /** Generated Zod v4 source code */
+  code: string;
+  /** Warnings from generation (e.g., unsupported features skipped) */
+  warnings: string[];
+}

--- a/src/schema-writer/writer.ts
+++ b/src/schema-writer/writer.ts
@@ -1,0 +1,31 @@
+import { inferTypeName } from "../codegen";
+import { emitField } from "./field-emitter";
+import type { SchemaWriterOptions, SchemaWriterResult } from "./types";
+
+/**
+ * Generates Zod v4 source code from a FormDescriptor.
+ * Only supports scalar types and arrays of scalars/enums.
+ * Throws on unsupported field types (object, union, tuple, record).
+ */
+export function writeSchema(options: SchemaWriterOptions): SchemaWriterResult {
+  const { form } = options;
+
+  const fieldEntries = form.fields.map(
+    (field) => `  ${field.name}: ${emitField(field)},`,
+  );
+
+  const typeName = inferTypeName(form.schemaExportName);
+
+  const code = [
+    'import { z } from "zod/v4";',
+    "",
+    `export const ${form.schemaExportName} = z.object({`,
+    ...fieldEntries,
+    "});",
+    "",
+    `export type ${typeName} = z.infer<typeof ${form.schemaExportName}>;`,
+    "",
+  ].join("\n");
+
+  return { code, warnings: [] };
+}

--- a/test/schema-writer/field-emitter.test.ts
+++ b/test/schema-writer/field-emitter.test.ts
@@ -1,0 +1,316 @@
+import { describe, expect, it } from "vitest";
+import { emitField } from "../../src/schema-writer/field-emitter";
+import { makeField } from "./helpers";
+
+describe("emitField", () => {
+  describe("string fields", () => {
+    it("emits z.string() for plain string", () => {
+      const field = makeField({ type: "string", metadata: { kind: "string" } });
+      expect(emitField(field)).toBe("z.string()");
+    });
+
+    it("emits z.string().min().max() with constraints", () => {
+      const field = makeField({
+        type: "string",
+        constraints: { minLength: 1, maxLength: 100 },
+        metadata: { kind: "string" },
+      });
+      expect(emitField(field)).toBe("z.string().min(1).max(100)");
+    });
+
+    it("emits z.string().regex() with pattern", () => {
+      const field = makeField({
+        type: "string",
+        constraints: { pattern: "^[a-z]+$" },
+        metadata: { kind: "string" },
+      });
+      expect(emitField(field)).toBe("z.string().regex(/^[a-z]+$/)");
+    });
+
+    it("emits z.email() for email format", () => {
+      const field = makeField({
+        type: "string",
+        constraints: { format: "email" },
+        metadata: { kind: "string" },
+      });
+      expect(emitField(field)).toBe("z.email()");
+    });
+
+    it("emits z.url() for url format", () => {
+      const field = makeField({
+        type: "string",
+        constraints: { format: "url" },
+        metadata: { kind: "string" },
+      });
+      expect(emitField(field)).toBe("z.url()");
+    });
+
+    it("emits z.uuid() for uuid format", () => {
+      const field = makeField({
+        type: "string",
+        constraints: { format: "uuid" },
+        metadata: { kind: "string" },
+      });
+      expect(emitField(field)).toBe("z.uuid()");
+    });
+
+    it("emits z.cuid() for cuid format", () => {
+      const field = makeField({
+        type: "string",
+        constraints: { format: "cuid" },
+        metadata: { kind: "string" },
+      });
+      expect(emitField(field)).toBe("z.cuid()");
+    });
+
+    it("emits z.iso.datetime() for datetime format", () => {
+      const field = makeField({
+        type: "string",
+        constraints: { format: "datetime" },
+        metadata: { kind: "string" },
+      });
+      expect(emitField(field)).toBe("z.iso.datetime()");
+    });
+
+    it("chains constraints after format types", () => {
+      const field = makeField({
+        type: "string",
+        constraints: { format: "email", minLength: 5 },
+        metadata: { kind: "string" },
+      });
+      expect(emitField(field)).toBe("z.email().min(5)");
+    });
+  });
+
+  describe("number fields", () => {
+    it("emits z.number() for plain number", () => {
+      const field = makeField({
+        type: "number",
+        constraints: {},
+        metadata: { kind: "number" },
+      });
+      expect(emitField(field)).toBe("z.number()");
+    });
+
+    it("emits z.number().int() when isInt constraint is set", () => {
+      const field = makeField({
+        type: "number",
+        constraints: { isInt: true },
+        metadata: { kind: "number" },
+      });
+      expect(emitField(field)).toBe("z.number().int()");
+    });
+
+    it("emits z.number().min().max() with range constraints", () => {
+      const field = makeField({
+        type: "number",
+        constraints: { min: 0, max: 100 },
+        metadata: { kind: "number" },
+      });
+      expect(emitField(field)).toBe("z.number().min(0).max(100)");
+    });
+
+    it("emits z.number().int().min().max() combining isInt and range", () => {
+      const field = makeField({
+        type: "number",
+        constraints: { isInt: true, min: 1, max: 10 },
+        metadata: { kind: "number" },
+      });
+      expect(emitField(field)).toBe("z.number().int().min(1).max(10)");
+    });
+
+    it("emits .multipleOf() for step constraint", () => {
+      const field = makeField({
+        type: "number",
+        constraints: { step: 0.5 },
+        metadata: { kind: "number" },
+      });
+      expect(emitField(field)).toBe("z.number().multipleOf(0.5)");
+    });
+  });
+
+  describe("boolean fields", () => {
+    it("emits z.boolean()", () => {
+      const field = makeField({
+        type: "boolean",
+        metadata: { kind: "boolean" },
+      });
+      expect(emitField(field)).toBe("z.boolean()");
+    });
+  });
+
+  describe("date fields", () => {
+    it("emits z.date()", () => {
+      const field = makeField({ type: "date", metadata: { kind: "date" } });
+      expect(emitField(field)).toBe("z.date()");
+    });
+  });
+
+  describe("enum fields", () => {
+    it("emits z.enum() with values", () => {
+      const field = makeField({
+        type: "enum",
+        metadata: { kind: "enum", values: ["admin", "user", "guest"] },
+      });
+      expect(emitField(field)).toBe('z.enum(["admin", "user", "guest"])');
+    });
+
+    it("emits z.enum() with single value", () => {
+      const field = makeField({
+        type: "enum",
+        metadata: { kind: "enum", values: ["only"] },
+      });
+      expect(emitField(field)).toBe('z.enum(["only"])');
+    });
+  });
+
+  describe("array fields", () => {
+    it("emits z.array() with scalar element", () => {
+      const field = makeField({
+        type: "array",
+        metadata: {
+          kind: "array",
+          element: makeField({
+            name: "item",
+            type: "string",
+            metadata: { kind: "string" },
+          }),
+        },
+      });
+      expect(emitField(field)).toBe("z.array(z.string())");
+    });
+
+    it("emits z.array() with enum element", () => {
+      const field = makeField({
+        type: "array",
+        metadata: {
+          kind: "array",
+          element: makeField({
+            name: "item",
+            type: "enum",
+            metadata: { kind: "enum", values: ["a", "b"] },
+          }),
+        },
+      });
+      expect(emitField(field)).toBe('z.array(z.enum(["a", "b"]))');
+    });
+
+    it("emits z.array().min().max() with item constraints", () => {
+      const field = makeField({
+        type: "array",
+        constraints: { minItems: 1, maxItems: 5 },
+        metadata: {
+          kind: "array",
+          element: makeField({
+            name: "item",
+            type: "number",
+            metadata: { kind: "number" },
+          }),
+        },
+      });
+      expect(emitField(field)).toBe("z.array(z.number()).min(1).max(5)");
+    });
+  });
+
+  describe("optional and nullable wrapping", () => {
+    it("wraps with .optional()", () => {
+      const field = makeField({
+        type: "string",
+        isOptional: true,
+        metadata: { kind: "string" },
+      });
+      expect(emitField(field)).toBe("z.string().optional()");
+    });
+
+    it("wraps with .nullable()", () => {
+      const field = makeField({
+        type: "string",
+        isNullable: true,
+        metadata: { kind: "string" },
+      });
+      expect(emitField(field)).toBe("z.string().nullable()");
+    });
+
+    it("wraps nullable then optional (correct order)", () => {
+      const field = makeField({
+        type: "string",
+        isOptional: true,
+        isNullable: true,
+        metadata: { kind: "string" },
+      });
+      expect(emitField(field)).toBe("z.string().nullable().optional()");
+    });
+  });
+
+  describe("description", () => {
+    it("chains .describe() when description exists", () => {
+      const field = makeField({
+        type: "string",
+        description: "A user name",
+        metadata: { kind: "string" },
+      });
+      expect(emitField(field)).toBe('z.string().describe("A user name")');
+    });
+
+    it("places .describe() after optional/nullable", () => {
+      const field = makeField({
+        type: "number",
+        isOptional: true,
+        isNullable: true,
+        description: "Age in years",
+        metadata: { kind: "number" },
+      });
+      expect(emitField(field)).toBe(
+        'z.number().nullable().optional().describe("Age in years")',
+      );
+    });
+
+    it("escapes special characters in description", () => {
+      const field = makeField({
+        type: "string",
+        description: 'Uses "quotes" and \\backslashes',
+        metadata: { kind: "string" },
+      });
+      expect(emitField(field)).toBe(
+        'z.string().describe("Uses \\"quotes\\" and \\\\backslashes")',
+      );
+    });
+  });
+
+  describe("unsupported types", () => {
+    it("throws on object type", () => {
+      const field = makeField({
+        type: "object",
+        metadata: { kind: "object", fields: [] },
+      });
+      expect(() => emitField(field)).toThrow('Unsupported field type "object"');
+    });
+
+    it("throws on union type", () => {
+      const field = makeField({
+        type: "union",
+        metadata: { kind: "union", variants: [] },
+      });
+      expect(() => emitField(field)).toThrow('Unsupported field type "union"');
+    });
+
+    it("throws on tuple type", () => {
+      const field = makeField({
+        type: "tuple",
+        metadata: { kind: "tuple", elements: [] },
+      });
+      expect(() => emitField(field)).toThrow('Unsupported field type "tuple"');
+    });
+
+    it("throws on record type", () => {
+      const field = makeField({
+        type: "record",
+        metadata: {
+          kind: "record",
+          valueDescriptor: makeField({ name: "value" }),
+        },
+      });
+      expect(() => emitField(field)).toThrow('Unsupported field type "record"');
+    });
+  });
+});

--- a/test/schema-writer/helpers.ts
+++ b/test/schema-writer/helpers.ts
@@ -1,0 +1,29 @@
+import type { FieldDescriptor, FormDescriptor } from "../../src/introspection";
+
+export function makeField(
+  overrides: Partial<FieldDescriptor>,
+): FieldDescriptor {
+  return {
+    name: "test",
+    label: "Test",
+    type: "string",
+    isOptional: false,
+    isNullable: false,
+    constraints: {},
+    metadata: { kind: "string" },
+    ...overrides,
+  };
+}
+
+export function makeForm(
+  overrides: Partial<FormDescriptor> = {},
+): FormDescriptor {
+  return {
+    name: "TestForm",
+    fields: [],
+    schemaImportPath: "./schema",
+    schemaExportName: "testSchema",
+    warnings: [],
+    ...overrides,
+  };
+}

--- a/test/schema-writer/round-trip.test.ts
+++ b/test/schema-writer/round-trip.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod/v4";
+import { introspect } from "../../src/introspection";
+import { writeSchema } from "../../src/schema-writer/writer";
+
+const INTROSPECT_OPTS = {
+  formName: "TestForm",
+  schemaImportPath: "./schema",
+  schemaExportName: "testSchema",
+};
+
+/**
+ * Introspects a schema, writes it back to source, evaluates the source,
+ * introspects the result, and compares the two descriptors.
+ */
+function roundTrip(schema: z.ZodObject) {
+  const descriptor1 = introspect(schema, INTROSPECT_OPTS);
+  const { code } = writeSchema({ form: descriptor1 });
+
+  const testSchema = evaluateSchemaCode(code);
+  const descriptor2 = introspect(testSchema, INTROSPECT_OPTS);
+
+  return { descriptor1, descriptor2, code };
+}
+
+/**
+ * Evaluates generated Zod schema code by stripping import/export syntax
+ * and executing with the z object injected.
+ *
+ * This is intentional: round-trip tests need to evaluate the generated code
+ * to verify it produces a valid Zod schema. The input is always from our own
+ * writeSchema function, never from user input.
+ */
+function evaluateSchemaCode(code: string): z.ZodObject {
+  const executableCode = code
+    .replace(/import\s*\{[^}]*\}\s*from\s*["'][^"']*["'];?\n?/g, "")
+    .replace(/export\s+type\s+[^;]*;\n?/g, "")
+    .replace(/export\s+const/g, "const");
+
+  // Using Function constructor to evaluate our own generated code in tests.
+  // The input is always from writeSchema(), never from external/user input.
+  const fn = new Function("z", `${executableCode}\nreturn testSchema;`);
+  return fn(z);
+}
+
+describe("round-trip: schema -> introspect -> writeSchema -> eval -> introspect", () => {
+  it("round-trips a plain string field", () => {
+    const schema = z.object({ name: z.string() });
+    const { descriptor1, descriptor2 } = roundTrip(schema);
+
+    expect(descriptor2.fields).toHaveLength(1);
+    expect(descriptor2.fields[0].type).toBe("string");
+    expect(descriptor2.fields[0].name).toBe(descriptor1.fields[0].name);
+    expect(descriptor2.fields[0].isOptional).toBe(false);
+    expect(descriptor2.fields[0].isNullable).toBe(false);
+  });
+
+  it("round-trips string with constraints", () => {
+    const schema = z.object({
+      username: z.string().min(3).max(20),
+    });
+    const { descriptor1, descriptor2 } = roundTrip(schema);
+
+    const f1 = descriptor1.fields[0];
+    const f2 = descriptor2.fields[0];
+    expect(f2.constraints.minLength).toBe(f1.constraints.minLength);
+    expect(f2.constraints.maxLength).toBe(f1.constraints.maxLength);
+  });
+
+  it("round-trips email format", () => {
+    const schema = z.object({ email: z.email() });
+    const { descriptor1, descriptor2 } = roundTrip(schema);
+
+    expect(descriptor2.fields[0].constraints.format).toBe("email");
+    expect(descriptor2.fields[0].constraints.format).toBe(
+      descriptor1.fields[0].constraints.format,
+    );
+  });
+
+  it("round-trips url format", () => {
+    const schema = z.object({ website: z.url() });
+    const { descriptor2 } = roundTrip(schema);
+
+    expect(descriptor2.fields[0].constraints.format).toBe("url");
+  });
+
+  it("round-trips uuid format", () => {
+    const schema = z.object({ id: z.uuid() });
+    const { descriptor2 } = roundTrip(schema);
+
+    expect(descriptor2.fields[0].constraints.format).toBe("uuid");
+  });
+
+  it("round-trips a number field", () => {
+    const schema = z.object({ count: z.number() });
+    const { descriptor1, descriptor2 } = roundTrip(schema);
+
+    expect(descriptor2.fields[0].type).toBe("number");
+    expect(descriptor2.fields[0].name).toBe(descriptor1.fields[0].name);
+  });
+
+  it("round-trips number with min/max", () => {
+    const schema = z.object({ score: z.number().min(0).max(100) });
+    const { descriptor1, descriptor2 } = roundTrip(schema);
+
+    const f1 = descriptor1.fields[0];
+    const f2 = descriptor2.fields[0];
+    expect(f2.constraints.min).toBe(f1.constraints.min);
+    expect(f2.constraints.max).toBe(f1.constraints.max);
+  });
+
+  it("round-trips z.int() (via z.number().int() chain)", () => {
+    // z.int() is a top-level Zod v4 type that stores format in def, not checks.
+    // The introspection currently extracts isInt only from z.number().int() chains.
+    // This test verifies the round-trip fidelity for the chain form.
+    const schema = z.object({ age: z.number().int() });
+    const { descriptor1, descriptor2 } = roundTrip(schema);
+
+    expect(descriptor2.fields[0].constraints.isInt).toBe(true);
+    expect(descriptor2.fields[0].constraints.isInt).toBe(
+      descriptor1.fields[0].constraints.isInt,
+    );
+  });
+
+  it("round-trips a boolean field", () => {
+    const schema = z.object({ active: z.boolean() });
+    const { descriptor2 } = roundTrip(schema);
+
+    expect(descriptor2.fields[0].type).toBe("boolean");
+  });
+
+  it("round-trips a date field", () => {
+    const schema = z.object({ createdAt: z.date() });
+    const { descriptor2 } = roundTrip(schema);
+
+    expect(descriptor2.fields[0].type).toBe("date");
+  });
+
+  it("round-trips an enum field", () => {
+    const schema = z.object({
+      role: z.enum(["admin", "user", "guest"]),
+    });
+    const { descriptor1, descriptor2 } = roundTrip(schema);
+
+    expect(descriptor2.fields[0].type).toBe("enum");
+    if (
+      descriptor2.fields[0].metadata.kind === "enum" &&
+      descriptor1.fields[0].metadata.kind === "enum"
+    ) {
+      expect(descriptor2.fields[0].metadata.values).toEqual(
+        descriptor1.fields[0].metadata.values,
+      );
+    }
+  });
+
+  it("round-trips an array of strings", () => {
+    const schema = z.object({ tags: z.array(z.string()) });
+    const { descriptor2 } = roundTrip(schema);
+
+    expect(descriptor2.fields[0].type).toBe("array");
+    if (descriptor2.fields[0].metadata.kind === "array") {
+      expect(descriptor2.fields[0].metadata.element.type).toBe("string");
+    }
+  });
+
+  it("round-trips an array of enums", () => {
+    const schema = z.object({
+      permissions: z.array(z.enum(["read", "write", "delete"])),
+    });
+    const { descriptor1, descriptor2 } = roundTrip(schema);
+
+    expect(descriptor2.fields[0].type).toBe("array");
+    if (
+      descriptor2.fields[0].metadata.kind === "array" &&
+      descriptor1.fields[0].metadata.kind === "array"
+    ) {
+      expect(descriptor2.fields[0].metadata.element.type).toBe("enum");
+      if (
+        descriptor2.fields[0].metadata.element.metadata.kind === "enum" &&
+        descriptor1.fields[0].metadata.element.metadata.kind === "enum"
+      ) {
+        expect(descriptor2.fields[0].metadata.element.metadata.values).toEqual(
+          descriptor1.fields[0].metadata.element.metadata.values,
+        );
+      }
+    }
+  });
+
+  it("round-trips optional fields", () => {
+    const schema = z.object({
+      nickname: z.string().optional(),
+    });
+    const { descriptor2 } = roundTrip(schema);
+
+    expect(descriptor2.fields[0].isOptional).toBe(true);
+    expect(descriptor2.fields[0].isNullable).toBe(false);
+  });
+
+  it("round-trips nullable fields", () => {
+    const schema = z.object({
+      middleName: z.string().nullable(),
+    });
+    const { descriptor2 } = roundTrip(schema);
+
+    expect(descriptor2.fields[0].isNullable).toBe(true);
+    expect(descriptor2.fields[0].isOptional).toBe(false);
+  });
+
+  it("round-trips nullable + optional fields", () => {
+    const schema = z.object({
+      bio: z.string().nullable().optional(),
+    });
+    const { descriptor2 } = roundTrip(schema);
+
+    expect(descriptor2.fields[0].isNullable).toBe(true);
+    expect(descriptor2.fields[0].isOptional).toBe(true);
+  });
+
+  it("round-trips a complex multi-field schema", () => {
+    const schema = z.object({
+      name: z.string().min(1),
+      email: z.email(),
+      age: z.number().int().min(0).max(150).optional(),
+      role: z.enum(["admin", "user"]),
+      active: z.boolean(),
+      tags: z.array(z.string()),
+    });
+
+    const { descriptor1, descriptor2 } = roundTrip(schema);
+
+    expect(descriptor2.fields).toHaveLength(descriptor1.fields.length);
+
+    for (let i = 0; i < descriptor1.fields.length; i++) {
+      const f1 = descriptor1.fields[i];
+      const f2 = descriptor2.fields[i];
+      expect(f2.name).toBe(f1.name);
+      expect(f2.type).toBe(f1.type);
+      expect(f2.isOptional).toBe(f1.isOptional);
+      expect(f2.isNullable).toBe(f1.isNullable);
+    }
+  });
+});

--- a/test/schema-writer/writer.test.ts
+++ b/test/schema-writer/writer.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "vitest";
+import { writeSchema } from "../../src/schema-writer/writer";
+import { makeField, makeForm } from "./helpers";
+
+describe("writeSchema", () => {
+  describe("output structure", () => {
+    it("generates correct import statement", () => {
+      const form = makeForm({
+        fields: [makeField({ name: "name" })],
+      });
+      const result = writeSchema({ form });
+      expect(result.code).toContain('import { z } from "zod/v4";');
+    });
+
+    it("generates const export with schema name", () => {
+      const form = makeForm({
+        schemaExportName: "userSchema",
+        fields: [makeField({ name: "name" })],
+      });
+      const result = writeSchema({ form });
+      expect(result.code).toContain("export const userSchema = z.object({");
+    });
+
+    it("generates type export with inferred name", () => {
+      const form = makeForm({
+        schemaExportName: "userSchema",
+        fields: [makeField({ name: "name" })],
+      });
+      const result = writeSchema({ form });
+      expect(result.code).toContain(
+        "export type User = z.infer<typeof userSchema>;",
+      );
+    });
+
+    it("generates type name from profileSchema -> Profile", () => {
+      const form = makeForm({
+        schemaExportName: "profileSchema",
+        fields: [makeField({ name: "bio" })],
+      });
+      const result = writeSchema({ form });
+      expect(result.code).toContain(
+        "export type Profile = z.infer<typeof profileSchema>;",
+      );
+    });
+
+    it("returns empty warnings when all fields succeed", () => {
+      const form = makeForm({
+        fields: [makeField({ name: "name" })],
+      });
+      const result = writeSchema({ form });
+      expect(result.warnings).toEqual([]);
+    });
+  });
+
+  describe("field ordering", () => {
+    it("preserves field order in output", () => {
+      const form = makeForm({
+        fields: [
+          makeField({ name: "alpha" }),
+          makeField({ name: "beta" }),
+          makeField({ name: "gamma" }),
+        ],
+      });
+      const result = writeSchema({ form });
+      const alphaIdx = result.code.indexOf("alpha:");
+      const betaIdx = result.code.indexOf("beta:");
+      const gammaIdx = result.code.indexOf("gamma:");
+      expect(alphaIdx).toBeLessThan(betaIdx);
+      expect(betaIdx).toBeLessThan(gammaIdx);
+    });
+  });
+
+  describe("multiple field types", () => {
+    it("generates full schema with mixed types", () => {
+      const form = makeForm({
+        schemaExportName: "contactSchema",
+        fields: [
+          makeField({
+            name: "name",
+            type: "string",
+            metadata: { kind: "string" },
+          }),
+          makeField({
+            name: "email",
+            type: "string",
+            constraints: { format: "email" },
+            metadata: { kind: "string" },
+          }),
+          makeField({
+            name: "age",
+            type: "number",
+            metadata: { kind: "number" },
+          }),
+          makeField({
+            name: "active",
+            type: "boolean",
+            metadata: { kind: "boolean" },
+          }),
+          makeField({
+            name: "role",
+            type: "enum",
+            metadata: { kind: "enum", values: ["admin", "user"] },
+          }),
+          makeField({
+            name: "tags",
+            type: "array",
+            metadata: {
+              kind: "array",
+              element: makeField({
+                name: "item",
+                type: "string",
+                metadata: { kind: "string" },
+              }),
+            },
+          }),
+        ],
+      });
+      const result = writeSchema({ form });
+
+      expect(result.code).toContain("name: z.string(),");
+      expect(result.code).toContain("email: z.email(),");
+      expect(result.code).toContain("age: z.number(),");
+      expect(result.code).toContain("active: z.boolean(),");
+      expect(result.code).toContain('role: z.enum(["admin", "user"]),');
+      expect(result.code).toContain("tags: z.array(z.string()),");
+      expect(result.code).toContain(
+        "export type Contact = z.infer<typeof contactSchema>;",
+      );
+    });
+  });
+
+  describe("error handling", () => {
+    it("throws on unsupported object type", () => {
+      const form = makeForm({
+        fields: [
+          makeField({
+            name: "nested",
+            type: "object",
+            metadata: { kind: "object", fields: [] },
+          }),
+        ],
+      });
+      expect(() => writeSchema({ form })).toThrow(
+        'Unsupported field type "object"',
+      );
+    });
+
+    it("throws on unsupported union type", () => {
+      const form = makeForm({
+        fields: [
+          makeField({
+            name: "choice",
+            type: "union",
+            metadata: { kind: "union", variants: [] },
+          }),
+        ],
+      });
+      expect(() => writeSchema({ form })).toThrow(
+        'Unsupported field type "union"',
+      );
+    });
+
+    it("throws on unsupported tuple type", () => {
+      const form = makeForm({
+        fields: [
+          makeField({
+            name: "pair",
+            type: "tuple",
+            metadata: { kind: "tuple", elements: [] },
+          }),
+        ],
+      });
+      expect(() => writeSchema({ form })).toThrow(
+        'Unsupported field type "tuple"',
+      );
+    });
+
+    it("throws on unsupported record type", () => {
+      const form = makeForm({
+        fields: [
+          makeField({
+            name: "map",
+            type: "record",
+            metadata: {
+              kind: "record",
+              valueDescriptor: makeField({ name: "value" }),
+            },
+          }),
+        ],
+      });
+      expect(() => writeSchema({ form })).toThrow(
+        'Unsupported field type "record"',
+      );
+    });
+  });
+
+  describe("empty schema", () => {
+    it("generates valid empty object schema", () => {
+      const form = makeForm({ fields: [] });
+      const result = writeSchema({ form });
+      expect(result.code).toContain("export const testSchema = z.object({");
+      expect(result.code).toContain("});");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `src/schema-writer/` module implementing the reverse pipeline: `FormDescriptor -> Zod v4 source file`
- Supports string (with `z.email()`, `z.url()`, `z.uuid()`, `z.cuid()`, `z.iso.datetime()` format variants), number (with `.int()`), boolean, date, enum, and array types
- Full constraint chaining (`.min()`, `.max()`, `.regex()`, `.multipleOf()`), optional/nullable wrapping, and `.describe()` support
- Exports `writeSchema()`, `emitField()`, and associated types from the public API

## Test plan
- [x] 31 unit tests for field emission (each type, constraints, formats, wrapping, unsupported type errors)
- [x] 12 integration tests for full source output (imports, exports, field ordering, error handling)
- [x] 17 round-trip tests (schema -> introspect -> writeSchema -> eval -> introspect -> compare descriptors)
- [x] All 321 existing + new tests passing
- [x] `pnpm build`, `pnpm typecheck`, `pnpm lint` all clean

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)