### PR TITLE
feat(introspection): warnings carry the field path, not just the leaf name

### DIFF
--- a/.changeset/warning-paths.md
+++ b/.changeset/warning-paths.md
@@ -1,0 +1,9 @@
+---
+"@rafters/kelex": patch
+---
+
+Warnings now identify a field by its full path rather than its leaf name. A field nested four levels down reported as `Field "name"` with no branch; tuple elements reported as `Field "0"` and `Field "1"` with nothing tying them to their tuple; a record value reported as `Field "value"`; and two same-named fields in different branches produced byte-identical warnings.
+
+Paths follow Standard Schema's `PathSegment[]` convention — `bag[0].quality`, `identity.origin.discipline.name`, `coords[0]` — so a warning can be matched against a `~standard` issue path. A record's value position uses a wildcard (`stats.*`), since its real key is not known until validation.
+
+Top-level fields still render as a bare name, and the number of warnings produced is unchanged. Only their content moved. The record-key warning gained a location it never had — it previously named no field at all.

--- a/src/introspection/introspect.ts
+++ b/src/introspection/introspect.ts
@@ -84,15 +84,45 @@ function nameToLabel(name: string): string {
 }
 
 /**
+ * A location within the schema, following Standard Schema's `PathSegment[]`
+ * convention: string segments are object keys, numbers are array or tuple
+ * indices. A consumer can match a warning against a `~standard` issue path.
+ *
+ * The one position with no runtime equivalent is a record's value schema, whose
+ * real key is not known until validation. It uses the `RECORD_VALUE` segment.
+ */
+type PathSegment = string | number;
+
+/** Stands in for "any key" at a record's value position. */
+const RECORD_VALUE = "*";
+
+/**
+ * Renders a path for humans: `bag[0].quality`, `coords[0]`, `stats.*`.
+ * A top-level field renders as its bare name, so the common case reads the
+ * same as it did before paths existed.
+ */
+function formatPath(path: PathSegment[]): string {
+  if (path.length === 0) {
+    return "(form)";
+  }
+  return path.reduce<string>((acc, segment, index) => {
+    if (typeof segment === "number") {
+      return `${acc}[${segment}]`;
+    }
+    return index === 0 ? String(segment) : `${acc}.${segment}`;
+  }, "");
+}
+
+/**
  * Formats a warning for a check the descriptor cannot carry. Refinements
  * (`.refine()`/`.superRefine()`) surface as Zod "custom" checks; every other
  * unrecognized check kind is named verbatim so nothing drops silently.
  */
-function formatDroppedCheck(fieldName: string, check: string): string {
+function formatDroppedCheck(location: string, check: string): string {
   if (check === "custom") {
-    return `Field "${fieldName}": a .refine()/.superRefine() constraint is not represented in the descriptor and must be re-applied downstream.`;
+    return `Field "${location}": a .refine()/.superRefine() constraint is not represented in the descriptor and must be re-applied downstream.`;
   }
-  return `Field "${fieldName}": dropped unrecognized check "${check}".`;
+  return `Field "${location}": dropped unrecognized check "${check}".`;
 }
 
 /**
@@ -200,7 +230,7 @@ function buildSyntheticObjectSchema(shape: Record<string, $ZodType>): $ZodType {
 /**
  * Builds FieldMetadata based on the field type.
  */
-function buildMetadata(inner: $ZodType, warnings: string[]): FieldMetadata {
+function buildMetadata(inner: $ZodType, warnings: string[], path: PathSegment[]): FieldMetadata {
   const def = inner._zod.def as { type: string };
   const type = def.type;
 
@@ -212,23 +242,27 @@ function buildMetadata(inner: $ZodType, warnings: string[]): FieldMetadata {
 
   if (type === "object") {
     const objDef = def as unknown as ZodObjectDef;
-    const fields = introspectShape(objDef.shape, warnings);
+    const fields = introspectShape(objDef.shape, warnings, path);
     return { kind: "object", fields };
   }
 
   if (type === "array") {
     const arrDef = def as unknown as ZodArrayDef;
-    const element = introspectField("item", arrDef.element, warnings);
+    // Index 0 stands for every element -- the descriptor describes one shape,
+    // not one occurrence.
+    const element = introspectField("item", arrDef.element, warnings, [...path, 0]);
     return { kind: "array", element };
   }
 
   if (type === "union") {
-    return buildUnionMetadata(def as unknown as ZodUnionDef, warnings);
+    return buildUnionMetadata(def as unknown as ZodUnionDef, warnings, path);
   }
 
   if (type === "tuple") {
     const tupDef = def as unknown as ZodTupleDef;
-    const elements = tupDef.items.map((item, i) => introspectField(String(i), item, warnings));
+    const elements = tupDef.items.map((item, i) =>
+      introspectField(String(i), item, warnings, [...path, i]),
+    );
     return { kind: "tuple", elements };
   }
 
@@ -245,10 +279,13 @@ function buildMetadata(inner: $ZodType, warnings: string[]): FieldMetadata {
       (!Array.isArray(keyDef.checks) || keyDef.checks.length === 0);
     if (!keyIsPlainString) {
       warnings.push(
-        `Record key schema (type "${keyDef.type}") is not represented in the descriptor; only the value schema is carried.`,
+        `Field "${formatPath(path)}": record key schema (type "${keyDef.type}") is not represented in the descriptor; only the value schema is carried.`,
       );
     }
-    const valueDescriptor = introspectField("value", recDef.valueType, warnings);
+    const valueDescriptor = introspectField("value", recDef.valueType, warnings, [
+      ...path,
+      RECORD_VALUE,
+    ]);
     return { kind: "record", valueDescriptor };
   }
 
@@ -263,10 +300,17 @@ function buildMetadata(inner: $ZodType, warnings: string[]): FieldMetadata {
 /**
  * Builds union metadata, detecting discriminated unions.
  */
-function buildUnionMetadata(def: ZodUnionDef, warnings: string[]): FieldMetadata {
+function buildUnionMetadata(
+  def: ZodUnionDef,
+  warnings: string[],
+  path: PathSegment[],
+): FieldMetadata {
   const discriminator = def.discriminator;
   const variants: { value: string; fields: FieldDescriptor[] }[] = [];
 
+  // Variants are alternatives at the SAME position, not children of it, so a
+  // variant's fields sit directly under the union's own path -- which is also
+  // where a `~standard` issue for them would report.
   for (const option of def.options) {
     const optDef = option._zod.def as { type: string };
 
@@ -283,15 +327,15 @@ function buildUnionMetadata(def: ZodUnionDef, warnings: string[]): FieldMetadata
         }
       }
 
-      const fields = introspectShape(objDef.shape, warnings);
+      const fields = introspectShape(objDef.shape, warnings, path);
       variants.push({ value, fields });
     } else if (optDef.type === "object") {
       const objDef = optDef as unknown as ZodObjectDef;
-      const fields = introspectShape(objDef.shape, warnings);
+      const fields = introspectShape(objDef.shape, warnings, path);
       variants.push({ value: `variant_${variants.length}`, fields });
     } else {
       // Non-object union option -- wrap as a single-field variant
-      const field = introspectField(`option_${variants.length}`, option, warnings);
+      const field = introspectField(`option_${variants.length}`, option, warnings, path);
       variants.push({
         value: `variant_${variants.length}`,
         fields: [field],
@@ -309,11 +353,15 @@ function buildUnionMetadata(def: ZodUnionDef, warnings: string[]): FieldMetadata
 /**
  * Introspects all fields in an object shape.
  */
-function introspectShape(shape: Record<string, $ZodType>, warnings: string[]): FieldDescriptor[] {
+function introspectShape(
+  shape: Record<string, $ZodType>,
+  warnings: string[],
+  parentPath: PathSegment[],
+): FieldDescriptor[] {
   const fields: FieldDescriptor[] = [];
 
   for (const [name, fieldSchema] of Object.entries(shape)) {
-    fields.push(introspectField(name, fieldSchema, warnings));
+    fields.push(introspectField(name, fieldSchema, warnings, [...parentPath, name]));
   }
 
   return fields;
@@ -399,15 +447,21 @@ function resolveType(inner: $ZodType): string {
 /**
  * Introspects a single field schema into a FieldDescriptor.
  */
-function introspectField(name: string, fieldSchema: $ZodType, warnings: string[]): FieldDescriptor {
+function introspectField(
+  name: string,
+  fieldSchema: $ZodType,
+  warnings: string[],
+  path: PathSegment[],
+): FieldDescriptor {
   // Resolve wrappers and pipes together so type, constraints, and metadata all
   // derive from one inner schema regardless of the order the author chained them.
   const { inner, isOptional, isNullable, defaultValue, hasCatch } = resolveInner(fieldSchema);
   const type = resolveType(inner);
+  const location = formatPath(path);
 
   if (hasCatch) {
     warnings.push(
-      `Field "${name}": a .catch() fallback value is not represented in the descriptor ` +
+      `Field "${location}": a .catch() fallback value is not represented in the descriptor ` +
         "(Zod stores it as a callback, not a literal) and must be re-applied downstream.",
     );
   }
@@ -418,7 +472,7 @@ function introspectField(name: string, fieldSchema: $ZodType, warnings: string[]
 
   // Check if it's a supported type
   if (!isScalarType(type) && !isCompositeType(type)) {
-    warnings.push(`Field "${name}": unsupported type "${type}", treating as string`);
+    warnings.push(`Field "${location}": unsupported type "${type}", treating as string`);
     const fallback: FieldDescriptor = {
       name,
       label,
@@ -445,9 +499,9 @@ function introspectField(name: string, fieldSchema: $ZodType, warnings: string[]
   const unknownChecks: string[] = [];
   const constraints = extractConstraints(inner, unknownChecks);
   for (const check of unknownChecks) {
-    warnings.push(formatDroppedCheck(name, check));
+    warnings.push(formatDroppedCheck(location, check));
   }
-  const metadata = buildMetadata(inner, warnings);
+  const metadata = buildMetadata(inner, warnings, path);
   const description = metaString(meta, "description");
 
   const field: FieldDescriptor = {
@@ -492,7 +546,7 @@ export function introspect(schema: $ZodType, options: IntrospectOptions): FormDe
     throw new Error(`kelex only supports z.object() schemas at the top level, got "${def.type}"`);
   }
 
-  const fields = introspectShape(def.shape, warnings);
+  const fields = introspectShape(def.shape, warnings, []);
 
   return {
     version: computeVersion(fields),

--- a/test/introspection/lossless.test.ts
+++ b/test/introspection/lossless.test.ts
@@ -102,7 +102,10 @@ describe("lossless reader (#141)", () => {
       z.object({ dict: z.record(z.enum(["a", "b"]), z.number()) }),
       OPTIONS,
     );
-    expect(record.warnings.some((w) => w.includes("Record key"))).toBe(true);
+    // Text updated in #158: the warning now names the record's path, since
+    // "Record key schema..." with no location was unusable on a nested record.
+    expect(record.warnings.some((w) => w.includes("record key schema"))).toBe(true);
+    expect(record.warnings.some((w) => w.includes('Field "dict"'))).toBe(true);
 
     const intersection = introspect(
       z.intersection(z.object({ a: z.string() }), z.object({ a: z.number() })),

--- a/test/introspection/warning-paths.test.ts
+++ b/test/introspection/warning-paths.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod/v4";
+import { introspect } from "../../src/introspection";
+
+const OPTIONS = {
+  formName: "PathForm",
+  schemaImportPath: "./path-fixture",
+  schemaExportName: "pathSchema",
+};
+
+function warningsFor(schema: Parameters<typeof introspect>[0]): string[] {
+  return introspect(schema, OPTIONS).warnings;
+}
+
+/** An unrepresentable type, so every case below has something to warn about. */
+const unsupported = z.map(z.string(), z.string());
+
+describe("warning paths (#158)", () => {
+  // Criterion 3: the common case must not regress into bracket noise. A
+  // top-level field still reads as a bare name.
+  it("names a top-level field by its plain name", () => {
+    const [warning] = warningsFor(z.object({ title: unsupported }));
+    expect(warning).toContain('Field "title"');
+    expect(warning).not.toContain("[");
+  });
+
+  // Criterion 2: the reported defect. A nested field said Field "name" with no
+  // indication of which branch it lived in.
+  it("names a nested field by its full dotted path", () => {
+    const [warning] = warningsFor(
+      z.object({
+        identity: z.object({ origin: z.object({ discipline: z.object({ name: unsupported }) }) }),
+      }),
+    );
+    expect(warning).toContain('Field "identity.origin.discipline.name"');
+  });
+
+  // Criterion 4: each composite kind gets a locator, so a sibling with the same
+  // leaf name in a different branch is distinguishable.
+  it("locates array elements by index", () => {
+    const [warning] = warningsFor(z.object({ bag: z.array(z.object({ item: unsupported })) }));
+    expect(warning).toContain('Field "bag[0].item"');
+  });
+
+  it("locates tuple elements by index", () => {
+    const warnings = warningsFor(z.object({ coords: z.tuple([unsupported, unsupported]) }));
+    expect(warnings[0]).toContain('Field "coords[0]"');
+    expect(warnings[1]).toContain('Field "coords[1]"');
+    // The defect this fixes: these two were both reported as Field "0" and
+    // Field "1", with nothing tying them to coords.
+    expect(warnings[0]).not.toBe(warnings[1]);
+  });
+
+  it("locates a record value with a wildcard segment", () => {
+    const [warning] = warningsFor(z.object({ stats: z.record(z.string(), unsupported) }));
+    // The real key is not known until validation, so the position is a template.
+    expect(warning).toContain('Field "stats.*"');
+  });
+
+  it("locates union variant fields under the union's own path", () => {
+    const warnings = warningsFor(
+      z.object({
+        payment: z.discriminatedUnion("kind", [
+          z.object({ kind: z.literal("card"), detail: unsupported }),
+          z.object({ kind: z.literal("bank"), detail: unsupported }),
+        ]),
+      }),
+    );
+    // Variants are alternatives at the same position, not children of it, so a
+    // ~standard issue for either would report at payment.detail.
+    expect(warnings.every((w) => w.includes('Field "payment.detail"'))).toBe(true);
+  });
+
+  // Criterion 4, the point of the whole card: two fields with the same leaf
+  // name in different branches must produce distinguishable warnings.
+  it("distinguishes same-named fields in different branches", () => {
+    const warnings = warningsFor(
+      z.object({
+        shipping: z.object({ line: unsupported }),
+        billing: z.object({ line: unsupported }),
+      }),
+    );
+    expect(warnings).toHaveLength(2);
+    expect(warnings[0]).toContain('Field "shipping.line"');
+    expect(warnings[1]).toContain('Field "billing.line"');
+    expect(warnings[0]).not.toBe(warnings[1]);
+  });
+
+  it("locates a field nested under several composite kinds at once", () => {
+    const [warning] = warningsFor(
+      z.object({
+        orders: z.array(z.object({ lines: z.array(z.object({ sku: unsupported })) })),
+      }),
+    );
+    expect(warning).toContain('Field "orders[0].lines[0].sku"');
+  });
+
+  // Criterion 5: content changes, count does not. A path-qualified warning must
+  // not become two warnings, or a consumer counting them sees a regression.
+  it("does not change how many warnings are produced", () => {
+    const warnings = warningsFor(
+      z.object({
+        a: unsupported,
+        b: z.object({ c: unsupported }),
+        d: z.array(unsupported),
+      }),
+    );
+    expect(warnings).toHaveLength(3);
+  });
+
+  // The catch and record-key warnings route through the same path, so they are
+  // pinned too rather than assumed to have been updated.
+  it("applies paths to catch warnings", () => {
+    const [warning] = warningsFor(
+      z.object({ bag: z.array(z.object({ count: z.number().catch(0) })) }),
+    );
+    expect(warning).toContain('Field "bag[0].count"');
+    expect(warning).toContain(".catch()");
+  });
+
+  it("applies paths to record-key warnings", () => {
+    const [warning] = warningsFor(
+      z.object({ outer: z.object({ dict: z.record(z.enum(["a"]), z.string()) }) }),
+    );
+    expect(warning).toContain('Field "outer.dict"');
+    expect(warning).toContain("record key schema");
+  });
+});


### PR DESCRIPTION
## Summary

Every warning kelex emitted named only the leaf field, because `introspectShape` and `introspectField` passed a bare `name` down the recursion and never accumulated a path. At depth the output was unusable — tuple elements reported as `Field "0"` and `Field "1"` with nothing tying them to their tuple, a record value as `Field "value"`, a field four levels down as `Field "name"` with no branch, and two same-named fields in different branches were byte-identical.

Found by building deep-nesting toys while verifying #154: the `.catch()` fix worked at depth, but the warnings *about* it could not be traced back to a field.

Closes #158

Recreated from PR #163, which was closed as a workflow violation: it was built by merging the #154 and #153 branches locally and opened against `main`, so although it declared one issue its **diff** carried three cards. `legion verify` keys per-card criteria to the PR diff, so it would have verified this card against three issues' worth of code, and `pr write-check` could not catch it because it validates the body against one issue and never inspects diff scope.

Those cards are now merged, so this branch cherry-picks only #158's own commit onto updated main. The diff is three source files plus a changeset — genuinely single-issue.

## Acceptance criteria mapping

### 1. `introspectField`/`introspectShape` thread an accumulated path through the recursion

A `PathSegment[]` is threaded through `introspectShape`, `introspectField`, `buildMetadata` and `buildUnionMetadata`. Each composite kind appends its own segment as it descends: object keys by name, array elements at index `0` (the descriptor describes one shape, not one occurrence), tuple elements at their real index.

Evidence: `src/introspection/introspect.ts` — `introspect` seeds the walk with `[]`, and every recursive call site appends rather than replacing.

### 2. Warnings identify a field by path rather than leaf name

All five warning sites now render through one `formatPath` call rather than interpolating a bare name: dropped checks, unsupported types, the catch fallback, the record key, and the unknown-check fallback. A field is computed once per `introspectField` into a `location` local and reused.

Evidence: `test/introspection/warning-paths.test.ts` "names a nested field by its full dotted path" asserts `Field "identity.origin.discipline.name"`; "locates a field nested under several composite kinds at once" asserts `Field "orders[0].lines[0].sku"`.

### 3. Top-level fields still read as a plain name

`formatPath` renders the first segment bare and only prefixes `.` from the second onward, so a top-level field is exactly the string it was before this card. The test asserts the absence of bracket noise rather than just the presence of the name, so a formatter that wrapped everything would fail.

Evidence: `test/introspection/warning-paths.test.ts` "names a top-level field by its plain name" asserts `Field "title"` and `not.toContain("[")`.

### 4. Array, tuple, record and union positions each get a distinguishing locator

Arrays and tuples use numeric indices. Records use a `"*"` segment rendering as `stats.*`, because a record's real key is not known until validation — that position is a template, not a literal key, and calling it `value` (as it did) implied a key that does not exist.

Union variants sit at the union's **own** path rather than gaining a variant segment. Variants are alternatives at one position, not children of it, and a `~standard` issue for a field in either variant reports at `payment.detail` — so adding a segment would produce a path that never occurs at runtime.

Evidence: `test/introspection/warning-paths.test.ts` "locates array elements by index", "locates tuple elements by index" (which also asserts the two warnings differ — the exact defect), "locates a record value with a wildcard segment", "locates union variant fields under the union's own path", and "distinguishes same-named fields in different branches".

### 5. Existing warning assertions updated rather than loosened; count unchanged

One existing assertion needed updating: the record-key case matched `"Record key"`, which no longer appears since the message is now prefixed with the location. It was tightened rather than relaxed — it now asserts both the reworded phrase and `Field "dict"`, so it pins the location this card added instead of merely tolerating new text. A loosened matcher would have survived a future rewording that dropped the location again.

Count is pinned explicitly, because a path rewrite invites turning one warning into two and a consumer counting warnings would see a phantom regression.

Evidence: `test/introspection/lossless.test.ts:105-108`; `test/introspection/warning-paths.test.ts` "does not change how many warnings are produced" asserts exactly 3 for 3 unrepresentable fields. Full suite green at 417 tests.

### 6. The path format follows Standard Schema's `PathSegment[]` convention

`type PathSegment = string | number` mirrors Standard Schema directly rather than inventing a format, so a consumer can match a warning against a `~standard` issue path — the same convention the #142 spike proved holds for nested/array/union shapes.

Evidence: the type declaration in `src/introspection/introspect.ts`; the union-variant decision above is a direct consequence of matching runtime issue paths rather than descriptor structure.

## The record-key warning gained a location it never had

Worth calling out separately: that warning previously named **no field at all** — just `Record key schema (type "X") is not represented...`. On a schema with more than one record it was untraceable. It is now prefixed like every other warning.

## Not done

- **Refine warnings are still not path-qualified.** They route through `warnObjectRefinements`, which derives its location from the refinement's own declared `path` rather than from the recursion, so a refine without an explicit `path` still reports as `(form)`. That is #156, which this card is groundwork for — it needs a path to exist before it can name what a refine touches.
- **The path is not exposed on the descriptor.** It is computed for warning text and discarded. Putting `path` on `FieldDescriptor` would be a contract change with a content-hash decision attached, and no consumer has asked for it; the descriptor's nesting already encodes the same information structurally.
- **No path on the intersection field-overlap warning.** It names a key at the root of a merged shape, where a path would always be a single segment already present in the message.