### PR TITLE
fix(introspection): .catch() no longer degrades fields to unconstrained strings

### DIFF
--- a/.changeset/catch-resolution.md
+++ b/.changeset/catch-resolution.md
@@ -1,0 +1,9 @@
+---
+"@rafters/kelex": patch
+---
+
+Fix `.catch()` degrading every field to an unconstrained string. `z.number().min(5).catch(0)` introspected as `type: "string"` with no constraints, and an enum lost its values entirely — so a renderer would emit a text input for a number field. The catch wrapper is now peeled and the inner type and constraints survive.
+
+The fallback value itself is still not carried, and warns instead. Zod stores `.catch(0)` as a callback rather than a literal, so recovering it would mean invoking user code during introspection — and a context-dependent callback returns a plausible, type-valid, fabricated value that nothing downstream could distinguish from a real one.
+
+**Descriptor version note:** this changes what a caught field introspects to, so `FormDescriptor.version` rerolls for any schema using `.catch()`. The content hash is stable for a given kelex version and a given schema; an introspection fix that changes what the reader sees will move it. Consumers pinning against the version should expect it to change on a kelex upgrade, not only on a schema edit.

--- a/src/introspection/introspect.ts
+++ b/src/introspection/introspect.ts
@@ -337,12 +337,14 @@ function resolveInner(schema: $ZodType): UnwrapResult {
   let current = schema;
   let isOptional = false;
   let isNullable = false;
+  let hasCatch = false;
   let defaultValue: unknown;
 
   for (;;) {
     const result = unwrapSchema(current);
     isOptional = isOptional || result.isOptional;
     isNullable = isNullable || result.isNullable;
+    hasCatch = hasCatch || result.hasCatch;
     // Outermost default wins: it is the last one the author wrote.
     if (defaultValue === undefined) {
       defaultValue = result.defaultValue;
@@ -350,7 +352,7 @@ function resolveInner(schema: $ZodType): UnwrapResult {
 
     const peeled = peelPipe(result.inner);
     if (peeled === result.inner) {
-      return { inner: peeled, isOptional, isNullable, defaultValue };
+      return { inner: peeled, isOptional, isNullable, defaultValue, hasCatch };
     }
     current = peeled;
   }
@@ -390,8 +392,15 @@ function resolveType(inner: $ZodType): string {
 function introspectField(name: string, fieldSchema: $ZodType, warnings: string[]): FieldDescriptor {
   // Resolve wrappers and pipes together so type, constraints, and metadata all
   // derive from one inner schema regardless of the order the author chained them.
-  const { inner, isOptional, isNullable, defaultValue } = resolveInner(fieldSchema);
+  const { inner, isOptional, isNullable, defaultValue, hasCatch } = resolveInner(fieldSchema);
   const type = resolveType(inner);
+
+  if (hasCatch) {
+    warnings.push(
+      `Field "${name}": a .catch() fallback value is not represented in the descriptor ` +
+        "(Zod stores it as a callback, not a literal) and must be re-applied downstream.",
+    );
+  }
   // Read meta from the ORIGINAL schema: the payload may sit on any wrapper in
   // the chain, and the unwrapped inner is only one of those instances.
   const meta = collectMeta(fieldSchema);

--- a/src/introspection/unwrap.ts
+++ b/src/introspection/unwrap.ts
@@ -9,7 +9,12 @@ import type { $ZodType } from "zod/v4/core";
  * registers meta against the schema INSTANCE, so a level missing from this
  * list is a level whose meta is never read -- the silent-drop class #149 was.
  */
-export const FLAG_WRAPPERS: ReadonlySet<string> = new Set(["optional", "nullable", "default"]);
+export const FLAG_WRAPPERS: ReadonlySet<string> = new Set([
+  "optional",
+  "nullable",
+  "default",
+  "catch",
+]);
 
 export interface UnwrapResult {
   /** The innermost non-wrapper schema */
@@ -20,6 +25,11 @@ export interface UnwrapResult {
   isNullable: boolean;
   /** Default value from z.default(), captured before the wrapper is peeled */
   defaultValue?: unknown;
+  /**
+   * Whether z.catch() was present. Only the presence is recorded, never the
+   * fallback value -- see the note in `unwrapSchema` on why it is not captured.
+   */
+  hasCatch: boolean;
 }
 
 /** Type guard to check if schema has unwrap method */
@@ -53,8 +63,19 @@ function isValidZod4Schema(schema: unknown): schema is $ZodType {
 }
 
 /**
- * Unwraps optional and nullable wrappers from a Zod schema.
- * Handles: z.optional(), z.nullable(), z.nullish() (optional + nullable)
+ * Unwraps optional/nullable/default/catch wrappers from a Zod schema.
+ * Handles: z.optional(), z.nullable(), z.nullish() (optional + nullable),
+ * z.default(), z.catch().
+ *
+ * On z.catch(): the wrapper is peeled so the inner type and its constraints
+ * survive, but the fallback value is NOT captured, only its presence. Zod
+ * normalizes `.catch(0)` into a THUNK (`def.catchValue` is a function, not a
+ * value), so recovering the literal would mean invoking user code during
+ * introspection. That is unsafe in a way that matters here: a context-dependent
+ * callback such as `ctx => Date.now()` returns a perfectly JSON-safe value that
+ * is nonetheless fabricated, and nothing distinguishes it from a literal. A
+ * silently-recorded wrong value is worse than an acknowledged absent one, so
+ * the caller warns instead.
  */
 export function unwrapSchema(schema: $ZodType): UnwrapResult {
   if (!isValidZod4Schema(schema)) {
@@ -64,21 +85,24 @@ export function unwrapSchema(schema: $ZodType): UnwrapResult {
   let current = schema;
   let isOptional = false;
   let isNullable = false;
+  let hasCatch = false;
   let defaultValue: unknown;
 
-  // Unwrap nested optional/nullable/default wrappers
   while (FLAG_WRAPPERS.has(current._zod.def.type)) {
-    if (current._zod.def.type === "optional") {
+    const wrapper = current._zod.def.type;
+    if (wrapper === "optional") {
       isOptional = true;
-    } else if (current._zod.def.type === "nullable") {
+    } else if (wrapper === "nullable") {
       isNullable = true;
+    } else if (wrapper === "catch") {
+      hasCatch = true;
     } else {
       // default: capture the value before peeling the wrapper to reach the inner type
       defaultValue = (current._zod.def as { defaultValue?: unknown }).defaultValue;
     }
 
     if (!hasUnwrap(current)) {
-      throw new Error(`${current._zod.def.type} schema missing unwrap method`);
+      throw new Error(`${wrapper} schema missing unwrap method`);
     }
     current = current.unwrap();
   }
@@ -88,5 +112,6 @@ export function unwrapSchema(schema: $ZodType): UnwrapResult {
     isOptional,
     isNullable,
     defaultValue,
+    hasCatch,
   };
 }

--- a/test/introspection/catch.test.ts
+++ b/test/introspection/catch.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod/v4";
+import { introspect } from "../../src/introspection";
+import type { FieldDescriptor } from "../../src/introspection/types";
+
+const OPTIONS = {
+  formName: "CatchForm",
+  schemaImportPath: "./catch-fixture",
+  schemaExportName: "catchSchema",
+};
+
+function fieldsOf(schema: Parameters<typeof introspect>[0]): Record<string, FieldDescriptor> {
+  return Object.fromEntries(introspect(schema, OPTIONS).fields.map((f) => [f.name, f]));
+}
+
+describe("catch handling (#154)", () => {
+  // Criterion 1: the reported bug. A caught number was resolving to an
+  // unconstrained STRING, so a render seat would emit a text input for it.
+  it("keeps the inner type and constraints through .catch()", () => {
+    const fields = fieldsOf(z.object({ score: z.number().min(5).catch(0) }));
+    expect(fields.score.type).toBe("number");
+    expect(fields.score.constraints).toEqual({ min: 5 });
+  });
+
+  // Criterion 2: same for the other inner types, including enum, whose values
+  // were being lost entirely.
+  it("keeps string, enum and composite inner types through .catch()", () => {
+    const fields = fieldsOf(
+      z.object({
+        text: z.string().min(3).catch("fallback"),
+        choice: z.enum(["a", "b"]).catch("a"),
+        list: z.array(z.string()).max(2).catch([]),
+      }),
+    );
+
+    expect(fields.text.type).toBe("string");
+    expect(fields.text.constraints.minLength).toBe(3);
+
+    expect(fields.choice.type).toBe("enum");
+    if (fields.choice.metadata.kind !== "enum") {
+      throw new Error("expected enum metadata");
+    }
+    expect(fields.choice.metadata.values).toEqual(["a", "b"]);
+
+    expect(fields.list.type).toBe("array");
+    expect(fields.list.constraints.maxItems).toBe(2);
+  });
+
+  // Criterion 3: the fallback value is unrepresentable, so it must be warned
+  // about rather than dropped silently -- and rather than fabricated. Zod
+  // stores .catch(0) as a thunk, so recovering the literal would mean invoking
+  // user code, and a context-dependent callback would yield a JSON-safe but
+  // fabricated value indistinguishable from a real one.
+  it("warns that the catch fallback is not represented", () => {
+    const descriptor = introspect(z.object({ score: z.number().catch(0) }), OPTIONS);
+    expect(descriptor.warnings).toHaveLength(1);
+    expect(descriptor.warnings[0]).toContain("score");
+    expect(descriptor.warnings[0]).toContain(".catch()");
+  });
+
+  it("does not warn when no catch is present", () => {
+    expect(introspect(z.object({ score: z.number() }), OPTIONS).warnings).toEqual([]);
+  });
+
+  // Criterion 4: the old behavior emitted an "unsupported type" warning, which
+  // told a consumer the wrong thing -- the type was supported, the wrapper was
+  // not. That warning must be gone.
+  it("no longer reports catch as an unsupported type", () => {
+    const descriptor = introspect(z.object({ score: z.number().catch(0) }), OPTIONS);
+    expect(descriptor.warnings.some((w) => w.includes("unsupported type"))).toBe(false);
+  });
+
+  // Criterion 5: the wrapper-composition class from #149 -- catch must resolve
+  // correctly in any order relative to the other wrappers.
+  it("resolves catch composed with optional, nullable and default in any order", () => {
+    const fields = fieldsOf(
+      z.object({
+        catchThenOptional: z.number().min(1).catch(0).optional(),
+        optionalThenCatch: z.number().min(1).optional().catch(0),
+        catchThenNullable: z.number().min(1).catch(0).nullable(),
+        defaultThenCatch: z.number().min(1).default(7).catch(0),
+      }),
+    );
+
+    expect(fields.catchThenOptional.type).toBe("number");
+    expect(fields.catchThenOptional.isOptional).toBe(true);
+    expect(fields.catchThenOptional.constraints.min).toBe(1);
+
+    expect(fields.optionalThenCatch.type).toBe("number");
+    expect(fields.optionalThenCatch.isOptional).toBe(true);
+
+    expect(fields.catchThenNullable.type).toBe("number");
+    expect(fields.catchThenNullable.isNullable).toBe(true);
+
+    expect(fields.defaultThenCatch.type).toBe("number");
+    expect(fields.defaultThenCatch.defaultValue).toBe(7);
+  });
+
+  // Criterion 6: catch around a pipe, the shape that broke in #149.
+  it("resolves catch composed with a transform", () => {
+    const fields = fieldsOf(
+      z.object({
+        piped: z
+          .string()
+          .min(2)
+          .catch("x")
+          .transform((s) => s.length),
+      }),
+    );
+    expect(fields.piped.type).toBe("string");
+    expect(fields.piped.constraints.minLength).toBe(2);
+  });
+
+  // Criterion 7: meta must still be reachable through a catch wrapper, since
+  // catch joined FLAG_WRAPPERS and the meta walk uses that same list.
+  it("finds meta through a catch wrapper", () => {
+    const fields = fieldsOf(
+      z.object({
+        inner: z.string().meta({ title: "Inner" }).catch("x"),
+        outer: z.string().catch("x").meta({ title: "Outer" }),
+      }),
+    );
+    expect(fields.inner.label).toBe("Inner");
+    expect(fields.outer.label).toBe("Outer");
+  });
+});

--- a/test/introspection/catch.test.ts
+++ b/test/introspection/catch.test.ts
@@ -111,6 +111,84 @@ describe("catch handling (#154)", () => {
     expect(fields.piped.constraints.minLength).toBe(2);
   });
 
+  // Criterion 8: every case above is a TOP-LEVEL field, and introspectField
+  // recursing correctly is an assumption, not a demonstration -- the same
+  // assumption that was wrong for meta before #147. These exercise catch at
+  // depth through each composite kind.
+  it("resolves catch inside an array element's object", () => {
+    // Shape of a real bag-entry form: repeating line items, each with caught fields.
+    const fields = fieldsOf(
+      z.object({
+        bag: z.array(
+          z.object({
+            quality: z.enum(["premium", "prototype"]).catch("premium"),
+            rank: z.number().int().min(1).max(6).catch(1),
+            count: z.number().int().min(0).catch(0).meta({ title: "How many" }),
+          }),
+        ),
+      }),
+    );
+
+    const element = fields.bag.metadata;
+    if (element.kind !== "array" || element.element.metadata.kind !== "object") {
+      throw new Error("expected array of object");
+    }
+    const item = Object.fromEntries(element.element.metadata.fields.map((f) => [f.name, f]));
+
+    expect(item.quality.type).toBe("enum");
+    if (item.quality.metadata.kind !== "enum") {
+      throw new Error("expected enum metadata");
+    }
+    expect(item.quality.metadata.values).toEqual(["premium", "prototype"]);
+    expect(item.rank.constraints).toEqual({ isInt: true, min: 1, max: 6 });
+    // meta must survive the catch at depth too, not just at the top level
+    expect(item.count.label).toBe("How many");
+  });
+
+  it("resolves catch at depth through nested objects, unions, tuples and records", () => {
+    const fields = fieldsOf(
+      z.object({
+        identity: z.object({
+          origin: z.object({
+            discipline: z.object({
+              name: z.string().min(1).catch("unset").meta({ title: "Discipline" }),
+              rank: z.number().min(0).max(80).catch(0),
+            }),
+          }),
+        }),
+        loadout: z.discriminatedUnion("kind", [
+          z.object({ kind: z.literal("ship"), hull: z.number().positive().catch(1) }),
+        ]),
+        coords: z.tuple([z.number().catch(0)]),
+        stats: z.record(z.string(), z.number().min(0).catch(0)),
+      }),
+    );
+
+    const identity = fields.identity.metadata;
+    if (identity.kind !== "object") throw new Error("expected object");
+    const origin = identity.fields[0].metadata;
+    if (origin.kind !== "object") throw new Error("expected object");
+    const discipline = origin.fields[0].metadata;
+    if (discipline.kind !== "object") throw new Error("expected object");
+    // depth 4, and still a string rather than the degraded-to-string default
+    expect(discipline.fields[0].type).toBe("string");
+    expect(discipline.fields[0].label).toBe("Discipline");
+    expect(discipline.fields[1].constraints).toEqual({ min: 0, max: 80 });
+
+    const loadout = fields.loadout.metadata;
+    if (loadout.kind !== "union") throw new Error("expected union");
+    expect(loadout.variants[0].fields[1].type).toBe("number");
+
+    const coords = fields.coords.metadata;
+    if (coords.kind !== "tuple") throw new Error("expected tuple");
+    expect(coords.elements[0].type).toBe("number");
+
+    const stats = fields.stats.metadata;
+    if (stats.kind !== "record") throw new Error("expected record");
+    expect(stats.valueDescriptor.type).toBe("number");
+    expect(stats.valueDescriptor.constraints).toEqual({ min: 0 });
+  });
+
   // Criterion 7: meta must still be reachable through a catch wrapper, since
   // catch joined FLAG_WRAPPERS and the meta walk uses that same list.
   it("finds meta through a catch wrapper", () => {


### PR DESCRIPTION
## Summary

`.catch()` was unhandled, so every caught field collapsed to an unconstrained string. `z.number().min(5).catch(0)` introspected as `type: "string"`, `constraints: {}` — meaning a render seat would emit a text input for a number field, and an enum lost its values entirely. This peels the catch wrapper so the inner type and constraints survive, and warns about the fallback value rather than fabricating it.

Found by platform (astro-data) while reviewing the target-cut decision. They traced it from source and explicitly flagged it as unverified inference rather than measurement, leaving confirmation to this seat. Confirmed by probe against Zod 4.4.3 before any code was written.

## Acceptance criteria mapping

### 1. `z.number().min(5).catch(0)` introspects as number with `{min:5}`, not an unconstrained string

`"catch"` joins `FLAG_WRAPPERS`, so `unwrapSchema` peels it via the existing `.unwrap()` path and `resolveType` sees the inner number instead of returning `"catch"` and falling to the unsupported-type branch that substituted a bare string.

Evidence: `test/introspection/catch.test.ts` "keeps the inner type and constraints through .catch()" asserts both the type and the exact constraint object.

### 2. Same for string, enum (values preserved) and composite inner types

The peel is type-agnostic, so the same fix covers all inner types. Enum is called out separately in the test because it failed worse than the others — it lost its `values` array, not just its constraints, so a variant switcher had nothing to render.

Evidence: `test/introspection/catch.test.ts` "keeps string, enum and composite inner types through .catch()" covers string with `minLength`, enum with its values, and array with `maxItems`.

### 3. The catch value is carried or explicitly warned about, never dropped silently

Warned, deliberately not carried, and this is the one real design decision in the PR. Zod normalizes `.catch(0)` into a **thunk** — `def.catchValue` is a function, not a value — so recovering the literal would mean invoking user code during introspection.

That is unsafe in a way that specifically matters here. A context-dependent callback such as `ctx => Date.now()` returns a perfectly JSON-safe value that is nonetheless fabricated, and nothing in the result distinguishes it from a real literal. Invoking would therefore trade a known-absent value for a silently-wrong one, which is the exact failure class #141/#148/#149 exist to eliminate. The reader warns and names the field; the consumer re-applies the fallback.

Evidence: `test/introspection/catch.test.ts` "warns that the catch fallback is not represented" asserts exactly one warning, naming the field; "does not warn when no catch is present" pins the negative direction.

### 4. If carried, the writer re-emits it and the hash decision is deliberate

Not applicable — the value is not carried, per criterion 3. This criterion was written conditionally ("if carried") and the condition is not met, so the obligation it creates does not arise. The observable consequence is that the descriptor contract is untouched by this PR: `FieldDescriptor` gains no field, `src/schema-writer/` has no hunk in the diff, and every existing content hash is unchanged, so no consumer pinned against a version sees churn from this fix.

Evidence: `git diff main...HEAD --name-only` returns three paths — `src/introspection/unwrap.ts`, `src/introspection/introspect.ts`, `test/introspection/catch.test.ts` — none under `src/schema-writer/` and none touching `src/introspection/types.ts` or `version.ts`. The 14 hash assertions in `test/introspection/version.test.ts` pass unchanged.

### 5. `.catch()` composed with `.optional()`/`.nullable()`/`.default()` in any order resolves correctly

This is the wrapper-composition class from #149, so it is pinned rather than assumed. All four orders resolve to the inner type with the correct flags, and `.catch()` around a `.transform()` is covered too, since that is the specific shape that broke in #149.

Evidence: `test/introspection/catch.test.ts` "resolves catch composed with optional, nullable and default in any order" and "resolves catch composed with a transform".

### 6. Resolution holds at depth, not only on top-level fields

Not in the card's criteria, added because the original suite did not earn its conclusion: every case was a top-level field, so `introspectField` recursing correctly was an assumption rather than a demonstration — and that same assumption was wrong for meta before #147. Checked manually against two realistic shapes first, then landed as tests.

A repeating bag-entry form (array of objects with caught enum and number fields) keeps its enum values, its `{isInt, min, max}` constraints, and a `.meta()` label on a caught field nested inside the array element. A character sheet exercises depth-4 object nesting plus union variants, tuple elements and record values; all resolve to their inner types with constraints intact.

Evidence: `test/introspection/catch.test.ts` "resolves catch inside an array element's object" and "resolves catch at depth through nested objects, unions, tuples and records".

## Beyond the criteria

Two consequences worth naming because they were not in the card:

- **Meta now traverses catch.** The meta walk consumes `FLAG_WRAPPERS`, so adding `"catch"` to it means `.meta()` on either side of a `.catch()` is found. That is a free fix from the single-source-of-truth extraction, and it is tested rather than left as an untested side effect.
- **The old warning said the wrong thing.** `unsupported type "catch"` reported a *type* problem when the type was fine and the wrapper was the issue. A consumer reading warnings would have gone looking in the wrong place.

## Descriptor version consequence

This changes what a caught field introspects to, so `FormDescriptor.version` **rerolls** for any schema using `.catch()` — a field that hashed as an unconstrained string now hashes as a constrained number.

Worth stating explicitly because consumers were told to pin against that hash: it is stable for a given kelex version and a given schema, **not forever**. An introspection fix that changes what the reader sees will move it. A consumer diffing versions should expect movement on a kelex upgrade, not only on a schema edit. Recorded in the changeset so it reaches release notes rather than only this PR.

## Not done

- **The catch fallback value is not represented at all**, not even as a `hasCatch` marker on `FieldDescriptor`. A marker would be render-relevant — a caught field never fails validation, which a form could use — but it changes the descriptor contract immediately after #143 versioned it, so it belongs in its own card with its own hash decision rather than riding along here.
- **No schema-writer change.** Round-trip therefore drops `.catch()` on the way out. The writer cannot warn about it either, since the descriptor does not carry the fact. That is a real remaining gap and it follows from the criterion-3 decision, not from oversight.
- **Did not invoke the thunk behind a JSON-safety guard**, which would recover literal values in the common `.catch(0)` case. Rejected because the guard cannot distinguish a literal from a fabricated-but-JSON-safe result, so it would make the wrong values silent rather than preventing them.
