### PR TITLE
chore: rename phantom-zone to kelex

### DIFF
--- a/.changeset/initial-release.md
+++ b/.changeset/initial-release.md
@@ -1,8 +1,8 @@
 ---
-"phantom-zone": minor
+"kelex": minor
 ---
 
-Initial release of phantom-zone - generate React form components from Zod schemas.
+Initial release of kelex - generate React form components from Zod schemas.
 
 Features:
 - CLI tool for generating forms from Zod schema files

--- a/.serena/memories/project-overview.md
+++ b/.serena/memories/project-overview.md
@@ -1,8 +1,8 @@
-# Phantom Zone - Project Overview
+# Kelex - Project Overview
 
 ## Purpose
 
-Phantom Zone is a CLI tool and library that generates type-safe React form components from Zod schemas. It reads a Zod schema and outputs a complete React form with:
+Kelex is a CLI tool and library that generates type-safe React form components from Zod schemas. It reads a Zod schema and outputs a complete React form with:
 - Full TypeScript types inferred from the schema
 - TanStack Form for state management and validation
 - Appropriate UI components (Rafters/shadcn) for each field type
@@ -27,9 +27,9 @@ Phantom Zone is a CLI tool and library that generates type-safe React form compo
 
 ## Repository
 
-- GitHub: https://github.com/ezmode-games/phantom-zone
+- GitHub: https://github.com/ezmode-games/kelex
 - License: MIT
-- Homepage: https://ezmode.games/oss/phantom-zone
+- Homepage: https://ezmode.games/oss/kelex
 
 ## Codebase Structure
 

--- a/.serena/memories/suggested_commands.md
+++ b/.serena/memories/suggested_commands.md
@@ -68,7 +68,7 @@ pnpm flightcheck
 node dist/cli.js generate ./path/to/schema.ts -s schemaName
 
 # Or via pnpx
-pnpx phantom-zone generate ./path/to/schema.ts -s schemaName
+pnpx kelex generate ./path/to/schema.ts -s schemaName
 ```
 
 ## Releases

--- a/.serena/memories/task-completion.md
+++ b/.serena/memories/task-completion.md
@@ -1,6 +1,6 @@
 # Task Completion Checklist
 
-When completing a task in phantom-zone, follow this checklist:
+When completing a task in kelex, follow this checklist:
 
 ## Before Committing
 

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,5 +1,5 @@
 # the name by which the project can be referenced within Serena
-project_name: "phantom-zone"
+project_name: "kelex"
 
 
 # list of languages for which language servers are started; choose from:
@@ -115,3 +115,10 @@ initial_prompt: ""
 # override of the corresponding setting in serena_config.yml, see the documentation there.
 # If null or missing, the value from the global config is used.
 symbol_info_budget:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# phantom-zone
+# kelex
 
 Generate type-safe React form components from Zod schemas. Built for [TanStack Form](https://tanstack.com/form) and [Rafters](https://rafters.studio)/[shadcn/ui](https://ui.shadcn.com) components.
 
 ## Quick Start
 
 ```bash
-pnpx phantom-zone@latest generate ./src/schemas/user.ts -s userSchema
+pnpx kelex@latest generate ./src/schemas/user.ts -s userSchema
 ```
 
 This reads your Zod schema and generates:
@@ -18,7 +18,7 @@ This reads your Zod schema and generates:
 The generated primitives are pure HTML/React components styled with Tailwind that match the shadcn component API. When you're ready to use your own components, pass `--ui` to swap the import path:
 
 ```bash
-pnpx phantom-zone@latest generate ./src/schemas/user.ts -s userSchema --ui @/components/ui
+pnpx kelex@latest generate ./src/schemas/user.ts -s userSchema --ui @/components/ui
 ```
 
 ## Requirements
@@ -30,7 +30,7 @@ pnpx phantom-zone@latest generate ./src/schemas/user.ts -s userSchema --ui @/com
 ## Usage
 
 ```bash
-pnpx phantom-zone@latest generate <schema-path> [options]
+pnpx kelex@latest generate <schema-path> [options]
 ```
 
 ### Options
@@ -46,16 +46,16 @@ pnpx phantom-zone@latest generate <schema-path> [options]
 
 ```bash
 # Basic - generates user-form.tsx + primitives.tsx
-pnpx phantom-zone@latest generate ./src/schemas/user-schema.ts -s userSchema
+pnpx kelex@latest generate ./src/schemas/user-schema.ts -s userSchema
 
 # Custom output path and component name
-pnpx phantom-zone@latest generate ./src/schemas/user.ts \
+pnpx kelex@latest generate ./src/schemas/user.ts \
   -o ./src/components/forms/profile-form.tsx \
   -n ProfileForm \
   -s userProfileSchema
 
 # Use your own shadcn components (no primitives generated)
-pnpx phantom-zone@latest generate ./src/schemas/user.ts \
+pnpx kelex@latest generate ./src/schemas/user.ts \
   -s userSchema \
   --ui @/components/ui
 ```
@@ -129,7 +129,7 @@ The form handles nested objects (Card-based grouping), arrays (dynamic add/remov
 ## Programmatic API
 
 ```typescript
-import { generate } from "phantom-zone";
+import { generate } from "kelex";
 import { userSchema } from "./schema";
 
 const result = generate({
@@ -162,7 +162,7 @@ result.primitives; // undefined
 
 ## Documentation
 
-Full documentation at [ezmode.games/oss/phantom-zone](https://ezmode.games/oss/phantom-zone)
+Full documentation at [ezmode.games/oss/kelex](https://ezmode.games/oss/kelex)
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "phantom-zone",
+  "name": "kelex",
   "version": "0.0.1",
   "description": "Generate React form components from Zod schemas",
   "type": "module",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ezmode-games/phantom-zone.git"
+    "url": "https://github.com/ezmode-games/kelex.git"
   },
-  "homepage": "https://ezmode.games/oss/phantom-zone",
+  "homepage": "https://ezmode.games/oss/kelex",
   "keywords": [
     "zod",
     "react",
@@ -22,7 +22,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
-    "phantom-zone": "./dist/cli.js"
+    "kelex": "./dist/cli.js"
   },
   "exports": {
     ".": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,7 +9,7 @@ import { generate } from "./codegen/generator";
 const program = new Command();
 
 program
-  .name("phantom-zone")
+  .name("kelex")
   .description("Generate React forms from Zod schemas")
   .version("0.0.1");
 

--- a/src/introspection/introspect.ts
+++ b/src/introspection/introspect.ts
@@ -371,7 +371,7 @@ export function introspect(
 
   if (def.type !== "object") {
     throw new Error(
-      `phantom-zone only supports z.object() schemas at the top level, got "${def.type}"`,
+      `kelex only supports z.object() schemas at the top level, got "${def.type}"`,
     );
   }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-describe("phantom-zone", () => {
+describe("kelex", () => {
   it("should export module", async () => {
     const module = await import("../src/index");
     expect(module).toBeDefined();

--- a/test/introspection/introspect.test.ts
+++ b/test/introspection/introspect.test.ts
@@ -317,7 +317,7 @@ describe("introspect", () => {
       const schema = z.string();
 
       expect(() => introspect(schema, defaultOptions)).toThrow(
-        "phantom-zone only supports z.object() schemas at the top level",
+        "kelex only supports z.object() schemas at the top level",
       );
     });
 
@@ -325,7 +325,7 @@ describe("introspect", () => {
       const schema = z.array(z.string());
 
       expect(() => introspect(schema, defaultOptions)).toThrow(
-        "phantom-zone only supports z.object() schemas at the top level",
+        "kelex only supports z.object() schemas at the top level",
       );
     });
 


### PR DESCRIPTION
## Summary
- npm package name `phantom-zone` is already taken (v0.5.1 by another author)
- Renamed to **kelex** (Kryptonian robot servant from Superman's Fortress of Solitude)
- `kelex` is available on npm
- All references updated: package.json, CLI name, error messages, tests, changeset, config, README

## Changed files
- `package.json` - name, bin, repo URL, homepage
- `src/cli.ts` - `.name("kelex")`
- `src/introspection/introspect.ts` - error message
- `README.md` - full rewrite with kelex references
- `test/index.test.ts` - describe block
- `test/introspection/introspect.test.ts` - error message assertions
- `.changeset/initial-release.md` - package name
- `.serena/` - project config and memories

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test:all` passes (261 tests)
- [ ] GitHub repo rename (done separately by maintainer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)