### PR TITLE
feat(introspection): descriptor fidelity -- meta capture, writer parity, silent drops, content version

### DIFF
--- a/src/introspection/index.ts
+++ b/src/introspection/index.ts
@@ -1,6 +1,7 @@
 export { extractConstraints } from "./checks";
 export { type IntrospectOptions, introspect } from "./introspect";
 export { collectMeta } from "./meta";
+export { computeVersion, withVersion } from "./version";
 export type {
   FieldConstraints,
   FieldDescriptor,

--- a/src/introspection/index.ts
+++ b/src/introspection/index.ts
@@ -1,5 +1,6 @@
 export { extractConstraints } from "./checks";
 export { type IntrospectOptions, introspect } from "./introspect";
+export { collectMeta } from "./meta";
 export type {
   FieldConstraints,
   FieldDescriptor,

--- a/src/introspection/introspect.ts
+++ b/src/introspection/introspect.ts
@@ -2,7 +2,7 @@ import type { $ZodType } from "zod/v4/core";
 import { extractConstraints } from "./checks";
 import { collectMeta, metaString } from "./meta";
 import type { FieldDescriptor, FieldMetadata, FieldType, FormDescriptor } from "./types";
-import { unwrapSchema } from "./unwrap";
+import { type UnwrapResult, unwrapSchema } from "./unwrap";
 
 export interface IntrospectOptions {
   /** Name for the generated form component */
@@ -161,6 +161,9 @@ function flattenIntersection(schema: $ZodType, warnings: string[]): Record<strin
   }
 
   if (def.type === "object") {
+    // A member's own .refine() lives on the member, and only its shape survives
+    // the merge -- surface it here or it vanishes with the wrapper.
+    warnObjectRefinements(schema, warnings);
     const objDef = def as unknown as ZodObjectDef;
     return { ...objDef.shape };
   }
@@ -320,6 +323,39 @@ function peelPipe(schema: $ZodType): $ZodType {
 }
 
 /**
+ * Alternates unwrapping (optional/nullable/default) and pipe-peeling until
+ * neither applies.
+ *
+ * One pass in a fixed order misses the other's wrapper: in
+ * `z.string().min(3).optional().transform(fn)` the optional sits INSIDE the
+ * pipe, so unwrap-then-peel leaves the optional wrapper as the resolved inner
+ * schema -- the field reads as an unsupported "optional" type, loses its
+ * constraints, and reports isOptional false.
+ */
+function resolveInner(schema: $ZodType): UnwrapResult {
+  let current = schema;
+  let isOptional = false;
+  let isNullable = false;
+  let defaultValue: unknown;
+
+  for (;;) {
+    const result = unwrapSchema(current);
+    isOptional = isOptional || result.isOptional;
+    isNullable = isNullable || result.isNullable;
+    // Outermost default wins: it is the last one the author wrote.
+    if (defaultValue === undefined) {
+      defaultValue = result.defaultValue;
+    }
+
+    const peeled = peelPipe(result.inner);
+    if (peeled === result.inner) {
+      return { inner: peeled, isOptional, isNullable, defaultValue };
+    }
+    current = peeled;
+  }
+}
+
+/**
  * Resolves the effective type string from an unwrapped, pipe-peeled schema def.
  * Handles Zod v4 top-level format shortcuts (z.email() -> string with format).
  */
@@ -351,9 +387,9 @@ function resolveType(inner: $ZodType): string {
  * Introspects a single field schema into a FieldDescriptor.
  */
 function introspectField(name: string, fieldSchema: $ZodType, warnings: string[]): FieldDescriptor {
-  const { inner: unwrapped, isOptional, isNullable, defaultValue } = unwrapSchema(fieldSchema);
-  // Peel pipe/transform once so type, constraints, and metadata share one inner schema.
-  const inner = peelPipe(unwrapped);
+  // Resolve wrappers and pipes together so type, constraints, and metadata all
+  // derive from one inner schema regardless of the order the author chained them.
+  const { inner, isOptional, isNullable, defaultValue } = resolveInner(fieldSchema);
   const type = resolveType(inner);
   // Read meta from the ORIGINAL schema: the payload may sit on any wrapper in
   // the chain, and the unwrapped inner is only one of those instances.
@@ -436,8 +472,10 @@ export function introspect(schema: $ZodType, options: IntrospectOptions): FormDe
     throw new Error(`kelex only supports z.object() schemas at the top level, got "${def.type}"`);
   }
 
-  // Surface cross-field refinements on the top-level object (dropped otherwise).
-  warnObjectRefinements(resolved, warnings);
+  // Scan the ORIGINAL schema, not the resolved one: for an intersection the
+  // resolved schema is a synthetic object carrying only the merged shape, so
+  // the intersection's own .refine() checks are not on it to be found.
+  warnObjectRefinements(schema, warnings);
 
   const fields = introspectShape(def.shape, warnings);
 

--- a/src/introspection/introspect.ts
+++ b/src/introspection/introspect.ts
@@ -3,6 +3,7 @@ import { extractConstraints } from "./checks";
 import { collectMeta, metaString } from "./meta";
 import type { FieldDescriptor, FieldMetadata, FieldType, FormDescriptor } from "./types";
 import { type UnwrapResult, unwrapSchema } from "./unwrap";
+import { computeVersion } from "./version";
 
 export interface IntrospectOptions {
   /** Name for the generated form component */
@@ -480,6 +481,7 @@ export function introspect(schema: $ZodType, options: IntrospectOptions): FormDe
   const fields = introspectShape(def.shape, warnings);
 
   return {
+    version: computeVersion(fields),
     name: options.formName,
     fields,
     schemaImportPath: options.schemaImportPath,

--- a/src/introspection/introspect.ts
+++ b/src/introspection/introspect.ts
@@ -1,5 +1,6 @@
 import type { $ZodType } from "zod/v4/core";
 import { extractConstraints } from "./checks";
+import { collectMeta, metaString } from "./meta";
 import type { FieldDescriptor, FieldMetadata, FieldType, FormDescriptor } from "./types";
 import { unwrapSchema } from "./unwrap";
 
@@ -354,19 +355,30 @@ function introspectField(name: string, fieldSchema: $ZodType, warnings: string[]
   // Peel pipe/transform once so type, constraints, and metadata share one inner schema.
   const inner = peelPipe(unwrapped);
   const type = resolveType(inner);
+  // Read meta from the ORIGINAL schema: the payload may sit on any wrapper in
+  // the chain, and the unwrapped inner is only one of those instances.
+  const meta = collectMeta(fieldSchema);
+  const label = metaString(meta, "title") ?? nameToLabel(name);
 
   // Check if it's a supported type
   if (!isScalarType(type) && !isCompositeType(type)) {
     warnings.push(`Field "${name}": unsupported type "${type}", treating as string`);
     const fallback: FieldDescriptor = {
       name,
-      label: nameToLabel(name),
+      label,
       type: "string",
       isOptional,
       isNullable,
       constraints: {},
       metadata: { kind: "string" },
     };
+    const fallbackDescription = metaString(meta, "description");
+    if (fallbackDescription) {
+      fallback.description = fallbackDescription;
+    }
+    if (meta) {
+      fallback.meta = meta;
+    }
     if (defaultValue !== undefined) {
       fallback.defaultValue = defaultValue;
     }
@@ -380,11 +392,11 @@ function introspectField(name: string, fieldSchema: $ZodType, warnings: string[]
     warnings.push(formatDroppedCheck(name, check));
   }
   const metadata = buildMetadata(inner, warnings);
-  const description = (inner as { description?: string }).description;
+  const description = metaString(meta, "description");
 
   const field: FieldDescriptor = {
     name,
-    label: nameToLabel(name),
+    label,
     type: fieldType,
     isOptional,
     isNullable,
@@ -394,6 +406,10 @@ function introspectField(name: string, fieldSchema: $ZodType, warnings: string[]
 
   if (description) {
     field.description = description;
+  }
+
+  if (meta) {
+    field.meta = meta;
   }
 
   if (defaultValue !== undefined) {

--- a/src/introspection/meta.ts
+++ b/src/introspection/meta.ts
@@ -1,9 +1,9 @@
 import { globalRegistry } from "zod/v4/core";
 import type { $ZodType } from "zod/v4/core";
+import { FLAG_WRAPPERS } from "./unwrap";
 
 /**
- * Returns the schema one level in, for the wrapper kinds the reader traverses
- * (`unwrapSchema` peels optional/nullable/default, `peelPipe` peels pipe).
+ * Returns the schema one level in, for the wrapper kinds the reader traverses.
  * Returns undefined at the first non-wrapper.
  */
 function innerSchema(schema: $ZodType): $ZodType | undefined {
@@ -16,7 +16,7 @@ function innerSchema(schema: $ZodType): $ZodType | undefined {
   if (def.type === "pipe") {
     return def.in;
   }
-  if (def.type === "optional" || def.type === "nullable" || def.type === "default") {
+  if (FLAG_WRAPPERS.has(def.type)) {
     return def.innerType;
   }
   return undefined;

--- a/src/introspection/meta.ts
+++ b/src/introspection/meta.ts
@@ -1,0 +1,70 @@
+import { globalRegistry } from "zod/v4/core";
+import type { $ZodType } from "zod/v4/core";
+
+/**
+ * Returns the schema one level in, for the wrapper kinds the reader traverses
+ * (`unwrapSchema` peels optional/nullable/default, `peelPipe` peels pipe).
+ * Returns undefined at the first non-wrapper.
+ */
+function innerSchema(schema: $ZodType): $ZodType | undefined {
+  const def = schema._zod.def as {
+    type: string;
+    innerType?: $ZodType;
+    in?: $ZodType;
+  };
+
+  if (def.type === "pipe") {
+    return def.in;
+  }
+  if (def.type === "optional" || def.type === "nullable" || def.type === "default") {
+    return def.innerType;
+  }
+  return undefined;
+}
+
+/**
+ * Collects the `.meta()`/`.describe()` payload for a field.
+ *
+ * Zod 4 stores meta in `globalRegistry` keyed by the schema INSTANCE, not in
+ * `_zod.def`, and each wrapper is a distinct instance. So `z.string().meta(m)`
+ * registers against the string while `z.string().optional().meta(m)` registers
+ * against the optional wrapper -- reading either level alone misses the other.
+ * This walks the whole wrapper chain and merges, outermost winning per key,
+ * since the outermost call is the last one the author wrote.
+ *
+ * Returns the payload verbatim (arbitrary keys included, not just title and
+ * description) so the descriptor stays lossless and the schema-writer can
+ * re-emit the original `.meta()` call.
+ */
+export function collectMeta(schema: $ZodType): Record<string, unknown> | undefined {
+  const layers: Record<string, unknown>[] = [];
+
+  let current: $ZodType | undefined = schema;
+  while (current) {
+    const entry: unknown = globalRegistry.get(current);
+    if (entry && typeof entry === "object") {
+      layers.push(entry as Record<string, unknown>);
+    }
+    current = innerSchema(current);
+  }
+
+  if (layers.length === 0) {
+    return undefined;
+  }
+
+  // layers runs outer -> inner; assign innermost first so the outermost wins.
+  const merged: Record<string, unknown> = {};
+  for (let i = layers.length - 1; i >= 0; i--) {
+    Object.assign(merged, layers[i]);
+  }
+  return merged;
+}
+
+/** Reads a string-valued meta key, ignoring non-string payloads. */
+export function metaString(
+  meta: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  const value = meta?.[key];
+  return typeof value === "string" ? value : undefined;
+}

--- a/src/introspection/types.ts
+++ b/src/introspection/types.ts
@@ -127,6 +127,15 @@ export interface FormStep {
 
 /** Complete form descriptor */
 export interface FormDescriptor {
+  /**
+   * Deterministic content hash of the fields -- the descriptor's data contract.
+   * Identical schemas hash identically and any contract change produces a new
+   * value with no human bump, so consumers can pin against it and detect
+   * schema evolution on their own. Presentation and cosmetic options are
+   * excluded; see `computeVersion`.
+   */
+  version: string;
+
   /** Form name for the generated component */
   name: string;
 

--- a/src/introspection/types.ts
+++ b/src/introspection/types.ts
@@ -63,11 +63,22 @@ export interface FieldDescriptor {
   /** Original key name from schema shape */
   name: string;
 
-  /** Human-readable label derived from name */
+  /**
+   * Human-readable label. Taken from `.meta({ title })` when the schema author
+   * set one; otherwise derived from `name`.
+   */
   label: string;
 
-  /** Description from schema.describe() */
+  /** Description from `.meta({ description })` or `.describe()` */
   description?: string;
+
+  /**
+   * The full `.meta()`/`.describe()` payload, verbatim. Zod 4 keeps this in
+   * `globalRegistry` rather than the schema def, and it is an open record --
+   * carrying it whole (not just `title`/`description`) keeps presentation
+   * metadata lossless through the round trip.
+   */
+  meta?: Record<string, unknown>;
 
   /** Core type after unwrapping optional/nullable */
   type: FieldType;

--- a/src/introspection/unwrap.ts
+++ b/src/introspection/unwrap.ts
@@ -1,5 +1,16 @@
 import type { $ZodType } from "zod/v4/core";
 
+/**
+ * Wrapper defs that carry a presence flag or a default and hold their inner
+ * schema under `innerType`.
+ *
+ * Single source of truth: this list is consumed both here (to peel the
+ * wrappers) and by the meta walk (to visit every level of the chain). Zod
+ * registers meta against the schema INSTANCE, so a level missing from this
+ * list is a level whose meta is never read -- the silent-drop class #149 was.
+ */
+export const FLAG_WRAPPERS: ReadonlySet<string> = new Set(["optional", "nullable", "default"]);
+
 export interface UnwrapResult {
   /** The innermost non-wrapper schema */
   inner: $ZodType;
@@ -56,11 +67,7 @@ export function unwrapSchema(schema: $ZodType): UnwrapResult {
   let defaultValue: unknown;
 
   // Unwrap nested optional/nullable/default wrappers
-  while (
-    current._zod.def.type === "optional" ||
-    current._zod.def.type === "nullable" ||
-    current._zod.def.type === "default"
-  ) {
+  while (FLAG_WRAPPERS.has(current._zod.def.type)) {
     if (current._zod.def.type === "optional") {
       isOptional = true;
     } else if (current._zod.def.type === "nullable") {

--- a/src/introspection/version.ts
+++ b/src/introspection/version.ts
@@ -1,0 +1,66 @@
+import { createHash } from "node:crypto";
+import type { FieldDescriptor, FormDescriptor } from "./types";
+
+/**
+ * Field-level keys excluded from the version hash at every depth.
+ *
+ * These are presentation, not contract: they describe how a field is labelled,
+ * not what data conforms to it. Renaming a label must not invalidate captured
+ * records or trigger a schema evolution downstream. `label` is additionally
+ * redundant -- absent an explicit title it is derived from `name`, which is
+ * hashed.
+ */
+const PRESENTATION_KEYS = new Set(["label", "description", "meta", "schemaRef"]);
+
+/**
+ * Produces a canonical, order-stable structure for hashing.
+ *
+ * Object keys are sorted so a property reordering in the reader does not churn
+ * the version, while ARRAYS keep their order -- field declaration order is
+ * semantic, and so is tuple element and union variant order. Excluded keys and
+ * undefined values are dropped so an absent key and an explicitly-undefined one
+ * hash identically.
+ */
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalize);
+  }
+
+  if (value !== null && typeof value === "object") {
+    const source = value as Record<string, unknown>;
+    const result: Record<string, unknown> = {};
+    for (const key of Object.keys(source).sort()) {
+      if (PRESENTATION_KEYS.has(key) || source[key] === undefined) {
+        continue;
+      }
+      result[key] = canonicalize(source[key]);
+    }
+    return result;
+  }
+
+  return value;
+}
+
+/**
+ * Computes a deterministic content hash over a descriptor's structural content.
+ *
+ * Identical schemas produce an identical version and any change to the data
+ * contract produces a new one, with no human bump -- so a capture pipeline can
+ * detect schema evolution on its own and a descriptor-reading consumer can pin
+ * against a stable value.
+ *
+ * Hashes the FIELDS only. Everything else on the descriptor is either cosmetic
+ * (`name`, `schemaImportPath`, `schemaExportName`), derived diagnostics
+ * (`warnings` -- whose text changes when warning wording improves, which is not
+ * a schema change), or presentation grouping (`steps`). Including any of them
+ * would churn the version without the data contract having moved.
+ */
+export function computeVersion(fields: FieldDescriptor[]): string {
+  const canonical = JSON.stringify(canonicalize(fields));
+  return createHash("sha256").update(canonical, "utf8").digest("hex").slice(0, 16);
+}
+
+/** Recomputes the version for a descriptor whose fields may have been edited. */
+export function withVersion(form: Omit<FormDescriptor, "version">): FormDescriptor {
+  return { ...form, version: computeVersion(form.fields) };
+}

--- a/src/schema-writer/field-emitter.ts
+++ b/src/schema-writer/field-emitter.ts
@@ -21,8 +21,10 @@ const SUPPORTED_TYPES = new Set([
  * chaining but without re-emitting the full schema body.
  * All field types are now supported.
  */
-export function emitField(field: FieldDescriptor): string {
-  // Named schema reference: emit validated identifier, chain optional/nullable.
+export function emitField(field: FieldDescriptor, warnings?: string[]): string {
+  let expr: string;
+
+  // Named schema reference: emit validated identifier without the schema body.
   if (field.schemaRef) {
     if (!VALID_IDENTIFIER.test(field.schemaRef)) {
       throw new Error(
@@ -30,20 +32,16 @@ export function emitField(field: FieldDescriptor): string {
           "schemaRef must be a valid JavaScript identifier.",
       );
     }
-    let expr = field.schemaRef;
-    if (field.isNullable) expr += ".nullable()";
-    if (field.isOptional) expr += ".optional()";
-    return expr;
+    expr = field.schemaRef;
+  } else {
+    if (!SUPPORTED_TYPES.has(field.type)) {
+      throw new Error(
+        `Unsupported field type "${field.type}" for field "${field.name}". ` +
+          "Only string, number, boolean, date, enum, array, tuple, object, record, and union are supported.",
+      );
+    }
+    expr = emitBaseExpression(field, warnings);
   }
-
-  if (!SUPPORTED_TYPES.has(field.type)) {
-    throw new Error(
-      `Unsupported field type "${field.type}" for field "${field.name}". ` +
-        "Only string, number, boolean, date, enum, array, tuple, object, record, and union are supported.",
-    );
-  }
-
-  let expr = emitBaseExpression(field);
 
   if (field.isNullable) {
     expr += ".nullable()";
@@ -53,14 +51,96 @@ export function emitField(field: FieldDescriptor): string {
     expr += ".optional()";
   }
 
-  if (field.description) {
-    expr += `.describe(${JSON.stringify(field.description)})`;
-  }
+  expr += emitDefault(field, warnings);
+  expr += emitMeta(field, warnings);
 
   return expr;
 }
 
-function emitBaseExpression(field: FieldDescriptor): string {
+/**
+ * Emits `.default(value)` for a captured default. Applied after
+ * optional/nullable so the wrapper order matches what the reader unwraps.
+ */
+function emitDefault(field: FieldDescriptor, warnings?: string[]): string {
+  if (field.defaultValue === undefined) {
+    return "";
+  }
+
+  const literal = emitLiteral(field.defaultValue);
+  if (literal === undefined) {
+    warnings?.push(
+      `Field "${field.name}": default value is not a JSON literal (e.g. a Date or class instance) ` +
+        "and was not re-emitted; re-apply the .default() by hand.",
+    );
+    return "";
+  }
+
+  return `.default(${literal})`;
+}
+
+/**
+ * Emits the `.meta()` payload, falling back to `.describe()` for descriptors
+ * built by hand with only a description. Meta already contains `description`,
+ * so emitting both would duplicate it.
+ */
+function emitMeta(field: FieldDescriptor, warnings?: string[]): string {
+  if (field.meta && Object.keys(field.meta).length > 0) {
+    const literal = emitLiteral(field.meta);
+    if (literal === undefined) {
+      warnings?.push(
+        `Field "${field.name}": .meta() payload is not JSON-serializable and was not re-emitted.`,
+      );
+      return "";
+    }
+    return `.meta(${literal})`;
+  }
+
+  if (field.description) {
+    return `.describe(${JSON.stringify(field.description)})`;
+  }
+
+  return "";
+}
+
+/**
+ * Renders a value as a source literal, or undefined when it cannot survive the
+ * trip. Anything not JSON-shaped (Date, Map, class instance) would stringify
+ * into something that re-reads as a different type -- a silent corruption, so
+ * the caller warns instead.
+ */
+function emitLiteral(value: unknown): string | undefined {
+  if (!isJsonSafe(value)) {
+    return undefined;
+  }
+  return JSON.stringify(value);
+}
+
+function isJsonSafe(value: unknown): boolean {
+  if (value === null) {
+    return true;
+  }
+
+  const type = typeof value;
+  if (type === "string" || type === "number" || type === "boolean") {
+    return Number.isNaN(value) ? false : true;
+  }
+
+  if (Array.isArray(value)) {
+    return value.every(isJsonSafe);
+  }
+
+  if (type === "object") {
+    const proto = Object.getPrototypeOf(value);
+    if (proto !== Object.prototype && proto !== null) {
+      return false;
+    }
+    return Object.values(value as Record<string, unknown>).every(isJsonSafe);
+  }
+
+  return false;
+}
+
+function emitBaseExpression(field: FieldDescriptor, warnings?: string[]): string {
   switch (field.type) {
     case "string":
       return emitString(field);
@@ -73,15 +153,15 @@ function emitBaseExpression(field: FieldDescriptor): string {
     case "enum":
       return emitEnum(field);
     case "array":
-      return emitArray(field);
+      return emitArray(field, warnings);
     case "tuple":
-      return emitTuple(field);
+      return emitTuple(field, warnings);
     case "object":
-      return emitObject(field);
+      return emitObject(field, warnings);
     case "record":
-      return emitRecord(field);
+      return emitRecord(field, warnings);
     case "union":
-      return emitUnion(field);
+      return emitUnion(field, warnings);
     default:
       throw new Error(`Unexpected field type: ${field.type}`);
   }
@@ -119,6 +199,15 @@ function emitString(field: FieldDescriptor): string {
   if (constraints.maxLength !== undefined) {
     base += `.max(${constraints.maxLength})`;
   }
+  if (constraints.length !== undefined) {
+    base += `.length(${constraints.length})`;
+  }
+  if (constraints.startsWith !== undefined) {
+    base += `.startsWith(${JSON.stringify(constraints.startsWith)})`;
+  }
+  if (constraints.endsWith !== undefined) {
+    base += `.endsWith(${JSON.stringify(constraints.endsWith)})`;
+  }
   if (constraints.pattern !== undefined) {
     base += `.regex(/${constraints.pattern}/)`;
   }
@@ -137,11 +226,14 @@ function emitNumber(field: FieldDescriptor): string {
   if (constraints.isInt) {
     base += ".int()";
   }
+  // .min()/.max() are the inclusive bounds; exclusive ones must emit .gt()/.lt()
+  // or .positive() round-trips back as .nonnegative() -- an off-by-one at the
+  // validation boundary, not a cosmetic difference.
   if (constraints.min !== undefined) {
-    base += `.min(${constraints.min})`;
+    base += constraints.minExclusive ? `.gt(${constraints.min})` : `.min(${constraints.min})`;
   }
   if (constraints.max !== undefined) {
-    base += `.max(${constraints.max})`;
+    base += constraints.maxExclusive ? `.lt(${constraints.max})` : `.max(${constraints.max})`;
   }
   if (constraints.step !== undefined) {
     base += `.multipleOf(${constraints.step})`;
@@ -161,14 +253,14 @@ function emitEnum(field: FieldDescriptor): string {
   return `z.enum([${values}])`;
 }
 
-function emitArray(field: FieldDescriptor): string {
+function emitArray(field: FieldDescriptor, warnings?: string[]): string {
   if (field.metadata.kind !== "array") {
     throw new Error(
       `Field "${field.name}" has type "array" but metadata kind is "${field.metadata.kind}"`,
     );
   }
 
-  const elementExpr = emitField(field.metadata.element);
+  const elementExpr = emitField(field.metadata.element, warnings);
   let base = `z.array(${elementExpr})`;
 
   if (field.constraints.minItems !== undefined) {
@@ -177,22 +269,26 @@ function emitArray(field: FieldDescriptor): string {
   if (field.constraints.maxItems !== undefined) {
     base += `.max(${field.constraints.maxItems})`;
   }
+  // z.array(x).length(n) reads as length_equals, the same check as the string form.
+  if (field.constraints.length !== undefined) {
+    base += `.length(${field.constraints.length})`;
+  }
 
   return base;
 }
 
-function emitTuple(field: FieldDescriptor): string {
+function emitTuple(field: FieldDescriptor, warnings?: string[]): string {
   if (field.metadata.kind !== "tuple") {
     throw new Error(
       `Field "${field.name}" has type "tuple" but metadata kind is "${field.metadata.kind}"`,
     );
   }
 
-  const elements = field.metadata.elements.map((el) => emitField(el)).join(", ");
+  const elements = field.metadata.elements.map((el) => emitField(el, warnings)).join(", ");
   return `z.tuple([${elements}])`;
 }
 
-function emitObject(field: FieldDescriptor): string {
+function emitObject(field: FieldDescriptor, warnings?: string[]): string {
   if (field.metadata.kind !== "object") {
     throw new Error(
       `Field "${field.name}" has type "object" but metadata kind is "${field.metadata.kind}"`,
@@ -201,23 +297,31 @@ function emitObject(field: FieldDescriptor): string {
 
   const entries = field.metadata.fields.map((child) => {
     const key = VALID_IDENTIFIER.test(child.name) ? child.name : JSON.stringify(child.name);
-    return `${key}: ${emitField(child)}`;
+    return `${key}: ${emitField(child, warnings)}`;
   });
   return `z.object({ ${entries.join(", ")} })`;
 }
 
-function emitRecord(field: FieldDescriptor): string {
+function emitRecord(field: FieldDescriptor, warnings?: string[]): string {
   if (field.metadata.kind !== "record") {
     throw new Error(
       `Field "${field.name}" has type "record" but metadata kind is "${field.metadata.kind}"`,
     );
   }
 
-  const valueExpr = emitField(field.metadata.valueDescriptor);
+  // The descriptor carries no key schema (the reader warns and keeps only the
+  // value), so the key is always re-emitted as a plain z.string(). A narrowed
+  // key -- z.record(z.enum([...]), v) -- cannot be reconstructed from here.
+  warnings?.push(
+    `Field "${field.name}": record key re-emitted as z.string(); a narrower key schema ` +
+      "is not carried by the descriptor and must be re-applied by hand.",
+  );
+
+  const valueExpr = emitField(field.metadata.valueDescriptor, warnings);
   return `z.record(z.string(), ${valueExpr})`;
 }
 
-function emitUnion(field: FieldDescriptor): string {
+function emitUnion(field: FieldDescriptor, warnings?: string[]): string {
   if (field.metadata.kind !== "union") {
     throw new Error(
       `Field "${field.name}" has type "union" but metadata kind is "${field.metadata.kind}"`,
@@ -227,15 +331,16 @@ function emitUnion(field: FieldDescriptor): string {
   const { discriminator, variants } = field.metadata;
 
   if (discriminator !== undefined) {
-    return emitDiscriminatedUnion(discriminator, variants);
+    return emitDiscriminatedUnion(discriminator, variants, warnings);
   }
 
-  return emitPlainUnion(variants);
+  return emitPlainUnion(variants, warnings);
 }
 
 function emitDiscriminatedUnion(
   discriminator: string,
   variants: { value: string; fields: FieldDescriptor[] }[],
+  warnings?: string[],
 ): string {
   const variantExprs = variants.map((variant) => {
     const entries = variant.fields.map((child) => {
@@ -243,7 +348,7 @@ function emitDiscriminatedUnion(
       if (child.name === discriminator) {
         return `${child.name}: z.literal(${JSON.stringify(variant.value)})`;
       }
-      return `${child.name}: ${emitField(child)}`;
+      return `${child.name}: ${emitField(child, warnings)}`;
     });
     return `z.object({ ${entries.join(", ")} })`;
   });
@@ -251,7 +356,10 @@ function emitDiscriminatedUnion(
   return `z.discriminatedUnion(${JSON.stringify(discriminator)}, [${variantExprs.join(", ")}])`;
 }
 
-function emitPlainUnion(variants: { value: string; fields: FieldDescriptor[] }[]): string {
+function emitPlainUnion(
+  variants: { value: string; fields: FieldDescriptor[] }[],
+  warnings?: string[],
+): string {
   const optionExprs = variants.map((variant) => {
     // Heuristic: the introspector wraps non-object union members in synthetic
     // single-field objects named "variant_N" / "option_N" (see introspect.ts
@@ -263,10 +371,10 @@ function emitPlainUnion(variants: { value: string; fields: FieldDescriptor[] }[]
       variant.fields[0].name.startsWith("option_");
 
     if (isSyntheticScalar) {
-      return emitField(variant.fields[0]);
+      return emitField(variant.fields[0], warnings);
     }
 
-    const entries = variant.fields.map((child) => `${child.name}: ${emitField(child)}`);
+    const entries = variant.fields.map((child) => `${child.name}: ${emitField(child, warnings)}`);
     return `z.object({ ${entries.join(", ")} })`;
   });
 

--- a/src/schema-writer/writer.ts
+++ b/src/schema-writer/writer.ts
@@ -13,19 +13,20 @@ export function writeSchema(options: SchemaWriterOptions): SchemaWriterResult {
   const { form, embeddedSchemas } = options;
 
   const lines: string[] = ['import { z } from "zod/v4";', ""];
+  const warnings: string[] = [];
 
   if (embeddedSchemas && embeddedSchemas.length > 0) {
     const sorted = topologicalSort(embeddedSchemas);
     for (const schema of sorted) {
-      lines.push(...emitSchemaDeclaration(schema.form));
+      lines.push(...emitSchemaDeclaration(schema.form, warnings));
       lines.push("");
     }
   }
 
-  lines.push(...emitSchemaDeclaration(form));
+  lines.push(...emitSchemaDeclaration(form, warnings));
   lines.push("");
 
-  return { code: lines.join("\n"), warnings: [] };
+  return { code: lines.join("\n"), warnings };
 }
 
 /**
@@ -47,8 +48,8 @@ function inferTypeName(schemaExportName: string): string {
  *   export const fooSchema = z.object({ ... });
  *   export type Foo = z.infer<typeof fooSchema>;
  */
-function emitSchemaDeclaration(form: FormDescriptor): string[] {
-  const fieldEntries = form.fields.map((field) => `  ${field.name}: ${emitField(field)},`);
+function emitSchemaDeclaration(form: FormDescriptor, warnings?: string[]): string[] {
+  const fieldEntries = form.fields.map((field) => `  ${field.name}: ${emitField(field, warnings)},`);
 
   const typeName = inferTypeName(form.schemaExportName);
 

--- a/src/schema-writer/writer.ts
+++ b/src/schema-writer/writer.ts
@@ -49,7 +49,9 @@ function inferTypeName(schemaExportName: string): string {
  *   export type Foo = z.infer<typeof fooSchema>;
  */
 function emitSchemaDeclaration(form: FormDescriptor, warnings?: string[]): string[] {
-  const fieldEntries = form.fields.map((field) => `  ${field.name}: ${emitField(field, warnings)},`);
+  const fieldEntries = form.fields.map(
+    (field) => `  ${field.name}: ${emitField(field, warnings)},`,
+  );
 
   const typeName = inferTypeName(form.schemaExportName);
 

--- a/test/introspection/meta.test.ts
+++ b/test/introspection/meta.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod/v4";
+import { introspect } from "../../src/introspection/introspect";
+import type { FieldDescriptor } from "../../src/introspection/types";
+import { architectureObject } from "../fixtures/architecture-fixture";
+
+const OPTIONS = {
+  formName: "MetaForm",
+  schemaImportPath: "./meta-fixture",
+  schemaExportName: "metaObject",
+};
+
+function fieldsOf(schema: Parameters<typeof introspect>[0]): Record<string, FieldDescriptor> {
+  const descriptor = introspect(schema, OPTIONS);
+  return Object.fromEntries(descriptor.fields.map((field) => [field.name, field]));
+}
+
+describe("meta capture (#147)", () => {
+  // Criterion 1: .meta({ title }) becomes the label instead of the name derivation.
+  it("uses .meta({ title }) as the label", () => {
+    const fields = fieldsOf(z.object({ firstName: z.string().meta({ title: "Given name" }) }));
+    expect(fields.firstName.label).toBe("Given name");
+  });
+
+  // Criterion 2: absent meta still falls back to the name-derived label.
+  it("falls back to the name-derived label when no meta is set", () => {
+    const fields = fieldsOf(z.object({ firstName: z.string() }));
+    expect(fields.firstName.label).toBe("First Name");
+  });
+
+  // Criterion 3: the canonical fixture's title field -- the exact gap #141/PR #146 surfaced.
+  it("captures the fixture's explicit title, which the lossless reader dropped", () => {
+    const fields = fieldsOf(architectureObject);
+    expect(fields.title.label).toBe("Title");
+    expect(fields.title.meta).toEqual({ title: "Title" });
+    // Constraints must survive alongside meta, not be replaced by it.
+    expect(fields.title.constraints).toEqual({ minLength: 3, maxLength: 80 });
+  });
+
+  // Criterion 4: .describe() and .meta({ description }) both land on description.
+  it("captures descriptions from both .describe() and .meta()", () => {
+    const fields = fieldsOf(
+      z.object({
+        a: z.string().describe("via describe"),
+        b: z.string().meta({ description: "via meta" }),
+      }),
+    );
+    expect(fields.a.description).toBe("via describe");
+    expect(fields.b.description).toBe("via meta");
+  });
+
+  // Criterion 5 (the real gotcha): Zod 4 registers meta against the schema INSTANCE,
+  // so a wrapper added after .meta() -- or .meta() added after a wrapper -- puts the
+  // payload on a different instance than the unwrapped inner the reader used to read.
+  it("finds meta at any level of the wrapper chain", () => {
+    const fields = fieldsOf(
+      z.object({
+        innerMeta: z.string().meta({ title: "Inner" }).optional(),
+        outerMeta: z.string().optional().meta({ title: "Outer" }),
+        deep: z.string().meta({ title: "Deep" }).optional().default("x"),
+        acrossPipe: z
+          .string()
+          .meta({ title: "Piped" })
+          .transform((s) => s.length),
+      }),
+    );
+    expect(fields.innerMeta.label).toBe("Inner");
+    expect(fields.outerMeta.label).toBe("Outer");
+    expect(fields.deep.label).toBe("Deep");
+    expect(fields.acrossPipe.label).toBe("Piped");
+  });
+
+  // Criterion 6: when both levels carry meta, the outermost call wins per key,
+  // but keys only the inner set are still preserved.
+  it("merges meta across the chain with the outermost winning per key", () => {
+    const fields = fieldsOf(
+      z.object({
+        both: z
+          .string()
+          .meta({ title: "Inner", description: "kept from inner" })
+          .optional()
+          .meta({ title: "Outer" }),
+      }),
+    );
+    expect(fields.both.label).toBe("Outer");
+    expect(fields.both.description).toBe("kept from inner");
+  });
+
+  // Criterion 7 (losslessness): the payload is an open record. Capturing only
+  // title/description would silently drop the rest -- the exact failure class
+  // the lossless-reader work exists to eliminate.
+  it("carries the full meta payload verbatim, not just title and description", () => {
+    const fields = fieldsOf(
+      z.object({
+        rich: z.string().meta({
+          title: "Rich",
+          description: "desc",
+          examples: ["a", "b"],
+          deprecated: true,
+          "x-custom": { nested: 1 },
+        }),
+      }),
+    );
+    expect(fields.rich.meta).toEqual({
+      title: "Rich",
+      description: "desc",
+      examples: ["a", "b"],
+      deprecated: true,
+      "x-custom": { nested: 1 },
+    });
+  });
+
+  // Criterion 8: meta on composite types and on nested fields, not just top-level scalars.
+  it("captures meta on nested fields and composite types", () => {
+    const fields = fieldsOf(
+      z.object({
+        author: z
+          .object({ email: z.string().meta({ title: "Email address" }) })
+          .meta({ title: "Author" }),
+        tags: z.array(z.string()).meta({ title: "Tags" }),
+      }),
+    );
+    expect(fields.author.label).toBe("Author");
+    expect(fields.tags.label).toBe("Tags");
+    const authorMeta = fields.author.metadata;
+    if (authorMeta.kind !== "object") {
+      throw new Error("expected object metadata");
+    }
+    expect(authorMeta.fields[0].label).toBe("Email address");
+  });
+
+  // Criterion 9: no meta means no meta key at all -- an empty object would make
+  // every un-annotated field look annotated to a descriptor consumer.
+  it("omits the meta key entirely when the author set none", () => {
+    const fields = fieldsOf(z.object({ plain: z.string() }));
+    expect(fields.plain.meta).toBeUndefined();
+    expect("meta" in fields.plain).toBe(false);
+  });
+});

--- a/test/introspection/silent-drops.test.ts
+++ b/test/introspection/silent-drops.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod/v4";
+import { introspect } from "../../src/introspection";
+import type { FieldDescriptor } from "../../src/introspection/types";
+
+const OPTIONS = {
+  formName: "DropForm",
+  schemaImportPath: "./drop-fixture",
+  schemaExportName: "dropSchema",
+};
+
+function fieldsOf(descriptor: { fields: FieldDescriptor[] }): Record<string, FieldDescriptor> {
+  return Object.fromEntries(descriptor.fields.map((field) => [field.name, field]));
+}
+
+describe("remaining silent drops (#149)", () => {
+  describe("refine on an intersection", () => {
+    const left = z.object({ x: z.string() });
+    const right = z.object({ y: z.number() });
+
+    // Criterion 1: the intersection's OWN refine. resolveRootSchema replaces the
+    // intersection with a synthetic object holding only the merged shape, so the
+    // checks array was not on the schema the warning scan inspected.
+    it("warns about a refine attached directly to the intersection", () => {
+      const descriptor = introspect(
+        z.intersection(left, right).refine((v) => v.x.length > 0, { message: "nonempty" }),
+        OPTIONS,
+      );
+      expect(descriptor.warnings.some((w) => w.includes(".refine()"))).toBe(true);
+    });
+
+    // Criterion 2: a refine on a MEMBER. Only the member's shape survives the
+    // merge, so its checks drop with the wrapper.
+    it("warns about a refine attached to an intersection member", () => {
+      const descriptor = introspect(
+        z.intersection(
+          left.refine((v) => v.x !== "", { message: "member rule" }),
+          right,
+        ),
+        OPTIONS,
+      );
+      expect(descriptor.warnings.some((w) => w.includes(".refine()"))).toBe(true);
+    });
+
+    // Criterion 3: the merge itself still works -- warning must not cost fields.
+    it("still merges the intersection shape while warning", () => {
+      const descriptor = introspect(
+        z.intersection(left, right).refine(() => true),
+        OPTIONS,
+      );
+      expect(descriptor.fields.map((f) => f.name)).toEqual(["x", "y"]);
+    });
+
+    // Criterion 4: no refine means no spurious warning.
+    it("does not warn on a plain intersection", () => {
+      const descriptor = introspect(z.intersection(left, right), OPTIONS);
+      expect(descriptor.warnings).toEqual([]);
+    });
+  });
+
+  describe("wrapper immediately before transform", () => {
+    // Criterion 5: the wrapper sits INSIDE the pipe, so unwrap-then-peel left it
+    // as the resolved type -- the field read as an unsupported "optional" type,
+    // lost its constraints, and reported isOptional false.
+    it("resolves optional before transform without losing constraints", () => {
+      const descriptor = introspect(
+        z.object({
+          value: z
+            .string()
+            .min(3)
+            .optional()
+            .transform((s) => s?.length),
+        }),
+        OPTIONS,
+      );
+      const field = fieldsOf(descriptor).value;
+      expect(field.type).toBe("string");
+      expect(field.isOptional).toBe(true);
+      expect(field.constraints.minLength).toBe(3);
+      expect(descriptor.warnings).toEqual([]);
+    });
+
+    it("resolves nullable before transform", () => {
+      const descriptor = introspect(
+        z.object({
+          value: z
+            .string()
+            .max(9)
+            .nullable()
+            .transform((s) => s ?? ""),
+        }),
+        OPTIONS,
+      );
+      const field = fieldsOf(descriptor).value;
+      expect(field.type).toBe("string");
+      expect(field.isNullable).toBe(true);
+      expect(field.constraints.maxLength).toBe(9);
+      expect(descriptor.warnings).toEqual([]);
+    });
+
+    it("resolves default before transform and keeps the default value", () => {
+      const descriptor = introspect(
+        z.object({
+          value: z
+            .string()
+            .min(2)
+            .default("ab")
+            .transform((s) => s.length),
+        }),
+        OPTIONS,
+      );
+      const field = fieldsOf(descriptor).value;
+      expect(field.type).toBe("string");
+      expect(field.defaultValue).toBe("ab");
+      expect(field.constraints.minLength).toBe(2);
+      expect(descriptor.warnings).toEqual([]);
+    });
+
+    // Criterion 6: stacked wrappers on both sides of the pipe.
+    it("resolves wrappers stacked around a transform", () => {
+      const descriptor = introspect(
+        z.object({
+          value: z
+            .string()
+            .min(1)
+            .nullable()
+            .optional()
+            .transform((s) => s ?? "")
+            .optional(),
+        }),
+        OPTIONS,
+      );
+      const field = fieldsOf(descriptor).value;
+      expect(field.type).toBe("string");
+      expect(field.isOptional).toBe(true);
+      expect(field.isNullable).toBe(true);
+      expect(field.constraints.minLength).toBe(1);
+    });
+
+    // Criterion 7: the pre-existing transform path still behaves.
+    it("keeps resolving a transform with no wrapper in between", () => {
+      const descriptor = introspect(
+        z.object({
+          value: z
+            .string()
+            .min(3)
+            .transform((s) => s.length),
+        }),
+        OPTIONS,
+      );
+      const field = fieldsOf(descriptor).value;
+      expect(field.type).toBe("string");
+      expect(field.constraints.minLength).toBe(3);
+      expect(field.isOptional).toBe(false);
+    });
+  });
+});

--- a/test/introspection/version.test.ts
+++ b/test/introspection/version.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod/v4";
+import type { $ZodType } from "zod/v4/core";
+import { introspect } from "../../src/introspection";
+import { compositeTarget } from "../../src/targets/composite";
+import { architectureObject } from "../fixtures/architecture-fixture";
+
+const OPTIONS = {
+  formName: "VersionForm",
+  schemaImportPath: "./version-fixture",
+  schemaExportName: "versionSchema",
+};
+
+function versionOf(schema: $ZodType, options = OPTIONS): string {
+  return introspect(schema, options).version;
+}
+
+describe("descriptor content version (#143)", () => {
+  // Criterion 1: deterministic -- the same schema always hashes the same, so a
+  // consumer can pin against it and a regenerate produces a comparable value.
+  it("produces the same version for the same schema every time", () => {
+    expect(versionOf(architectureObject)).toBe(versionOf(architectureObject));
+    expect(versionOf(z.object({ a: z.string().min(1) }))).toBe(
+      versionOf(z.object({ a: z.string().min(1) })),
+    );
+  });
+
+  it("produces a stable, non-empty hash", () => {
+    expect(versionOf(architectureObject)).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  // Criterion 2: cosmetic options must not churn the version, or every consumer
+  // re-pins because someone renamed the generated component.
+  it("ignores formName, import path and export name", () => {
+    const base = versionOf(z.object({ a: z.string() }));
+    expect(
+      versionOf(z.object({ a: z.string() }), {
+        formName: "CompletelyDifferentForm",
+        schemaImportPath: "../elsewhere/other",
+        schemaExportName: "renamedSchema",
+      }),
+    ).toBe(base);
+  });
+
+  // Criterion 3: presentation is not the data contract. A label edit must not
+  // invalidate captured records or trigger a downstream schema evolution.
+  it("ignores meta, labels and descriptions", () => {
+    const bare = versionOf(z.object({ a: z.string().min(2) }));
+    const annotated = versionOf(
+      z.object({
+        a: z
+          .string()
+          .min(2)
+          .meta({ title: "Alpha", description: "the first", examples: ["x"] }),
+      }),
+    );
+    expect(annotated).toBe(bare);
+  });
+
+  // Criterion 4: anything that changes what data conforms MUST change the version.
+  it("changes when a field is added, removed or renamed", () => {
+    const base = versionOf(z.object({ a: z.string() }));
+    expect(versionOf(z.object({ a: z.string(), b: z.number() }))).not.toBe(base);
+    expect(versionOf(z.object({ renamed: z.string() }))).not.toBe(base);
+    expect(versionOf(z.object({}))).not.toBe(base);
+  });
+
+  it("changes when a type changes", () => {
+    expect(versionOf(z.object({ a: z.string() }))).not.toBe(versionOf(z.object({ a: z.number() })));
+  });
+
+  it("changes when a constraint changes", () => {
+    const base = versionOf(z.object({ a: z.string().min(2) }));
+    expect(versionOf(z.object({ a: z.string().min(3) }))).not.toBe(base);
+    expect(versionOf(z.object({ a: z.string() }))).not.toBe(base);
+  });
+
+  // Criterion 5: the exclusivity distinction is a real boundary difference, so
+  // it must move the version -- .positive() and .nonnegative() are not the same
+  // contract even though both read as min 0.
+  it("changes between exclusive and inclusive bounds", () => {
+    expect(versionOf(z.object({ a: z.number().positive() }))).not.toBe(
+      versionOf(z.object({ a: z.number().nonnegative() })),
+    );
+  });
+
+  it("changes when optionality or nullability changes", () => {
+    const base = versionOf(z.object({ a: z.string() }));
+    expect(versionOf(z.object({ a: z.string().optional() }))).not.toBe(base);
+    expect(versionOf(z.object({ a: z.string().nullable() }))).not.toBe(base);
+  });
+
+  it("changes when a default changes", () => {
+    const base = versionOf(z.object({ a: z.string().default("x") }));
+    expect(versionOf(z.object({ a: z.string().default("y") }))).not.toBe(base);
+    expect(versionOf(z.object({ a: z.string() }))).not.toBe(base);
+  });
+
+  // Criterion 6: declaration order is semantic -- a form has exactly one order,
+  // and reordering fields is a contract change for anything positional.
+  it("changes when field declaration order changes", () => {
+    expect(versionOf(z.object({ a: z.string(), b: z.number() }))).not.toBe(
+      versionOf(z.object({ b: z.number(), a: z.string() })),
+    );
+  });
+
+  it("changes when a nested field changes", () => {
+    const base = versionOf(z.object({ outer: z.object({ inner: z.string().min(1) }) }));
+    expect(versionOf(z.object({ outer: z.object({ inner: z.string().min(2) }) }))).not.toBe(base);
+  });
+
+  it("changes when enum values or union variants change", () => {
+    expect(versionOf(z.object({ a: z.enum(["x", "y"]) }))).not.toBe(
+      versionOf(z.object({ a: z.enum(["x", "z"]) })),
+    );
+    expect(
+      versionOf(
+        z.object({
+          a: z.discriminatedUnion("k", [
+            z.object({ k: z.literal("one"), v: z.string() }),
+            z.object({ k: z.literal("two"), v: z.number() }),
+          ]),
+        }),
+      ),
+    ).not.toBe(
+      versionOf(
+        z.object({
+          a: z.discriminatedUnion("k", [z.object({ k: z.literal("one"), v: z.string() })]),
+        }),
+      ),
+    );
+  });
+
+  // Criterion 7: stamped into the emitted artifact as a discoverable top-level
+  // field, so a regenerate can diff it without re-deriving the descriptor.
+  it("is a top-level field of the composite artifact", () => {
+    const descriptor = introspect(architectureObject, OPTIONS);
+    const result = compositeTarget.generate(descriptor, {});
+    const parsed = JSON.parse(result.files[0].content) as Record<string, unknown>;
+
+    expect(parsed.version).toBe(descriptor.version);
+    expect(typeof parsed.version).toBe("string");
+  });
+});

--- a/test/schema-writer/field-emitter.test.ts
+++ b/test/schema-writer/field-emitter.test.ts
@@ -649,7 +649,11 @@ describe("emitField", () => {
       expect(emitField(field)).toBe("addressSchema.nullable().optional()");
     });
 
-    it("ignores description when schemaRef is set", () => {
+    // Behavior change in #148: this previously emitted a bare "addressSchema".
+    // A schemaRef suppresses the schema BODY, not the field's own annotations --
+    // dropping a description the descriptor carries is a silent round-trip loss,
+    // and `ref.describe(...)` returns a new schema rather than mutating the ref.
+    it("keeps description when schemaRef is set", () => {
       const field = makeField({
         name: "address",
         type: "object",
@@ -657,7 +661,7 @@ describe("emitField", () => {
         metadata: { kind: "object", fields: [] },
         schemaRef: "addressSchema",
       });
-      expect(emitField(field)).toBe("addressSchema");
+      expect(emitField(field)).toBe('addressSchema.describe("Mailing address")');
     });
 
     it("throws on schemaRef with spaces", () => {

--- a/test/schema-writer/round-trip.test.ts
+++ b/test/schema-writer/round-trip.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { z } from "zod/v4";
 import { introspect } from "../../src/introspection";
 import { writeSchema } from "../../src/schema-writer/writer";
+import { architectureObject } from "../fixtures/architecture-fixture";
 import { evaluateSchemaCode } from "../helpers/evaluate-schema";
 
 const INTROSPECT_OPTS = {
@@ -427,5 +428,135 @@ describe("round-trip: schema -> introspect -> writeSchema -> eval -> introspect"
       expect(f2.isOptional).toBe(f1.isOptional);
       expect(f2.isNullable).toBe(f1.isNullable);
     }
+  });
+});
+
+/**
+ * The cases above assert field-by-field, so a constraint the writer never
+ * emitted passed by simply not being looked at -- which is how the writer
+ * stayed lossy while the suite was green. These compare whole descriptors.
+ */
+describe("writer re-emit parity (#148)", () => {
+  // Criterion 1: the canonical adversarial fixture, whole.
+  it("round-trips the canonical fixture with every field identical", () => {
+    const { descriptor1, descriptor2 } = roundTrip(architectureObject);
+    expect(descriptor2.fields).toEqual(descriptor1.fields);
+  });
+
+  // Criterion 2: exclusive bounds. Emitting .min()/.max() for these turns
+  // .positive() into .nonnegative() -- the boundary moves by one, silently.
+  it("preserves exclusive vs inclusive numeric bounds", () => {
+    const { descriptor1, descriptor2, code } = roundTrip(
+      z.object({
+        exclusiveMin: z.number().gt(5),
+        inclusiveMin: z.number().gte(5),
+        exclusiveMax: z.number().lt(10),
+        inclusiveMax: z.number().lte(10),
+        positive: z.number().positive(),
+        nonneg: z.number().nonnegative(),
+      }),
+    );
+    expect(code).toContain(".gt(5)");
+    expect(code).toContain(".lt(10)");
+    expect(descriptor2.fields).toEqual(descriptor1.fields);
+
+    const byName = Object.fromEntries(descriptor2.fields.map((f) => [f.name, f]));
+    expect(byName.positive.constraints).toEqual({ min: 0, minExclusive: true });
+    expect(byName.nonneg.constraints).toEqual({ min: 0 });
+    expect(byName.positive.constraints).not.toEqual(byName.nonneg.constraints);
+  });
+
+  // Criterion 3: exact length, prefix, suffix.
+  it("preserves exact length, startsWith and endsWith", () => {
+    const { descriptor1, descriptor2 } = roundTrip(
+      z.object({
+        code: z.string().length(6),
+        prefixed: z.string().startsWith("ID-"),
+        suffixed: z.string().endsWith(".png"),
+        both: z.string().startsWith("a").endsWith("z"),
+        sizedList: z.array(z.string()).length(3),
+      }),
+    );
+    expect(descriptor2.fields).toEqual(descriptor1.fields);
+  });
+
+  // Criterion 4: defaults survive the trip out as well as in.
+  it("preserves defaults of every JSON-shaped kind", () => {
+    const { descriptor1, descriptor2 } = roundTrip(
+      z.object({
+        str: z.string().default("hello"),
+        num: z.number().default(42),
+        bool: z.boolean().default(true),
+        enumerated: z.enum(["a", "b"]).default("b"),
+        list: z.array(z.string()).default([]),
+        nested: z.object({ a: z.string() }).default({ a: "x" }),
+        withConstraints: z.string().min(2).max(8).default("mid"),
+      }),
+    );
+    expect(descriptor2.fields).toEqual(descriptor1.fields);
+  });
+
+  // Criterion 5 (the #147 seam): the reader now captures meta, so the writer
+  // must re-emit it or the round trip is lossy on the field #147 just added.
+  it("preserves the full .meta() payload", () => {
+    const { descriptor1, descriptor2, code } = roundTrip(
+      z.object({
+        annotated: z.string().meta({
+          title: "Annotated",
+          description: "with detail",
+          examples: ["one"],
+          deprecated: false,
+        }),
+        described: z.string().describe("plain"),
+      }),
+    );
+    expect(code).toContain(".meta(");
+    expect(descriptor2.fields).toEqual(descriptor1.fields);
+
+    const byName = Object.fromEntries(descriptor2.fields.map((f) => [f.name, f]));
+    expect(byName.annotated.label).toBe("Annotated");
+    expect(byName.annotated.meta).toEqual({
+      title: "Annotated",
+      description: "with detail",
+      examples: ["one"],
+      deprecated: false,
+    });
+    expect(byName.described.description).toBe("plain");
+  });
+
+  // Criterion 6: constraints nested inside composites, not just at top level.
+  it("round-trips constraints nested inside objects, arrays, tuples and unions", () => {
+    const { descriptor1, descriptor2 } = roundTrip(
+      z.object({
+        nested: z.object({ deep: z.object({ value: z.string().min(2).meta({ title: "V" }) }) }),
+        list: z.array(z.string().length(3)).min(1).max(5),
+        pair: z.tuple([z.string().startsWith("x"), z.number().gt(0)]),
+        choice: z.discriminatedUnion("kind", [
+          z.object({ kind: z.literal("a"), count: z.number().int().lt(9) }),
+          z.object({ kind: z.literal("b"), label: z.string().max(4).default("bb") }),
+        ]),
+      }),
+    );
+    expect(descriptor2.fields).toEqual(descriptor1.fields);
+  });
+
+  // Criterion 7: what the writer cannot reproduce must warn, never pass silently.
+  it("warns instead of silently narrowing a record key", () => {
+    const descriptor = introspect(z.object({ lookup: z.record(z.string(), z.number()) }), {
+      ...INTROSPECT_OPTS,
+    });
+    const { warnings } = writeSchema({ form: descriptor });
+    expect(warnings.some((w) => w.includes("record key"))).toBe(true);
+  });
+
+  it("warns instead of silently corrupting a non-JSON default", () => {
+    const descriptor = introspect(z.object({ when: z.date() }), INTROSPECT_OPTS);
+    descriptor.fields[0].defaultValue = new Date("2020-01-01");
+
+    const { code, warnings } = writeSchema({ form: descriptor });
+    expect(warnings.some((w) => w.includes("not a JSON literal"))).toBe(true);
+    // A Date would stringify to a quoted string and re-read as a string default
+    // on a date field. Omitting it and saying so beats a silent type change.
+    expect(code).not.toContain(".default(");
   });
 });


### PR DESCRIPTION
## Summary

Closes the four descriptor-fidelity cards left after the target plugin system was cut (#135, #136, #142, #144, #145 closed unbuilt). Every one is introspect / schema-writer / descriptor work with no dependency on the closed targets. Together they make the descriptor round trip losslessly -- schema to descriptor to source and back -- and give it a content-hash version that descriptor-reading consumers can pin against.

Sequencing note: #147 had to land before #148. #147 makes the reader capture `.meta()`, and #148 is chartered to close the reader-captures-more-than-the-writer-emits gap, so building #148 first would have shipped a knowingly-lossy round trip on the field #147 had just added. The commits are ordered accordingly.

## Acceptance criteria mapping

### 1. (#147) Confirm which Zod 4.4.3 def surface carries the meta payload

Established empirically against the installed Zod 4.4.3 rather than assumed, because the answer turned out to contradict the obvious guess. The payload is NOT in `_zod.def` -- for an annotated string the def keys are just `["type"]`. It lives in `globalRegistry`, keyed by the schema instance. `zod/v4/core` re-exports the identical registry object as `zod` does, so the reader imports from the same surface the rest of the introspection already uses rather than adding a second Zod entry point.

Evidence: `src/introspection/meta.ts:1` imports `globalRegistry` from `zod/v4/core`; the identity was verified by probe before the code was written.

### 2. (#147) Capture `.meta({title})` as the label and `.meta({description})`/`.describe()` as the description

`collectMeta` is called from `introspectField` on the ORIGINAL field schema, and both `label` and `description` derive from its result. The instance-keying from criterion 1 is the load-bearing detail and the reason the previous code was wrong: every wrapper is a distinct instance, so `z.string().meta(m).optional()` registers against the string while `z.string().optional().meta(m)` registers against the optional wrapper. The old code read `.description` off the unwrapped inner schema, which caught the first shape and silently missed the second. `collectMeta` walks the entire wrapper chain and merges, outermost winning per key.

Evidence: `src/introspection/meta.ts:39` defines `collectMeta`; `test/introspection/meta.test.ts` criterion 5 asserts all four wrapper positions (inner, outer, deep, across-pipe) and criterion 6 asserts merge precedence.

### 3. (#147) Explicit meta wins over the name-derived label; absent meta falls back

`metaString(meta, "title") ?? nameToLabel(name)` -- a single expression, so the two directions cannot drift apart. Beyond the card's letter, the payload is carried WHOLE rather than lifted key by key: Zod's meta is an open record, so capturing only `title` and `description` would silently drop `examples`, `deprecated` and custom keys, which is the exact failure class the lossless-reader work exists to eliminate.

Evidence: `test/introspection/meta.test.ts` criteria 1 and 2 assert both directions; criterion 7 asserts the full payload survives verbatim; criterion 9 asserts an un-annotated field has no `meta` key at all rather than an empty object.

### 4. (#148) Emit `.gt()`/`.gte()`/`.lt()`/`.lte()` from min/max plus the exclusive flags

`emitNumber` now selects the method from the exclusivity flag instead of always emitting `.min()`/`.max()`. This is the one criterion in the card that was not cosmetic: `.positive()` was re-emitting as `.nonnegative()`, which moves the validation boundary by one. The canonical fixture demonstrates it directly -- `score: z.number().positive()` and `floor: z.number().nonnegative()` previously emitted byte-identical source and now emit `.gt(0)` and `.min(0)` respectively.

Evidence: `test/schema-writer/round-trip.test.ts` "preserves exclusive vs inclusive numeric bounds" asserts the emitted source and the re-read descriptor, including that the two constraint objects are NOT equal.

### 5. (#148) Emit `.length(n)`, `.startsWith()` and `.endsWith()`

`.length(n)` is emitted from both `emitString` and `emitArray`, since `length_equals` is the same underlying check on either type and the array case would otherwise have stayed lossy. `.startsWith()`/`.endsWith()` are emitted from `emitString` with `JSON.stringify` on the operand so quoting is correct.

Evidence: `test/schema-writer/round-trip.test.ts` "preserves exact length, startsWith and endsWith" includes a `z.array(z.string()).length(3)` case alongside the string cases.

### 6. (#148) Emit `.default(value)`

Applied after `.nullable()`/`.optional()` in the chain so the emitted wrapper order matches what the reader unwraps, which is what makes the round trip converge rather than merely produce valid source. Non-JSON defaults are refused rather than corrupted: a `Date` would stringify to a quoted string and re-read as a string default on a date field, so `emitDefault` omits it and warns.

Evidence: `test/schema-writer/round-trip.test.ts` "preserves defaults of every JSON-shaped kind" covers string, number, boolean, enum, array, object and constrained cases; "warns instead of silently corrupting a non-JSON default" covers the refusal.

### 7. (#148) Decide record-key re-emission, or keep the warning

Decided: keep the warning, and additionally raise it on the WRITER side. The descriptor carries no key schema at all -- only the value descriptor -- so `z.record(z.enum([...]), v)` is genuinely not reconstructable from a descriptor without a descriptor shape change beyond this card's scope. Rather than leave that silent at write time, `emitRecord` now warns through `SchemaWriterResult.warnings`, a declared channel that previously always returned `[]` regardless of what was dropped.

Evidence: `test/schema-writer/round-trip.test.ts` "warns instead of silently narrowing a record key"; the channel is populated in `src/schema-writer/writer.ts:29`.

### 8. (#149) Refine attached directly to an intersection must not drop silently

`resolveRootSchema` replaces an intersection with a synthetic object carrying only the merged shape, so the intersection's own `checks` array was not present on the schema the warning scan inspected. The scan now runs against the original schema, where the checks actually live. A refine on an intersection MEMBER dropped identically -- only the member's shape survives `flattenIntersection` -- so that scan is added in the object branch too, which the card did not name but is the same defect.

Evidence: `test/introspection/silent-drops.test.ts` covers both the direct and member cases, plus a negative case asserting a plain intersection produces no spurious warning.

### 9. (#149) Optional before transform must keep its constraints and flags

`unwrapSchema` ran once before `peelPipe` and never re-entered, so in `z.string().min(3).optional().transform(fn)` the optional wrapper became the resolved inner schema: the field reported an unsupported "optional" type, `isOptional` false, and no constraints. `resolveInner` now alternates unwrapping and peeling until neither applies. The card named `.optional()`; `.nullable()` and `.default()` failed identically, with `default` additionally losing its captured value, so all three are covered.

Evidence: `src/introspection/introspect.ts:336` defines `resolveInner`; `test/introspection/silent-drops.test.ts` has a case per wrapper kind plus a stacked-wrapper case and a no-wrapper regression case.

### 10. (#143) Deterministic content hash over the descriptor's structural content

sha256 over a canonical serialization of the fields. Object keys are sorted so a property reordering inside the reader does not churn the version, while arrays keep their order -- field declaration order is semantic, and so is tuple element and union variant order. Identical schemas therefore hash identically and any contract change produces a new value with no human bump.

Evidence: `test/introspection/version.test.ts` asserts determinism, plus that field reordering, type changes, constraint changes, optionality, defaults, nesting, enum values and union variants each move the hash.

### 11. (#143) Exclude non-structural options so cosmetic changes do not churn the version

Excluded: `formName`, `schemaImportPath` and `schemaExportName` (cosmetic); `warnings` (derived diagnostics -- their text changed in this very PR when #149 improved the wording, which is emphatically not a schema change); `steps` (presentation grouping); and `label`, `description`, `meta`, `schemaRef` (presentation). The exclusion is a deny-list rather than an allow-list on purpose: a newly added constraint is then hashed by default, which is the fail-safe direction, since under-hashing silently fails to bump a version while over-hashing only churns one.

Evidence: `PRESENTATION_KEYS` in `src/introspection/version.ts`; `test/introspection/version.test.ts` "ignores formName, import path and export name" and "ignores meta, labels and descriptions".

### 12. (#143) Stamp the version into emitted artifacts as a discoverable top-level field

The composite target serializes the whole descriptor, so adding `version` to `FormDescriptor` places it at the artifact's top level where a regenerate can diff it without re-deriving the descriptor. Asserted by parsing the emitted artifact back rather than assumed from the serializer's shape.

Evidence: `test/introspection/version.test.ts` "is a top-level field of the composite artifact" parses `result.files[0].content` and compares to `descriptor.version`.

## Decision for the reviewer

Excluding `meta` from the version hash is the one genuinely debatable call, and it was confirmed with the operator rather than assumed. Consequence: a label-only edit does NOT produce a new version, so a consumer regenerating purely to pick up changed labels cannot detect that from the version alone. The reasoning is that the version serves the capture/Iceberg consumer, where a label change is not a schema evolution and must not invalidate captured records; and with the target plugin system closed, nothing kelex emits renders labels, while veneer reads constraints rather than presentation. If render-skew detection is ever needed, a separate presentation hash is additive and non-breaking.

## Not done

- **No target or plugin work.** #135, #136, #142, #144 and #145 were closed rather than built, per the operator decision that kelex ships descriptor-in / descriptor-out and does not render.
- **`src/mapping/` untouched.** It is now permanently orphaned -- `generate()` has never called `resolveField`, and with the plugin system closed it cannot acquire a consumer -- but the operator's call is to park it, so it stays in-tree and exported.
- **The `Map` to `{}` serialization bug documented in the #142 close is not fixed.** It only fires through `resolveField`, which nothing calls. Fixing latent code on an unreachable path buys nothing; it is recorded so it is not rediscovered as a live defect.
- **Refines on NESTED intersections still drop.** `z.intersection(z.intersection(a,b).refine(...), c)` warns nothing, because `flattenIntersection` scans checks in its object branch but not its intersection branch. Outside #149's named shapes; filed as a separate follow-up rather than scope-crept into this PR.
- **No presentation hash added**, per the decision above.

Closes #147
Closes #148
Closes #149
Closes #143
