### PR TITLE
refactor(mapping)!: remove the mapping module from the public API

### DIFF
--- a/.changeset/unexport-mapping.md
+++ b/.changeset/unexport-mapping.md
@@ -1,0 +1,11 @@
+---
+"@rafters/kelex": major
+---
+
+Remove the mapping module from the public API. `resolveField`, `findMatchingRule`, `defaultMappingRules` and the `ComponentConfig`, `ComponentType` and `MappingRule` types are no longer exported from the package root.
+
+kelex does not own component selection. Which component renders a field belongs to the consumer, along with the rest of the presentation layer — kelex carries presentation data losslessly and makes no presentation decisions. Exporting a component-selection table contradicted that boundary in the one place a consumer would actually discover it.
+
+The module remains in the tree, unmodified. It is unreachable from the pipeline — `generate()` calls `introspect()` and the target directly, and has never called `resolveField` — so nothing in kelex's behavior changes.
+
+Consumers that were importing these should own the field-type-to-component table on their side, reading `FieldDescriptor.type`, `constraints` and `metadata` from the descriptor to make the choice.

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,9 +15,11 @@ export type {
 
 export { extractConstraints, introspect, unwrapSchema } from "./introspection";
 
-export type { ComponentConfig, ComponentType, MappingRule } from "./mapping";
-
-export { defaultMappingRules, findMatchingRule, resolveField } from "./mapping";
+// The mapping module (resolveField, findMatchingRule, defaultMappingRules,
+// ComponentConfig, ComponentType, MappingRule) is deliberately NOT exported.
+// kelex does not own component selection -- which component renders a field is
+// the consumer's decision, along with the rest of the presentation layer. The
+// module remains in-tree but is not public API; see #155.
 
 export type { SchemaWriterOptions, SchemaWriterResult } from "./schema-writer";
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -13,11 +13,16 @@ describe("public API exports", () => {
     expect(typeof mod.unwrapSchema).toBe("function");
   });
 
-  it("exports all mapping functions and data", async () => {
-    const mod = await import("../src/index");
-    expect(Array.isArray(mod.defaultMappingRules)).toBe(true);
-    expect(typeof mod.findMatchingRule).toBe("function");
-    expect(typeof mod.resolveField).toBe("function");
+  // Inverted in #155. kelex does not own component selection -- which component
+  // renders a field belongs to the consumer, along with the rest of the
+  // presentation layer. Exporting the mapping module contradicted that boundary
+  // in the one place a consumer would actually discover it, and two render seats
+  // caught the mismatch. The module stays in-tree; it is not public API.
+  it("does not export the mapping module", async () => {
+    const mod = (await import("../src/index")) as Record<string, unknown>;
+    expect(mod.defaultMappingRules).toBeUndefined();
+    expect(mod.findMatchingRule).toBeUndefined();
+    expect(mod.resolveField).toBeUndefined();
   });
 
   it("exports all schema writer functions", async () => {


### PR DESCRIPTION
## Summary

kelex announced that component selection is delegated to consumers along with the rest of the presentation layer — while `src/index.ts` still exported `resolveField`, `findMatchingRule`, `defaultMappingRules` and the `ComponentConfig`, `ComponentType` and `MappingRule` types. That *is* component selection, shipped as public API. The announced boundary and the discoverable surface disagreed.

Two render seats caught it independently while reviewing the target cut. One had read `resolveField` as the dispatch for a field inspector and asked for a ruling before pinning against something that might leave. Their point stands on its own: either answer is workable, the ambiguity is not.

The module stays in the tree, unmodified, per the operator's park ruling. This changes only what is reachable from the package root.

## Acceptance criteria mapping

### 1. The mapping symbols are no longer exported from `src/index.ts`

All six are removed — the issue named five, but the barrel also re-exported the `MappingRule` type, and leaving it would have kept a mapping type public and half-drawn the boundary. A comment stands in their place explaining why they are absent, since "I cannot find `resolveField`" is the question a reader arrives with.

Evidence: `src/index.ts:18-20` previously held the three export statements; the diff replaces them with the rationale comment.

### 2. `src/mapping/` remains in the tree, unmodified

No file under `src/mapping/` appears in the diff. The park ruling was to keep the code and drop the surface, not to delete.

Evidence: `git diff main...HEAD --name-only` returns exactly `.changeset/unexport-mapping.md`, `src/index.ts`, `test/index.test.ts`.

### 3. A major changeset accompanies the change

`major`, because removing six public exports is breaking whether or not anything consumed them. The prose names the removed symbols, states that nothing in kelex's behavior changes, and tells a consumer what to do instead — own the field-type-to-component table on their side, reading `type`, `constraints` and `metadata` off the descriptor.

Evidence: `.changeset/unexport-mapping.md`, keyed to `@rafters/kelex`.

### 4. Existing `src/mapping/` unit tests still pass against the module directly

They import from the module path rather than the barrel, so unexporting does not reach them. The full suite is green at 348 unit tests.

Evidence: `pnpm preflight` passes; `test/mapping/` is untouched by the diff.

### 5. No remaining public export implies kelex performs component selection

Verified rather than eyeballed: the only references to the mapping module anywhere in `src/` are inside `src/mapping/` itself, so nothing re-exports it by another path and no internal code path breaks.

Evidence: `legion sym def mapping` returns hits only under `src/mapping/`; the public-API test now asserts the absence directly.

## The test is inverted, not deleted

`exports all mapping functions and data` became `does not export the mapping module`. Deleting it would have been the smaller diff and the wrong call — it would leave the boundary unpinned, so a future barrel edit could silently re-export the module with no test objecting. That is exactly the mistake this card corrects, and it was already made once. An inverted assertion keeps it caught.

## Not done

- **`src/mapping/` is not deleted.** Operator ruling is park, not remove. It stays reachable by direct import for anyone who needs it, and its latent `Map`-to-`{}` serialization bug (documented in the #142 close) stays latent, since nothing calls the code path.
- **No replacement guidance shipped.** Consumers owning their own component table get a sentence in the changeset, not a documented recipe. If more than one consumer needs the same table, that is a docs card, not this one.
- **`computeVersion`/`withVersion` remain unexported from the root** — noticed while working here, unrelated to this card. `FormDescriptor.version` is public contract, so a consumer editing fields arguably needs the recompute path. Left alone rather than folded in.

Closes #155
