### PR TITLE
fix(introspection): warn on refines at every intersection level

### DIFF
--- a/.changeset/nested-intersection-refine.md
+++ b/.changeset/nested-intersection-refine.md
@@ -1,0 +1,7 @@
+---
+"@rafters/kelex": patch
+---
+
+Warn on `.refine()` at every intersection level. A refinement attached to an intersection nested inside another intersection was dropped silently — `flattenIntersection` scanned its object branch but not its intersection branch, so it recursed past intermediate nodes and discarded their checks.
+
+Root-refinement warnings now come from a single owner (`resolveRootSchema`) rather than two call sites, so a root-level refinement is reported exactly once. Warning count is unchanged for every shape that already warned; only coverage widened.

--- a/src/introspection/introspect.ts
+++ b/src/introspection/introspect.ts
@@ -126,9 +126,11 @@ function resolveRootSchema(schema: $ZodType): {
   warnings: string[];
 } {
   const def = schema._zod.def as { type: string };
+  const warnings: string[] = [];
 
   if (def.type === "intersection") {
-    const warnings: string[] = [];
+    // flattenIntersection scans every level for refinements, root included, so
+    // the root must NOT be scanned again by the caller.
     const shape = flattenIntersection(schema, warnings);
     // Build a synthetic object-like schema view
     return {
@@ -137,7 +139,11 @@ function resolveRootSchema(schema: $ZodType): {
     };
   }
 
-  return { resolved: schema, warnings: [] };
+  // Non-intersection root: its own checks are still on it, so scan here. This
+  // function owns root-refinement warnings for both shapes, which is what keeps
+  // the intersection case from being warned about twice.
+  warnObjectRefinements(schema, warnings);
+  return { resolved: schema, warnings };
 }
 
 /**
@@ -148,6 +154,10 @@ function flattenIntersection(schema: $ZodType, warnings: string[]): Record<strin
   const def = schema._zod.def as { type: string };
 
   if (def.type === "intersection") {
+    // An intersection's own .refine() lives on the intersection node, and the
+    // node is discarded once its members are merged into a shape. Scanning only
+    // the object leaves misses every refine attached at an intersection level.
+    warnObjectRefinements(schema, warnings);
     const intDef = def as unknown as ZodIntersectionDef;
     const leftShape = flattenIntersection(intDef.left, warnings);
     const rightShape = flattenIntersection(intDef.right, warnings);
@@ -472,11 +482,6 @@ export function introspect(schema: $ZodType, options: IntrospectOptions): FormDe
   if (def.type !== "object") {
     throw new Error(`kelex only supports z.object() schemas at the top level, got "${def.type}"`);
   }
-
-  // Scan the ORIGINAL schema, not the resolved one: for an intersection the
-  // resolved schema is a synthetic object carrying only the merged shape, so
-  // the intersection's own .refine() checks are not on it to be found.
-  warnObjectRefinements(schema, warnings);
 
   const fields = introspectShape(def.shape, warnings);
 

--- a/test/introspection/silent-drops.test.ts
+++ b/test/introspection/silent-drops.test.ts
@@ -56,6 +56,74 @@ describe("remaining silent drops (#149)", () => {
       const descriptor = introspect(z.intersection(left, right), OPTIONS);
       expect(descriptor.warnings).toEqual([]);
     });
+
+    // #153: an intersection nested inside another intersection. The inner node
+    // is discarded once its members merge, so scanning only the root and the
+    // object leaves missed every refine attached at an intermediate level.
+    it("warns about a refine on a nested intersection", () => {
+      const extra = z.object({ z: z.boolean() });
+      const descriptor = introspect(
+        z.intersection(
+          z.intersection(left, right).refine((v) => v.x !== "", { message: "inner rule" }),
+          extra,
+        ),
+        OPTIONS,
+      );
+      expect(descriptor.warnings.some((w) => w.includes(".refine()"))).toBe(true);
+      expect(descriptor.fields.map((f) => f.name)).toEqual(["x", "y", "z"]);
+    });
+
+    it("warns at every level of a deeply nested intersection", () => {
+      const extra = z.object({ z: z.boolean() });
+      const deeper = z.object({ w: z.string() });
+      const descriptor = introspect(
+        z
+          .intersection(
+            z
+              .intersection(
+                z.intersection(left, right).refine(() => true, { message: "depth 3" }),
+                extra,
+              )
+              .refine(() => true, { message: "depth 2" }),
+            deeper,
+          )
+          .refine(() => true, { message: "depth 1" }),
+        OPTIONS,
+      );
+      const refineWarnings = descriptor.warnings.filter((w) => w.includes(".refine()"));
+      expect(refineWarnings).toHaveLength(3);
+    });
+
+    // Criterion 3: the root and object-member cases #149 already covered must
+    // still warn exactly once, not twice now that intersection nodes are scanned.
+    it("does not double-warn a refine on the root intersection", () => {
+      const descriptor = introspect(
+        z.intersection(left, right).refine(() => true, { message: "root rule" }),
+        OPTIONS,
+      );
+      expect(descriptor.warnings.filter((w) => w.includes(".refine()"))).toHaveLength(1);
+    });
+
+    it("does not double-warn a refine on an object member", () => {
+      const descriptor = introspect(
+        z.intersection(
+          left.refine(() => true, { message: "member rule" }),
+          right,
+        ),
+        OPTIONS,
+      );
+      expect(descriptor.warnings.filter((w) => w.includes(".refine()"))).toHaveLength(1);
+    });
+
+    // A non-intersection root still warns, since resolveRootSchema now owns
+    // that scan for both shapes.
+    it("still warns on a refine on a plain object root", () => {
+      const descriptor = introspect(
+        z.object({ a: z.string(), b: z.string() }).refine(() => true, { message: "obj rule" }),
+        OPTIONS,
+      );
+      expect(descriptor.warnings.filter((w) => w.includes(".refine()"))).toHaveLength(1);
+    });
   });
 
   describe("wrapper immediately before transform", () => {


### PR DESCRIPTION
## Summary

#149 closed refines on the root intersection and on object members. A refine on an intersection **nested inside another intersection** still dropped with `warnings === []` — `flattenIntersection` scanned its object branch but not its intersection branch, so it recursed past an intermediate node and discarded that node's checks with it.

Found while building #149, filed rather than scope-crept into it.

## Acceptance criteria mapping

### 1. `z.intersection(z.intersection(a, b).refine(fn), c)` produces a refine warning

`flattenIntersection`'s intersection branch now scans the node before recursing into its members. An intersection's own `.refine()` lives on the intersection node, and that node is discarded once its members merge into a shape — so scanning only the object leaves could never see it.

Evidence: `test/introspection/silent-drops.test.ts` "warns about a refine on a nested intersection", which also asserts the merge still yields `["x", "y", "z"]` so a fix that warned correctly but broke flattening would fail.

### 2. Nesting depth does not matter — a refine at any level warns

The scan sits in the recursive branch, so it runs once per intersection node at any depth. Pinned with a count rather than a presence check, so an implementation that warned once for the whole tree, or once per member, fails.

Evidence: `test/introspection/silent-drops.test.ts` "warns at every level of a deeply nested intersection" — three refines at three depths, asserting exactly 3 warnings.

### 3. No duplicate warning for the shapes #149 already covers

This is the criterion that shaped the fix. The naive change — adding a scan to the intersection branch and leaving everything else — would double-warn a root-level refine, because `introspect()` was scanning the root separately. The root would be seen once by `introspect` and once by `flattenIntersection`.

Rather than guarding the second call site, the root scan is **removed** from `introspect()` and `resolveRootSchema` becomes the single owner: it scans intersections via `flattenIntersection` and non-intersections directly. Net one fewer call site than before, and the double-warn is structurally impossible rather than defended against.

Evidence: `test/introspection/silent-drops.test.ts` "does not double-warn a refine on the root intersection" and "does not double-warn a refine on an object member", both asserting exactly 1.

### 4. A plain nested intersection with no refine produces no warning

The pre-existing "does not warn on a plain intersection" case still passes, and the field-overlap warnings are untouched, so scanning more nodes did not make the reader noisier on clean schemas.

Evidence: "does not warn on a plain intersection" asserts `warnings` equals `[]`; the full suite is green at 396 tests.

## One consequence worth flagging

Moving the root scan into `resolveRootSchema` means a refine on a **non-intersection** root is now warned by that function rather than by `introspect()`. Behavior is identical and pinned by a new test, but it is a real relocation of responsibility rather than a pure addition, so it is called out rather than buried — anyone tracing where root-refinement warnings come from should look in `resolveRootSchema` now.

Evidence: `test/introspection/silent-drops.test.ts` "still warns on a refine on a plain object root".

## Not done

- **The warnings still do not say which fields the refine constrains.** A nested refine reports against `(form)` unless it carries an explicit `path`. That is the actionability gap huttspawn raised from the render seat, tracked as #156 and #158; this card is about the warning existing at all, not about it being locatable.
- **Refine predicates are still not represented**, only reported. That boundary is settled — kelex records that a constraint exists without reasoning through it.
- **Intersection members must still be objects.** `flattenIntersection` throws on anything else, unchanged here.
