### PR TITLE
ci: add release workflow and scope package for npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,80 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  version:
+    name: Version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      hasChangesets: ${{ steps.changesets.outputs.hasChangesets }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Create release PR or detect merged version
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          title: "chore: version packages"
+          commit: "chore: version packages"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    name: Publish
+    needs: version
+    if: needs.version.outputs.hasChangesets == 'false'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install latest npm (>=11.5.1 for OIDC)
+        run: npm install -g npm@latest
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm build
+
+      - name: Publish to npm
+        run: pnpm changeset publish

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "kelex",
+  "name": "@ezmode-games/kelex",
   "version": "0.0.1",
   "description": "Generate React form components from Zod schemas",
   "type": "module",


### PR DESCRIPTION
## Summary
- Scope package as `@ezmode-games/kelex` (npm rejects unscoped `kelex` due to typosquatting similarity to knex/katex/lolex)
- Add `release.yml` workflow with changesets Version Packages PR flow
- Publish job uses npm OIDC trusted publishing (no token needed)

## How it works
1. PR includes a changeset file
2. PR merges to main -> changesets/action creates "Version Packages" PR
3. Merge Version Packages PR -> publish job fires -> npm publish via OIDC

## After merge: manual one-time setup
1. Create `ezmode-games` org on [npmjs.com/org/create](https://www.npmjs.com/org/create)
2. First publish manually: `pnpm build && npm publish --access public`
3. Configure trusted publisher on npmjs.com package settings:
   - Organization: `ezmode-games` | Repository: `kelex` | Workflow: `release.yml`

## Test plan
- [x] `pnpm build` succeeds
- [x] `pnpm flightcheck` passes (321 tests, lint, typecheck)
- [ ] After merge + manual npm setup: push a changeset and verify Version Packages PR is created
- [ ] Merge Version Packages PR and verify npm publish via OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)