### PR TITLE
feat(introspection): lossless reader (#141)

### DIFF
--- a/src/introspection/checks.ts
+++ b/src/introspection/checks.ts
@@ -6,8 +6,16 @@ interface ZodCheckDef {
   minimum?: number;
   maximum?: number;
   value?: number;
+  /** Present on greater_than/less_than: whether the bound is inclusive (.gte/.lte/.min/.max) or exclusive (.gt/.lt/.positive) */
+  inclusive?: boolean;
+  /** Exact length from length_equals (z.string().length(n)) */
+  length?: number;
   format?: string;
   pattern?: RegExp;
+  /** Literal prefix on string_format with format "starts_with" */
+  prefix?: string;
+  /** Literal suffix on string_format with format "ends_with" */
+  suffix?: string;
 }
 
 interface ZodCheck {
@@ -77,26 +85,47 @@ export function extractConstraints(schema: $ZodType, unknownChecks?: string[]): 
         }
         break;
 
+      case "length_equals":
+        if (checkDef.length !== undefined) {
+          constraints.length = checkDef.length;
+        }
+        break;
+
       case "string_format":
         if (checkDef.format === "regex" && checkDef.pattern) {
           constraints.pattern = checkDef.pattern.source;
+        } else if (checkDef.format === "starts_with" && checkDef.prefix !== undefined) {
+          constraints.startsWith = checkDef.prefix;
+        } else if (checkDef.format === "ends_with" && checkDef.suffix !== undefined) {
+          constraints.endsWith = checkDef.suffix;
         } else if (
           checkDef.format &&
           KNOWN_FORMATS.has(checkDef.format as FieldConstraints["format"] & string)
         ) {
           constraints.format = checkDef.format as FieldConstraints["format"];
+        } else {
+          unknownChecks?.push(
+            checkDef.format ? `string_format:${checkDef.format}` : "string_format",
+          );
         }
         break;
 
       case "greater_than":
         if (checkDef.value !== undefined) {
           constraints.min = checkDef.value;
+          // .positive()/.gt() are exclusive; .nonnegative()/.gte()/.min() are inclusive
+          if (checkDef.inclusive === false) {
+            constraints.minExclusive = true;
+          }
         }
         break;
 
       case "less_than":
         if (checkDef.value !== undefined) {
           constraints.max = checkDef.value;
+          if (checkDef.inclusive === false) {
+            constraints.maxExclusive = true;
+          }
         }
         break;
 

--- a/src/introspection/introspect.ts
+++ b/src/introspection/introspect.ts
@@ -82,6 +82,40 @@ function nameToLabel(name: string): string {
 }
 
 /**
+ * Formats a warning for a check the descriptor cannot carry. Refinements
+ * (`.refine()`/`.superRefine()`) surface as Zod "custom" checks; every other
+ * unrecognized check kind is named verbatim so nothing drops silently.
+ */
+function formatDroppedCheck(fieldName: string, check: string): string {
+  if (check === "custom") {
+    return `Field "${fieldName}": a .refine()/.superRefine() constraint is not represented in the descriptor and must be re-applied downstream.`;
+  }
+  return `Field "${fieldName}": dropped unrecognized check "${check}".`;
+}
+
+/**
+ * Surfaces object-level checks (cross-field `.refine()` on the schema itself) as
+ * warnings. Names the field from the refinement's `path` when present, since a
+ * top-level refine is never introspected as one of the object's fields.
+ */
+function warnObjectRefinements(schema: $ZodType, warnings: string[]): void {
+  const def = schema._zod.def as {
+    checks?: { _zod?: { def?: { check?: string; path?: (string | number)[] } } }[];
+  };
+  if (!Array.isArray(def.checks)) {
+    return;
+  }
+  for (const check of def.checks) {
+    const checkDef = check._zod?.def;
+    if (!checkDef?.check) {
+      continue;
+    }
+    const field = checkDef.path && checkDef.path.length > 0 ? String(checkDef.path[0]) : "(form)";
+    warnings.push(formatDroppedCheck(field, checkDef.check));
+  }
+}
+
+/**
  * Resolves a schema to its root, unwrapping intersections into a merged
  * object shape. Returns the resolved schema and any warnings.
  */
@@ -92,11 +126,12 @@ function resolveRootSchema(schema: $ZodType): {
   const def = schema._zod.def as { type: string };
 
   if (def.type === "intersection") {
-    const shape = flattenIntersection(schema);
+    const warnings: string[] = [];
+    const shape = flattenIntersection(schema, warnings);
     // Build a synthetic object-like schema view
     return {
       resolved: buildSyntheticObjectSchema(shape),
-      warnings: [],
+      warnings,
     };
   }
 
@@ -104,15 +139,23 @@ function resolveRootSchema(schema: $ZodType): {
 }
 
 /**
- * Recursively flattens an intersection into a single merged shape.
+ * Recursively flattens an intersection into a single merged shape. Overlapping
+ * keys warn: the right-hand member wins and declaration order is not preserved.
  */
-function flattenIntersection(schema: $ZodType): Record<string, $ZodType> {
+function flattenIntersection(schema: $ZodType, warnings: string[]): Record<string, $ZodType> {
   const def = schema._zod.def as { type: string };
 
   if (def.type === "intersection") {
     const intDef = def as unknown as ZodIntersectionDef;
-    const leftShape = flattenIntersection(intDef.left);
-    const rightShape = flattenIntersection(intDef.right);
+    const leftShape = flattenIntersection(intDef.left, warnings);
+    const rightShape = flattenIntersection(intDef.right, warnings);
+    for (const key of Object.keys(rightShape)) {
+      if (key in leftShape) {
+        warnings.push(
+          `Intersection field "${key}" is declared in both members; the right-hand definition wins and original field order may not be preserved.`,
+        );
+      }
+    }
     return { ...leftShape, ...rightShape };
   }
 
@@ -176,8 +219,27 @@ function buildMetadata(inner: $ZodType, warnings: string[]): FieldMetadata {
 
   if (type === "record") {
     const recDef = def as unknown as ZodRecordDef;
+    const keyDef = recDef.keyType._zod.def as {
+      type: string;
+      format?: string;
+      checks?: unknown[];
+    };
+    const keyIsPlainString =
+      keyDef.type === "string" &&
+      !keyDef.format &&
+      (!Array.isArray(keyDef.checks) || keyDef.checks.length === 0);
+    if (!keyIsPlainString) {
+      warnings.push(
+        `Record key schema (type "${keyDef.type}") is not represented in the descriptor; only the value schema is carried.`,
+      );
+    }
     const valueDescriptor = introspectField("value", recDef.valueType, warnings);
     return { kind: "record", valueDescriptor };
+  }
+
+  if (type === "literal") {
+    const litDef = def as unknown as ZodLiteralDef;
+    return { kind: "literal", value: litDef.values[0] };
   }
 
   return { kind: type as "string" | "number" | "boolean" | "date" };
@@ -243,9 +305,22 @@ function introspectShape(shape: Record<string, $ZodType>, warnings: string[]): F
 }
 
 /**
- * Resolves the effective type string from an unwrapped schema def.
+ * Peels pipe/transform wrappers to the input schema so that the field's
+ * constraints, metadata, and resolved type are all derived from ONE consistent
+ * inner schema. Without this, a pre-pipe schema (e.g. z.string().min(3).transform)
+ * has its constraints read from the pipe wrapper (which carries none) and lost.
+ */
+function peelPipe(schema: $ZodType): $ZodType {
+  let current = schema;
+  while ((current._zod.def as { type: string }).type === "pipe") {
+    current = (current._zod.def as unknown as { in: $ZodType }).in;
+  }
+  return current;
+}
+
+/**
+ * Resolves the effective type string from an unwrapped, pipe-peeled schema def.
  * Handles Zod v4 top-level format shortcuts (z.email() -> string with format).
- * Also handles pipe/transform by extracting the input type.
  */
 function resolveType(inner: $ZodType): string {
   const def = inner._zod.def as { type: string; format?: string };
@@ -255,12 +330,6 @@ function resolveType(inner: $ZodType): string {
   // Their def.type is already "string", so they pass through naturally.
 
   // z.int() is a number with def.format "safeint" -- type is already "number"
-
-  // pipe/transform: use the input type
-  if (type === "pipe") {
-    const pipeDef = def as unknown as { type: string; in: $ZodType };
-    return resolveType(pipeDef.in);
-  }
 
   // literal: map to the JS type of the literal value for scalar representation
   if (type === "literal") {
@@ -281,13 +350,15 @@ function resolveType(inner: $ZodType): string {
  * Introspects a single field schema into a FieldDescriptor.
  */
 function introspectField(name: string, fieldSchema: $ZodType, warnings: string[]): FieldDescriptor {
-  const { inner, isOptional, isNullable } = unwrapSchema(fieldSchema);
+  const { inner: unwrapped, isOptional, isNullable, defaultValue } = unwrapSchema(fieldSchema);
+  // Peel pipe/transform once so type, constraints, and metadata share one inner schema.
+  const inner = peelPipe(unwrapped);
   const type = resolveType(inner);
 
   // Check if it's a supported type
   if (!isScalarType(type) && !isCompositeType(type)) {
     warnings.push(`Field "${name}": unsupported type "${type}", treating as string`);
-    return {
+    const fallback: FieldDescriptor = {
       name,
       label: nameToLabel(name),
       type: "string",
@@ -296,10 +367,18 @@ function introspectField(name: string, fieldSchema: $ZodType, warnings: string[]
       constraints: {},
       metadata: { kind: "string" },
     };
+    if (defaultValue !== undefined) {
+      fallback.defaultValue = defaultValue;
+    }
+    return fallback;
   }
 
   const fieldType = type as FieldType;
-  const constraints = extractConstraints(inner);
+  const unknownChecks: string[] = [];
+  const constraints = extractConstraints(inner, unknownChecks);
+  for (const check of unknownChecks) {
+    warnings.push(formatDroppedCheck(name, check));
+  }
   const metadata = buildMetadata(inner, warnings);
   const description = (inner as { description?: string }).description;
 
@@ -315,6 +394,10 @@ function introspectField(name: string, fieldSchema: $ZodType, warnings: string[]
 
   if (description) {
     field.description = description;
+  }
+
+  if (defaultValue !== undefined) {
+    field.defaultValue = defaultValue;
   }
 
   return field;
@@ -336,6 +419,9 @@ export function introspect(schema: $ZodType, options: IntrospectOptions): FormDe
   if (def.type !== "object") {
     throw new Error(`kelex only supports z.object() schemas at the top level, got "${def.type}"`);
   }
+
+  // Surface cross-field refinements on the top-level object (dropped otherwise).
+  warnObjectRefinements(resolved, warnings);
 
   const fields = introspectShape(def.shape, warnings);
 

--- a/src/introspection/types.ts
+++ b/src/introspection/types.ts
@@ -16,12 +16,22 @@ export interface FieldConstraints {
   // String constraints
   minLength?: number;
   maxLength?: number;
+  /** Exact length from z.string().length(n) */
+  length?: number;
   pattern?: string;
+  /** Literal prefix from z.string().startsWith(p) */
+  startsWith?: string;
+  /** Literal suffix from z.string().endsWith(s) */
+  endsWith?: string;
   format?: "email" | "url" | "uuid" | "cuid" | "datetime";
 
   // Number constraints
   min?: number;
   max?: number;
+  /** True when `min` is exclusive (z.number().positive() / .gt()) rather than inclusive (.gte()/.min()) */
+  minExclusive?: boolean;
+  /** True when `max` is exclusive (z.number().lt()) rather than inclusive (.lte()/.max()) */
+  maxExclusive?: boolean;
   step?: number;
   isInt?: boolean;
 
@@ -45,7 +55,8 @@ export type FieldMetadata =
       variants: { value: string; fields: FieldDescriptor[] }[];
     }
   | { kind: "tuple"; elements: FieldDescriptor[] }
-  | { kind: "record"; valueDescriptor: FieldDescriptor };
+  | { kind: "record"; valueDescriptor: FieldDescriptor }
+  | { kind: "literal"; value: unknown };
 
 /** Single field descriptor */
 export interface FieldDescriptor {
@@ -72,6 +83,12 @@ export interface FieldDescriptor {
 
   /** Type-specific metadata (e.g., enum values) */
   metadata: FieldMetadata;
+
+  /**
+   * Default value from z.default(). Captured before the default wrapper is
+   * peeled during unwrapping. `undefined` when the field has no default.
+   */
+  defaultValue?: unknown;
 
   /**
    * Reference to a named schema export. When set, the schema-writer emits the

--- a/src/introspection/unwrap.ts
+++ b/src/introspection/unwrap.ts
@@ -7,6 +7,8 @@ export interface UnwrapResult {
   isOptional: boolean;
   /** Whether z.nullable() was present */
   isNullable: boolean;
+  /** Default value from z.default(), captured before the wrapper is peeled */
+  defaultValue?: unknown;
 }
 
 /** Type guard to check if schema has unwrap method */
@@ -51,6 +53,7 @@ export function unwrapSchema(schema: $ZodType): UnwrapResult {
   let current = schema;
   let isOptional = false;
   let isNullable = false;
+  let defaultValue: unknown;
 
   // Unwrap nested optional/nullable/default wrappers
   while (
@@ -62,8 +65,10 @@ export function unwrapSchema(schema: $ZodType): UnwrapResult {
       isOptional = true;
     } else if (current._zod.def.type === "nullable") {
       isNullable = true;
+    } else {
+      // default: capture the value before peeling the wrapper to reach the inner type
+      defaultValue = (current._zod.def as { defaultValue?: unknown }).defaultValue;
     }
-    // default: no flag, just peel the wrapper to get at the inner type
 
     if (!hasUnwrap(current)) {
       throw new Error(`${current._zod.def.type} schema missing unwrap method`);
@@ -75,5 +80,6 @@ export function unwrapSchema(schema: $ZodType): UnwrapResult {
     inner: current,
     isOptional,
     isNullable,
+    defaultValue,
   };
 }

--- a/test/fixtures/architecture-fixture.ts
+++ b/test/fixtures/architecture-fixture.ts
@@ -1,0 +1,30 @@
+import { z } from "zod/v4";
+
+/**
+ * Canonical shared adversarial fixture for the generation architecture.
+ *
+ * Exercises: nested object + array + discriminated union + default + refine +
+ * length + positive/nonnegative. Flat-scalar success is a false green, so every
+ * downstream conservation/compile assertion (#141 reader, #142 IR, #143 version,
+ * #144 component map, #145 Astro plugin) runs against THIS shape. Import it here
+ * rather than redefining it -- one fixture, no drift.
+ */
+export const architectureObject = z.object({
+  title: z.string().min(3).max(80).meta({ title: "Title" }),
+  priority: z.enum(["low", "med", "high"]).default("med"),
+  score: z.number().positive(),
+  floor: z.number().nonnegative(),
+  code: z.string().length(6),
+  tags: z.array(z.string().min(1)).max(5),
+  author: z.object({ name: z.string(), email: z.string().email() }),
+  payment: z.discriminatedUnion("kind", [
+    z.object({ kind: z.literal("card"), last4: z.string().length(4) }),
+    z.object({ kind: z.literal("bank"), routing: z.string() }),
+  ]),
+});
+
+/** The `.refine()`-wrapped form. A cross-field invariant the reader cannot represent -- only name. */
+export const architectureSchema = architectureObject.refine((v) => v.score > v.floor, {
+  message: "score must exceed floor",
+  path: ["score"],
+});

--- a/test/introspection/lossless.test.ts
+++ b/test/introspection/lossless.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod/v4";
+import { introspect } from "../../src/introspection/introspect";
+import type { FieldDescriptor } from "../../src/introspection/types";
+import { architectureObject, architectureSchema } from "../fixtures/architecture-fixture";
+
+const OPTIONS = {
+  formName: "ArchitectureForm",
+  schemaImportPath: "./architecture-fixture",
+  schemaExportName: "architectureObject",
+};
+
+/** Introspect the shared fixture and index its top-level fields by name. */
+function fixtureFields(): Record<string, FieldDescriptor> {
+  const descriptor = introspect(architectureObject, OPTIONS);
+  return Object.fromEntries(descriptor.fields.map((field) => [field.name, field]));
+}
+
+describe("lossless reader (#141)", () => {
+  // Criterion 1: z.default() value is captured, not discarded during unwrap.
+  it("captures the default value from z.default()", () => {
+    const fields = fixtureFields();
+    expect(fields.priority.defaultValue).toBe("med");
+  });
+
+  // Criterion 2 (conservation): .positive() and .nonnegative() must NOT collapse
+  // to the same descriptor -- exclusivity is the distinguishing information.
+  it("distinguishes positive (exclusive) from nonnegative (inclusive)", () => {
+    const fields = fixtureFields();
+    expect(fields.score.constraints).toEqual({ min: 0, minExclusive: true });
+    expect(fields.floor.constraints).toEqual({ min: 0 });
+    expect(fields.score.constraints).not.toEqual(fields.floor.constraints);
+  });
+
+  // Criterion 3: z.string().length(n) (a length_equals check) is captured.
+  it("captures exact length from z.string().length(n)", () => {
+    const fields = fixtureFields();
+    expect(fields.code.constraints.length).toBe(6);
+  });
+
+  // Criterion 4: gt/gte inclusivity is read from the check's `inclusive` flag.
+  it("captures gt/gte inclusivity distinctly", () => {
+    const descriptor = introspect(
+      z.object({ excl: z.number().gt(5), incl: z.number().gte(5) }),
+      OPTIONS,
+    );
+    const fields = Object.fromEntries(descriptor.fields.map((f) => [f.name, f]));
+    expect(fields.excl.constraints).toEqual({ min: 5, minExclusive: true });
+    expect(fields.incl.constraints).toEqual({ min: 5 });
+  });
+
+  // Criterion 5 (conservation): a cross-field .refine() the reader cannot
+  // represent must produce a non-empty warning that names the affected field.
+  it("emits a warning naming the field for a dropped .refine()", () => {
+    const descriptor = introspect(architectureSchema, OPTIONS);
+    expect(descriptor.warnings.length).toBeGreaterThan(0);
+    expect(descriptor.warnings.some((w) => w.includes("score"))).toBe(true);
+  });
+
+  // Criterion 6: z.string().startsWith()/.endsWith() are captured, not dropped.
+  it("captures startsWith and endsWith prefixes/suffixes", () => {
+    const descriptor = introspect(
+      z.object({ sku: z.string().startsWith("AB").endsWith("Z") }),
+      OPTIONS,
+    );
+    expect(descriptor.fields[0].constraints.startsWith).toBe("AB");
+    expect(descriptor.fields[0].constraints.endsWith).toBe("Z");
+  });
+
+  // Criterion 7a: literal fields carry a legal { kind: "literal"; value } metadata
+  // variant instead of an out-of-union unchecked cast.
+  it("carries literal values as a legal literal metadata variant", () => {
+    const fields = fixtureFields();
+    const payment = fields.payment.metadata;
+    if (payment.kind !== "union") {
+      throw new Error("expected discriminated union metadata");
+    }
+    const cardKind = payment.variants[0].fields.find((f) => f.name === "kind");
+    expect(cardKind?.metadata).toEqual({ kind: "literal", value: "card" });
+  });
+
+  // Criterion 7b: pipe/transform peels to ONE inner schema so pre-pipe
+  // constraints (min(3)) survive rather than being read off the empty wrapper.
+  it("preserves pre-pipe constraints through a transform", () => {
+    const descriptor = introspect(
+      z.object({
+        slug: z
+          .string()
+          .min(3)
+          .transform((s) => s.length),
+      }),
+      OPTIONS,
+    );
+    expect(descriptor.fields[0].type).toBe("string");
+    expect(descriptor.fields[0].constraints.minLength).toBe(3);
+  });
+
+  // Criterion 8: reader corners -- a non-string record key and an overlapping
+  // intersection key are named rather than silently dropped.
+  it("warns on a dropped record key schema and an ambiguous intersection key", () => {
+    const record = introspect(
+      z.object({ dict: z.record(z.enum(["a", "b"]), z.number()) }),
+      OPTIONS,
+    );
+    expect(record.warnings.some((w) => w.includes("Record key"))).toBe(true);
+
+    const intersection = introspect(
+      z.intersection(z.object({ a: z.string() }), z.object({ a: z.number() })),
+      OPTIONS,
+    );
+    expect(intersection.warnings.some((w) => w.includes("Intersection field"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Makes the Zod introspection reader lossless: it now carries every constraint a schema
declares, or names in `descriptor.warnings` what it cannot represent. Before this change the
reader silently dropped default values, exact `.length()`, gt/gte inclusivity,
`.startsWith()`/`.endsWith()`, literal metadata, and refinements -- the architecture spike
proved every drop by observing `descriptor.warnings === []` on the hard fixture. Because the
descriptor is the contract feeding component mapping, the render-tree IR, and the captured-data
schema, a dropped constraint mislabels both the rendered UI and stored data; nothing downstream
is trustworthy until the reader is conservative. This PR also commits the one canonical
adversarial fixture (`test/fixtures/architecture-fixture.ts`) that #142-#145 import, so there is
no per-issue drift.

## Acceptance criteria mapping

### 1. Default value is captured
`z.default()` wraps the inner schema; `unwrapSchema` used to peel the `default` wrapper and
discard `_zod.def.defaultValue`. The peel loop now has an `else` branch that reads
`defaultValue` off the wrapper def *before* calling `.unwrap()`, returns it in `UnwrapResult`,
and `introspectField` sets it on the descriptor when defined. `FieldDescriptor.defaultValue?`
is the new slot.
Evidence: unwrap.ts:64 captures the value; lossless.test.ts "captures the default value from z.default()" asserts `fields.priority.defaultValue === "med"`.

### 2. positive vs nonnegative produce DISTINCT descriptors
`.positive()` and `.nonnegative()` both emit a `greater_than` check with `value: 0`, so both
used to collapse to `{ min: 0 }`. Zod's check def carries an `inclusive` boolean (false for
`.positive()`/`.gt()`, true for `.nonnegative()`/`.gte()`/`.min()`); the `greater_than` branch
now reads it and sets `minExclusive: true` when exclusive. The two fields now differ:
`{ min: 0, minExclusive: true }` vs `{ min: 0 }`.
Evidence: checks.ts:117 sets minExclusive; lossless.test.ts "distinguishes positive (exclusive) from nonnegative (inclusive)" asserts the two constraint objects are unequal on that flag specifically.

### 3. .length(n) is captured
`z.string().length(6)` emits a `length_equals` check that hit the switch `default:` and dropped.
A new `case "length_equals"` reads `checkDef.length` into `FieldConstraints.length`.
Evidence: checks.ts:88; lossless.test.ts "captures exact length from z.string().length(n)" asserts `code.constraints.length === 6`.

### 4. gt/gte inclusivity is represented
Beyond the positive/nonnegative special case, any `.gt()`/`.gte()`/`.lt()`/`.lte()` now records
its bound plus exclusivity: `greater_than` -> `min`/`minExclusive`, `less_than` ->
`max`/`maxExclusive`, driven by the same `inclusive` flag. Inclusive bounds leave the exclusive
flag unset.
Evidence: checks.ts:113-130; lossless.test.ts "captures gt/gte inclusivity distinctly" asserts `.gt(5)` -> `{min:5,minExclusive:true}` and `.gte(5)` -> `{min:5}`.

### 5. .refine() produces a non-empty warning naming the field
A `.refine()` on the top-level object surfaces as a Zod `custom` check on the object's def,
which `introspect` never inspected. `warnObjectRefinements` now scans the resolved object's
checks and, for each, pushes a warning naming the field from the refinement's `path[0]`
(field-level refines are handled symmetrically via `extractConstraints`' `unknownChecks`
out-param wired through `introspectField`). Both format through the single `formatDroppedCheck`.
Evidence: introspect.ts:101 (`warnObjectRefinements`) and introspect.ts:113 (path naming); lossless.test.ts "emits a warning naming the field for a dropped .refine()" asserts the fixture's refined schema yields a warning containing "score".

### 6. .startsWith()/.endsWith() are captured
Both are `string_format` checks (`starts_with` with a `prefix`, `ends_with` with a `suffix`)
that the format branch ignored. New branches read `prefix`/`suffix` into
`FieldConstraints.startsWith`/`endsWith`; genuinely unrepresented string formats now warn
instead of vanishing.
Evidence: checks.ts:97-100; lossless.test.ts "captures startsWith and endsWith prefixes/suffixes" asserts `{ startsWith: "AB", endsWith: "Z" }`.

### 7. Legal literal metadata + consistent pipe inner-schema
`buildMetadata` used to fall through to an unchecked cast producing `metadata.kind: "literal"`
outside the `FieldMetadata` union. A proper `{ kind: "literal"; value }` variant now exists and
is emitted with the literal's value. For pipes, `peelPipe` resolves the pipe to one inner schema
that feeds `resolveType`, `extractConstraints`, and `buildMetadata` alike, so pre-pipe
constraints survive; resolveType's redundant inline pipe branch was removed.
Evidence: types.ts:56 (variant), introspect.ts:240 (emit), `peelPipe` before resolveType; lossless.test.ts "carries literal values as a legal literal metadata variant" and "preserves pre-pipe constraints through a transform" (`.min(3).transform()` keeps `minLength: 3`).

### 8. Record-key and intersection-order corners are named
Record introspection carried only the value schema; a non-plain-string key now emits a warning.
Intersection flattening merged shapes with `{...left, ...right}` discarding the discarded
`warnings: []`; `flattenIntersection` now threads warnings and flags overlapping keys where the
right member wins and order may not be preserved.
Evidence: introspect.ts:227 (record key) and introspect.ts:152 (intersection overlap); lossless.test.ts "warns on a dropped record key schema and an ambiguous intersection key".

## Not done

- Record keys and exclusive bounds are captured in the descriptor but the schema-writer /
  codegen targets are not yet updated to re-emit them (e.g. round-trip still writes
  `z.string()` for a record key). This card is descriptor-level only per the issue ("No
  compile/render harness needed"); wiring the writer/targets belongs to the downstream IR and
  component-map cards (#142/#144).
- Field order within an intersection is warned-on rather than reconstructed; preserving true
  declaration order across overlapping members is out of scope for the reader card.

Closes #141
