### PR TITLE
fix(introspection): remove node:crypto so the library runs outside Node

### DIFF
--- a/.changeset/no-node-crypto.md
+++ b/.changeset/no-node-crypto.md
@@ -1,0 +1,9 @@
+---
+"@rafters/kelex": patch
+---
+
+Remove the `node:crypto` dependency from the programmatic API. `computeVersion` ran on every `introspect()` call and imported `createHash` from `node:crypto`, so importing kelex as a library in a browser, a worker, Deno, or an edge runtime failed at module load. Core is now runtime-agnostic; `node:` imports remain only in the CLI, where they belong.
+
+Replaced with a dependency-free synchronous SHA-256. Web Crypto was not an option: `crypto.subtle.digest` is async, which would have forced `computeVersion` and therefore `introspect()` to become async — a breaking change to the package's central API for the sake of an implementation detail.
+
+**No descriptor versions change.** The implementation produces byte-identical digests to `node:crypto`, asserted against it directly across the SHA-256 padding boundaries, multi-block inputs and non-ASCII encoding, and confirmed by comparing the canonical fixture's version before and after the swap. Consumers pinned against a `FormDescriptor.version` see no movement.

--- a/src/introspection/sha256.ts
+++ b/src/introspection/sha256.ts
@@ -1,0 +1,120 @@
+/**
+ * Dependency-free synchronous SHA-256.
+ *
+ * kelex's programmatic API must run in any JavaScript runtime -- a browser
+ * editor, a worker, Deno, an edge function -- so core cannot import
+ * `node:crypto`. Web Crypto is not an option either: `crypto.subtle.digest` is
+ * async, which would force `computeVersion` and therefore `introspect()` to
+ * become async, a breaking change to the package's central API for the sake of
+ * an implementation detail.
+ *
+ * This produces byte-identical digests to `node:crypto`'s `sha256`, which is
+ * asserted directly against it in the tests rather than against fixed strings,
+ * so descriptor versions do not move.
+ */
+
+/** First 32 bits of the fractional parts of the cube roots of the first 64 primes. */
+const K = new Uint32Array([
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+  0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+  0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+  0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+  0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+  0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+]);
+
+/** First 32 bits of the fractional parts of the square roots of the first 8 primes. */
+const INITIAL_HASH = new Uint32Array([
+  0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+]);
+
+function rotr(value: number, bits: number): number {
+  return (value >>> bits) | (value << (32 - bits));
+}
+
+/**
+ * Encodes a string as UTF-8 bytes, matching what `node:crypto` does when it
+ * hashes a string with the "utf8" encoding. Uses TextEncoder, which is a
+ * standard global in every runtime kelex targets.
+ */
+function utf8Bytes(input: string): Uint8Array {
+  return new TextEncoder().encode(input);
+}
+
+/**
+ * Appends the SHA-256 padding: a 0x80 byte, zeroes, then the message length in
+ * bits as a big-endian 64-bit integer, sized so the total is a multiple of 64.
+ */
+function padMessage(bytes: Uint8Array): Uint8Array {
+  const bitLength = bytes.length * 8;
+  // At least one byte for 0x80 plus eight for the length, rounded up to a block.
+  const paddedLength = Math.ceil((bytes.length + 9) / 64) * 64;
+  const padded = new Uint8Array(paddedLength);
+  padded.set(bytes);
+  padded[bytes.length] = 0x80;
+
+  // Length occupies the final 8 bytes. JS numbers hold 53 bits safely, which
+  // covers any input this will ever see, so the high word is written from the
+  // float division rather than BigInt.
+  const view = new DataView(padded.buffer);
+  view.setUint32(paddedLength - 8, Math.floor(bitLength / 0x100000000), false);
+  view.setUint32(paddedLength - 4, bitLength >>> 0, false);
+
+  return padded;
+}
+
+/** Returns the SHA-256 digest of a UTF-8 string as lowercase hex. */
+export function sha256Hex(input: string): string {
+  const padded = padMessage(utf8Bytes(input));
+  const view = new DataView(padded.buffer);
+  const hash = new Uint32Array(INITIAL_HASH);
+  const w = new Uint32Array(64);
+
+  for (let offset = 0; offset < padded.length; offset += 64) {
+    for (let i = 0; i < 16; i++) {
+      w[i] = view.getUint32(offset + i * 4, false);
+    }
+    for (let i = 16; i < 64; i++) {
+      const s0 = rotr(w[i - 15], 7) ^ rotr(w[i - 15], 18) ^ (w[i - 15] >>> 3);
+      const s1 = rotr(w[i - 2], 17) ^ rotr(w[i - 2], 19) ^ (w[i - 2] >>> 10);
+      w[i] = (w[i - 16] + s0 + w[i - 7] + s1) >>> 0;
+    }
+
+    let [a, b, c, d, e, f, g, h] = hash;
+
+    for (let i = 0; i < 64; i++) {
+      const S1 = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25);
+      const ch = (e & f) ^ (~e & g);
+      const temp1 = (h + S1 + ch + K[i] + w[i]) >>> 0;
+      const S0 = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22);
+      const maj = (a & b) ^ (a & c) ^ (b & c);
+      const temp2 = (S0 + maj) >>> 0;
+
+      h = g;
+      g = f;
+      f = e;
+      e = (d + temp1) >>> 0;
+      d = c;
+      c = b;
+      b = a;
+      a = (temp1 + temp2) >>> 0;
+    }
+
+    hash[0] = (hash[0] + a) >>> 0;
+    hash[1] = (hash[1] + b) >>> 0;
+    hash[2] = (hash[2] + c) >>> 0;
+    hash[3] = (hash[3] + d) >>> 0;
+    hash[4] = (hash[4] + e) >>> 0;
+    hash[5] = (hash[5] + f) >>> 0;
+    hash[6] = (hash[6] + g) >>> 0;
+    hash[7] = (hash[7] + h) >>> 0;
+  }
+
+  let hex = "";
+  for (const word of hash) {
+    hex += word.toString(16).padStart(8, "0");
+  }
+  return hex;
+}

--- a/src/introspection/version.ts
+++ b/src/introspection/version.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { sha256Hex } from "./sha256";
 import type { FieldDescriptor, FormDescriptor } from "./types";
 
 /**
@@ -57,7 +57,7 @@ function canonicalize(value: unknown): unknown {
  */
 export function computeVersion(fields: FieldDescriptor[]): string {
   const canonical = JSON.stringify(canonicalize(fields));
-  return createHash("sha256").update(canonical, "utf8").digest("hex").slice(0, 16);
+  return sha256Hex(canonical).slice(0, 16);
 }
 
 /** Recomputes the version for a descriptor whose fields may have been edited. */

--- a/test/introspection/sha256.test.ts
+++ b/test/introspection/sha256.test.ts
@@ -1,0 +1,75 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { sha256Hex } from "../../src/introspection/sha256";
+
+/**
+ * Reference digest. node:crypto is used HERE, in the test, deliberately -- the
+ * point is to prove the dependency-free implementation agrees with it, so the
+ * library can stop importing it. Asserting against hardcoded strings would only
+ * prove the implementation matches itself.
+ */
+function reference(input: string): string {
+  return createHash("sha256").update(input, "utf8").digest("hex");
+}
+
+function agrees(input: string): void {
+  expect(sha256Hex(input)).toBe(reference(input));
+}
+
+describe("sha256 (#165)", () => {
+  it("matches node:crypto on an empty string", () => {
+    agrees("");
+  });
+
+  it("matches node:crypto on short inputs", () => {
+    agrees("a");
+    agrees("abc");
+    agrees("hello world");
+  });
+
+  // The padding boundaries. A message needs a 0x80 byte plus an 8-byte length,
+  // so at 56 bytes the length no longer fits in the block and a second block is
+  // appended. Implementations that get padding wrong pass every other case and
+  // fail exactly here.
+  it("matches node:crypto across the 64-byte padding boundary", () => {
+    for (const length of [54, 55, 56, 57, 58, 63, 64, 65]) {
+      agrees("x".repeat(length));
+    }
+  });
+
+  it("matches node:crypto across the second block boundary", () => {
+    for (const length of [119, 120, 127, 128, 129]) {
+      agrees("y".repeat(length));
+    }
+  });
+
+  it("matches node:crypto on multi-block input", () => {
+    agrees("z".repeat(1000));
+    agrees(JSON.stringify({ nested: Array.from({ length: 200 }, (_, i) => ({ i })) }));
+  });
+
+  // UTF-8 encoding must agree, or any schema with a non-ASCII label or default
+  // would hash differently than it did before this change.
+  it("matches node:crypto on non-ASCII input", () => {
+    agrees("café");
+    agrees("日本語のラベル");
+    agrees("emoji: \u{1F600}\u{1F680}");
+    agrees("combining: é");
+  });
+
+  it("matches node:crypto on JSON containing quotes and escapes", () => {
+    agrees(JSON.stringify({ a: 'quote " and \\ backslash', b: "newline \n tab \t" }));
+  });
+
+  it("produces 64 lowercase hex characters", () => {
+    expect(sha256Hex("anything")).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("is deterministic across calls", () => {
+    expect(sha256Hex("stable")).toBe(sha256Hex("stable"));
+  });
+
+  it("differs for inputs differing by one bit", () => {
+    expect(sha256Hex("a")).not.toBe(sha256Hex("b"));
+  });
+});

--- a/test/introspection/version.test.ts
+++ b/test/introspection/version.test.ts
@@ -29,6 +29,20 @@ describe("descriptor content version (#143)", () => {
     expect(versionOf(architectureObject)).toMatch(/^[0-9a-f]{16}$/);
   });
 
+  // Pinned in #165, when the digest moved from node:crypto to a dependency-free
+  // implementation so the library could run outside Node. Every other assertion
+  // here is relational -- "this changes, that does not" -- so all of them would
+  // still pass if the hash function were swapped for a different one and every
+  // published version silently rerolled. This is the one that would not.
+  //
+  // The value was taken from main BEFORE the swap and verified identical after.
+  // If a change moves it, that is a breaking change for every consumer pinned
+  // against a descriptor version, and it needs a deliberate decision rather
+  // than an updated expectation.
+  it("produces the exact hash published for the canonical fixture", () => {
+    expect(versionOf(architectureObject)).toBe("11617b63d9d43a33");
+  });
+
   // Criterion 2: cosmetic options must not churn the version, or every consumer
   // re-pins because someone renamed the generated component.
   it("ignores formName, import path and export name", () => {


### PR DESCRIPTION
## Summary

`computeVersion` imported `createHash` from `node:crypto` and runs on every `introspect()` call, so importing kelex as a library in a browser, a worker, Deno, or an edge runtime failed at module load. I introduced this in #143 and it shipped in #152.

It blocks a real consumer, not a hypothetical one: rafters is bidirectional — their editor *builds* a `FormDescriptor` by drag-and-drop and saves it through `writeSchema`. A browser editor cannot import a package that reaches for `node:crypto` at module scope.

Prerequisite for splitting the package into core and CLI, since it was the only thing making core Node-only.

## Acceptance criteria mapping

### 1. No `node:` import outside `src/cli.ts`

`node:crypto` was the sole offender. The CLI keeps `fs`, `path`, `url` and `module`, which is where runtime-specific code belongs.

Evidence: `legion sym etc find-content 'from "node:'` now returns only `src/cli.ts` and two test files — one of which imports it deliberately, see criterion 3.

### 2. `computeVersion` stays synchronous; `introspect()` unchanged

Web Crypto was rejected rather than overlooked. `crypto.subtle.digest` is async, so using it would make `computeVersion` async and therefore `introspect()` async — a breaking change to the package's central API in service of an implementation detail. A dependency was also rejected: the package has exactly one runtime dep today (`commander`, CLI-only), and pulling a hashing library into core to avoid ~90 lines costs more than it saves.

Evidence: `computeVersion`'s signature is unchanged; the diff in `version.ts` is the import line and the digest call.

### 3. Byte-identical to `node:crypto`, verified against it rather than against fixed strings

The test file **imports `node:crypto` deliberately** — that is the right place for it. Asserting against hardcoded digests would only prove the implementation agrees with itself; comparing against the reference proves the property that actually matters.

Evidence: `test/introspection/sha256.test.ts` defines `reference()` over `createHash("sha256")` and every case compares against it.

### 4. The corpus covers the padding boundaries

SHA-256 appends a `0x80` byte plus an 8-byte length, so at 56 bytes the length no longer fits in the block and a second block is appended. Implementations that get padding wrong pass every casual case and fail exactly there. Covered: empty, 1 byte, 54–58, 63–65, 119–129, 1000 bytes, and a large generated JSON structure.

Evidence: `test/introspection/sha256.test.ts` "matches node:crypto across the 64-byte padding boundary" and "across the second block boundary".

### 5. Non-ASCII input hashes identically

The old call passed `"utf8"` explicitly to `.update()`; the replacement encodes via `TextEncoder`, which is UTF-8 by definition. Pinned rather than assumed, since a mismatched encoding is the second way a hash swap silently changes versions — any schema with an accented label or a non-ASCII default would have moved.

Evidence: `test/introspection/sha256.test.ts` "matches node:crypto on non-ASCII input" covers accented Latin, CJK, astral-plane emoji and combining marks.

### 6. No descriptor version moves

Verified empirically rather than inferred from the algorithm. The canonical fixture hashes to `11617b63d9d43a33` on `main` under `node:crypto`, and to the same value on this branch — checked by running the same introspection on both.

That string is now **pinned** in `version.test.ts`. Every other assertion in that file is relational — "this input changes the hash, that one does not" — so all of them would still pass if the hash function were swapped and every published version silently rerolled. This is the only case in the suite that would fail on that.

Evidence: `test/introspection/version.test.ts` "produces the exact hash published for the canonical fixture"; the full suite is green at 402 tests with no other version assertion touched.

### 7. No new runtime dependency

Nothing added to `package.json`. `commander` remains the only runtime dependency, and it is CLI-only.

Evidence: `package.json` is not in the diff.

## Not done

- **The package is not split into core and CLI.** This removes the blocker; the split is a separate piece of work and should follow the four open PRs rather than race them.
- **`src/cli.ts` still uses Node builtins**, correctly — the CLI is a Node program and stays one.
- **No runtime guard against a future `node:` import creeping back into core.** A lint rule restricting `node:` imports outside `src/cli.ts` would prevent a recurrence, but that is a tooling change with its own scope, and it becomes near-free once the core/CLI split makes the boundary a package boundary instead of a convention.

Closes #165
