### PR TITLE
fix(release): point the stale changeset at the renamed package

### DIFF
--- a/.changeset/cut-react-codegen.md
+++ b/.changeset/cut-react-codegen.md
@@ -1,5 +1,5 @@
 ---
-"@rafters-studio/kelex": minor
+"@rafters/kelex": minor
 ---
 
 Remove the react-tanstack target and all React/JSX code generation. The composite JSON FormDescriptor target is now the only built-in target and the CLI default. The audited React codegen did not compile against current @tanstack/react-form and is being replaced by a new target design; the pre-cut state is tagged `pre-codegen-cut`. Also removes the unused zocker test infrastructure, fixes the broken `test:spec` script, and makes `kelex --version` report the real package version.


### PR DESCRIPTION
## Summary

`.changeset/cut-react-codegen.md` named `@rafters-studio/kelex`, a package that stopped existing when b8838aa (#140) renamed it to `@rafters/kelex`. That commit updated `package.json` and the newer changeset but missed this pre-existing one.

Changesets refuses to operate at all when any changeset names a package outside the workspace, so this was not cosmetic — the release commands were dead. One token changes.

Found while adding a changeset for #155, when `changeset status` refused to validate it.

## Acceptance criteria mapping

### 1. `.changeset/cut-react-codegen.md` names `@rafters/kelex`

The frontmatter package key is corrected. Nothing else in the file changes — see criterion 4 for why that restraint is deliberate rather than lazy.

Evidence: `git diff main...HEAD` is a single line, `.changeset/cut-react-codegen.md:2`.

### 2. `pnpm changeset status` exits zero and reports the pending releases

It previously aborted inside `mapGetOrThrow` in `@changesets/assemble-release-plan` before evaluating anything. It now completes and reports `@rafters/kelex` at minor.

Evidence: run on the branch, `changeset status` prints "Packages to be bumped at minor: @rafters/kelex" and exits zero; on `main` the same command exits non-zero with `Found changeset cut-react-codegen for package @rafters-studio/kelex which is not in the workspace`.

### 3. No other changeset names a package outside the workspace

Checked the whole directory rather than assuming this was the only instance — a rename that missed one file could plausibly have missed several. `.changeset/` holds two content changesets: this one and `rename-and-toolchain.md`, which already named `@rafters/kelex` correctly. `changeset status` exiting zero is the positive confirmation, since it validates every changeset in the directory and would fail on any remaining bad key.

Evidence: `changeset status` now succeeds, which it cannot do while any changeset carries an unknown package.

### 4. Bump level and prose unchanged

Deliberately untouched. A stale package key could mean the changeset was orphaned by the rename and needed rewriting — worth checking before assuming a one-token fix was right. It was not orphaned: the body describes the react-tanstack cut, which shipped and is still unreleased, and `minor` remains the correct level for it. Rewriting the description here would be editing the record of a past release rather than fixing a key.

Evidence: the diff touches only line 2; the `minor` level and the body text are byte-identical.

## Why this was invisible

Worth stating for whoever reads this later: because `changeset status` aborts before validating anything, **no changeset added since the rename has ever been checked**. A malformed new changeset would have been just as silent. The #155 changeset is the first to be validated in this repo since #140, and only because this was fixed first.

## Not done

- **No release is cut.** This restores the ability to cut one; whether to do so is a separate decision.
- **No CI guard added** to catch a future stale changeset before merge. `changeset status` in CI would have caught this at #140 rather than several PRs later, but that is a workflow change with its own scope, not part of unbreaking the current state.

Closes #159
