### PR TITLE
test(integration): end-to-end ladder of 5 schemas through the wired stack

### DIFF
--- a/test/integration/schemas.ts
+++ b/test/integration/schemas.ts
@@ -1,0 +1,159 @@
+import { z } from "zod/v4";
+
+/**
+ * Five schemas on a deliberate complexity ladder, each rung adding a class of
+ * construct the one below does not exercise. They drive the end-to-end
+ * integration suite (`stack.test.ts`), which runs the real wired stack --
+ * `generate()` -> introspect -> descriptor -> composite target -- and the
+ * schema-writer round trip.
+ *
+ * The top rung is not just "bigger". It deliberately packs the constructs fixed
+ * across the 2026-07-20 session -- `.catch()`, a nested-intersection refine, a
+ * wrapper-before-transform, `.meta()` at depth, records, a discriminated union
+ * inside an array -- so a regression in any of those PRs fails here, exercised
+ * through the public entry point rather than a unit corner.
+ */
+
+/** Rung 1 -- flat scalars only. The floor: no constraints, no nesting, no warnings. */
+export const rung1Contact = z.object({
+  name: z.string(),
+  age: z.number(),
+  subscribed: z.boolean(),
+  joined: z.date(),
+});
+
+/** Rung 2 -- adds constraints: bounds (inclusive and exclusive), length, formats, defaults. */
+export const rung2Account = z.object({
+  username: z.string().min(3).max(20),
+  email: z.string().email(),
+  website: z.string().url().optional(),
+  age: z.number().int().gte(18).lt(120),
+  score: z.number().positive(),
+  balance: z.number().nonnegative().default(0),
+  role: z.enum(["admin", "member", "guest"]).default("member"),
+  referralCode: z.string().length(8).nullable(),
+  handle: z.string().startsWith("@"),
+});
+
+/** Rung 3 -- adds one level of nesting, scalar arrays, and `.meta()` labels/descriptions. */
+export const rung3Profile = z.object({
+  displayName: z.string().meta({ title: "Display name", description: "Shown on your profile" }),
+  bio: z.string().max(280).describe("A short bio"),
+  address: z.object({
+    street: z.string(),
+    city: z.string(),
+    postalCode: z.string().length(5),
+  }),
+  tags: z.array(z.string().min(1)).max(10),
+  interests: z.array(z.enum(["sports", "music", "tech", "art"])),
+  contactMethod: z.enum(["email", "phone", "none"]).default("email"),
+});
+
+/** Rung 4 -- adds composite shapes: object arrays, tuples, records, a discriminated union. */
+export const rung4Order = z.object({
+  orderId: z.string().meta({ title: "Order ID" }),
+  customer: z.object({
+    name: z.string(),
+    email: z.string().email(),
+  }),
+  items: z.array(
+    z.object({
+      sku: z.string(),
+      quantity: z.number().int().positive(),
+      unitPrice: z.number().nonnegative(),
+    }),
+  ),
+  coordinates: z.tuple([z.number(), z.number()]),
+  metadata: z.record(z.string(), z.string()),
+  payment: z.discriminatedUnion("kind", [
+    z.object({ kind: z.literal("card"), last4: z.string().length(4) }),
+    z.object({ kind: z.literal("bank"), routing: z.string().length(9) }),
+    z.object({ kind: z.literal("cash") }),
+  ]),
+  status: z.enum(["pending", "shipped", "delivered"]).default("pending"),
+});
+
+/**
+ * Rung 5 -- very complex, and the session regression guard. Its TOP LEVEL is a
+ * nested intersection, because that is the only place kelex processes an
+ * intersection's `.refine()` (they are flattened at the root; an
+ * intersection-typed *field* degrades to a string, which is a separate
+ * limitation). Every construct fixed on 2026-07-20 appears here:
+ *
+ * - a `.refine()` on a NESTED intersection (#153) -- the inner refine
+ * - a root `.refine()` carrying a message (#156) -- the outer refine
+ * - `.catch()` at depth, inside an array element, and combined with `.optional()` (#154)
+ * - a wrapper before `.transform()` (#149)
+ * - `.meta()` at depth, inside an array element (#147)
+ * - records and a discriminated-union-inside-an-array, path-qualified (#158)
+ *
+ * Shape: a base entity intersected with an audit mixin (inner, refined) and then
+ * with an extension block (outer, refined). Member keys are disjoint so the only
+ * refine warnings come from the two intersections, not from key overlap.
+ */
+const entityBlock = z.object({
+  accountId: z.string().meta({ title: "Account ID", description: "Immutable identifier" }),
+
+  // Discriminated union INSIDE an array, each variant with a caught field.
+  contacts: z.array(
+    z.discriminatedUnion("channel", [
+      z.object({
+        channel: z.literal("email"),
+        address: z.string().email(),
+        verified: z.boolean().catch(false),
+      }),
+      z.object({
+        channel: z.literal("phone"),
+        number: z.string().min(7),
+        extension: z.string().optional(),
+      }),
+    ]),
+  ),
+
+  // Wrapper before transform (#149): the .optional() sits inside the pipe;
+  // constraints and optionality must still resolve.
+  slug: z
+    .string()
+    .min(3)
+    .max(64)
+    .optional()
+    .transform((s) => s?.toLowerCase()),
+
+  // .catch() combined with .optional() on a constrained number (#154).
+  priority: z.number().int().min(1).max(5).catch(3).optional(),
+
+  // Records at depth, value carrying its own constraints and meta.
+  limits: z.record(z.string(), z.number().int().nonnegative().meta({ title: "Limit value" })),
+
+  // Deeply nested object with a caught enum three levels down.
+  settings: z.object({
+    display: z.object({
+      theme: z.enum(["light", "dark", "system"]).catch("system"),
+      density: z.enum(["comfortable", "compact"]).default("comfortable"),
+    }),
+  }),
+
+  tags: z.array(z.string().min(1).meta({ title: "Tag" })).max(20),
+});
+
+const auditMixin = z.object({
+  createdBy: z.string(),
+  revision: z.number().int().nonnegative(),
+});
+
+const extensionBlock = z.object({
+  displayName: z.string().meta({ title: "Display name" }),
+  region: z.enum(["us", "eu", "apac"]).catch("us"),
+});
+
+export const rung5Enterprise = z
+  .intersection(
+    // Inner intersection carrying its own refine (#153): this must surface as a
+    // warning, not vanish when the members are merged.
+    z
+      .intersection(entityBlock, auditMixin)
+      .refine((v) => v.revision >= 0, { message: "revision must be non-negative" }),
+    extensionBlock,
+  )
+  // Root refine with a constant message (#156).
+  .refine((v) => v.tags.length > 0, { message: "an account must have at least one tag" });

--- a/test/integration/stack.test.ts
+++ b/test/integration/stack.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+import { generate } from "../../src/codegen";
+import { introspect } from "../../src/introspection";
+import type { FormDescriptor } from "../../src/introspection";
+import { compositeTarget } from "../../src/targets";
+import { evaluateSchemaCode } from "../helpers/evaluate-schema";
+import { writeSchema } from "../../src/schema-writer/writer";
+import { rung1Contact, rung2Account, rung3Profile, rung4Order, rung5Enterprise } from "./schemas";
+
+const OPTS = {
+  formName: "TestForm",
+  schemaImportPath: "./schema",
+  schemaExportName: "testSchema",
+};
+
+/**
+ * End-to-end integration over the wired stack: schema -> `generate()` ->
+ * introspect -> descriptor -> composite target, plus the schema-writer round
+ * trip. Deliberately stops before any real codegen plugin -- the composite
+ * target is the identity serialization of the product, and the mapping layer
+ * (`resolveField`) is parked, so neither is exercised here.
+ *
+ * Each rung adds a class of construct; assertions common to all rungs run in
+ * the shared block, and per-rung specifics (warnings, field counts) follow.
+ */
+
+interface Rung {
+  name: string;
+  schema: unknown;
+  fieldCount: number;
+  /** Warnings expected on the FIRST introspect pass. See the round-trip note below. */
+  expectedWarnings: number;
+}
+
+const RUNGS: Rung[] = [
+  { name: "1 · flat scalars", schema: rung1Contact, fieldCount: 4, expectedWarnings: 0 },
+  { name: "2 · constraints", schema: rung2Account, fieldCount: 9, expectedWarnings: 0 },
+  { name: "3 · nesting + meta", schema: rung3Profile, fieldCount: 6, expectedWarnings: 0 },
+  { name: "4 · composites", schema: rung4Order, fieldCount: 7, expectedWarnings: 0 },
+  { name: "5 · very complex", schema: rung5Enterprise, fieldCount: 11, expectedWarnings: 6 },
+];
+
+function descriptorOf(schema: unknown): FormDescriptor {
+  return introspect(schema as Parameters<typeof introspect>[0], OPTS);
+}
+
+describe("integration: schema -> generate -> composite (up to the plugins)", () => {
+  for (const rung of RUNGS) {
+    describe(`rung ${rung.name}`, () => {
+      it("generate() produces a composite artifact whose JSON is the descriptor", () => {
+        const result = generate({
+          schema: rung.schema as Parameters<typeof generate>[0]["schema"],
+          formName: OPTS.formName,
+          schemaImportPath: OPTS.schemaImportPath,
+          schemaExportName: OPTS.schemaExportName,
+          target: compositeTarget,
+        });
+
+        expect(result.files).toHaveLength(1);
+        const file = result.files[0];
+        expect(file.filename).toMatch(/\.composite\.json$/);
+
+        // The composite target serializes the descriptor verbatim, so parsing
+        // the artifact must reproduce exactly what introspect() returned.
+        const parsed = JSON.parse(file.content) as FormDescriptor;
+        expect(parsed).toEqual(descriptorOf(rung.schema));
+
+        // generate() surfaces the descriptor's warnings.
+        expect(result.warnings).toEqual(parsed.warnings);
+        expect(result.fields).toEqual(parsed.fields.map((f) => f.name));
+      });
+
+      it("stamps a deterministic version into the artifact", () => {
+        const parsed = JSON.parse(
+          generate({
+            schema: rung.schema as Parameters<typeof generate>[0]["schema"],
+            formName: OPTS.formName,
+            schemaImportPath: OPTS.schemaImportPath,
+            schemaExportName: OPTS.schemaExportName,
+            target: compositeTarget,
+          }).files[0].content,
+        ) as FormDescriptor;
+
+        // Discoverable, top-level, 16 hex chars, and stable run to run.
+        expect(parsed.version).toMatch(/^[0-9a-f]{16}$/);
+        expect(parsed.version).toBe(descriptorOf(rung.schema).version);
+      });
+
+      it("has the expected field count", () => {
+        expect(descriptorOf(rung.schema).fields).toHaveLength(rung.fieldCount);
+      });
+
+      it("emits exactly the expected number of first-pass warnings", () => {
+        expect(descriptorOf(rung.schema).warnings).toHaveLength(rung.expectedWarnings);
+      });
+
+      it("round-trips through the schema writer with an identical field tree", () => {
+        const before = descriptorOf(rung.schema);
+        const { code } = writeSchema({ form: before });
+        const after = introspect(evaluateSchemaCode(code), OPTS);
+
+        // Whole-tree equality, not field-by-field. The writer omits what it
+        // warns about (refine predicates, catch values), but none of those live
+        // in `fields`, so the field tree is conserved exactly.
+        expect(after.fields).toEqual(before.fields);
+
+        // Version is computed from `fields`, so it must survive the trip.
+        expect(after.version).toBe(before.version);
+      });
+
+      it("does not throw a warning it cannot re-emit on the way back out", () => {
+        // The re-emitted schema has already had its unrepresentable constructs
+        // dropped, so the SECOND pass must be clean -- a warning here would mean
+        // the writer emitted something the reader then failed to represent.
+        const before = descriptorOf(rung.schema);
+        const { code } = writeSchema({ form: before });
+        const after = introspect(evaluateSchemaCode(code), OPTS);
+        expect(after.warnings).toEqual([]);
+      });
+    });
+  }
+});
+
+describe("integration: the ladder is a monotonic complexity gradient", () => {
+  it("each rung introspects to at least as many fields as intended, simple to complex", () => {
+    // A sanity check that the fixtures did not silently collapse -- e.g. a
+    // top-level intersection that failed to merge would drop to zero fields.
+    const counts = RUNGS.map((r) => descriptorOf(r.schema).fields.length);
+    expect(counts).toEqual([4, 9, 6, 7, 11]);
+  });
+
+  it("only the complex rungs produce warnings", () => {
+    const withWarnings = RUNGS.filter((r) => descriptorOf(r.schema).warnings.length > 0).map(
+      (r) => r.name,
+    );
+    expect(withWarnings).toEqual(["5 · very complex"]);
+  });
+});
+
+describe("integration: rung 5 exercises the 2026-07-20 fixes end to end", () => {
+  const warningsOf = (): string[] => descriptorOf(rung5Enterprise).warnings;
+
+  it("surfaces the refine on the NESTED intersection (#153), with its message", () => {
+    // The inner intersection's refine must not vanish when members merge.
+    expect(warningsOf().some((w) => w.includes("revision must be non-negative"))).toBe(true);
+  });
+
+  it("surfaces the root refine with its message (#156)", () => {
+    expect(warningsOf().some((w) => w.includes("an account must have at least one tag"))).toBe(
+      true,
+    );
+  });
+
+  it("both refines report as form-level, not as a field named (form)", () => {
+    const refineWarnings = warningsOf().filter((w) => w.includes(".refine()"));
+    expect(refineWarnings).toHaveLength(2);
+    expect(refineWarnings.every((w) => w.startsWith("Form-level"))).toBe(true);
+    expect(warningsOf().some((w) => w.includes('Field "(form)"'))).toBe(false);
+  });
+
+  it("path-qualifies a caught field inside an array of unions (#154, #158)", () => {
+    expect(
+      warningsOf().some(
+        (w) => w.includes('Field "contacts[0].verified"') && w.includes(".catch()"),
+      ),
+    ).toBe(true);
+  });
+
+  it("path-qualifies a caught enum nested three levels deep (#154, #158)", () => {
+    expect(
+      warningsOf().some(
+        (w) => w.includes('Field "settings.display.theme"') && w.includes(".catch()"),
+      ),
+    ).toBe(true);
+  });
+
+  it("resolves a wrapper placed before a transform (#149)", () => {
+    const slug = descriptorOf(rung5Enterprise).fields.find((f) => f.name === "slug");
+    expect(slug?.type).toBe("string");
+    expect(slug?.isOptional).toBe(true);
+    expect(slug?.constraints).toMatchObject({ minLength: 3, maxLength: 64 });
+  });
+
+  it("captures a .meta() label carried on an entity field (#147)", () => {
+    const accountId = descriptorOf(rung5Enterprise).fields.find((f) => f.name === "accountId");
+    expect(accountId?.label).toBe("Account ID");
+    expect(accountId?.meta).toMatchObject({ description: "Immutable identifier" });
+  });
+
+  it("recovers a caught number field's constraints rather than degrading to string (#154)", () => {
+    const priority = descriptorOf(rung5Enterprise).fields.find((f) => f.name === "priority");
+    expect(priority?.type).toBe("number");
+    expect(priority?.isOptional).toBe(true);
+    expect(priority?.constraints).toMatchObject({ isInt: true, min: 1, max: 5 });
+  });
+});


### PR DESCRIPTION
## Summary

An end-to-end integration suite: five schemas on a simple→very-complex gradient, each run through the real wired stack — `generate()` → introspect → descriptor → composite target — plus the schema-writer round trip. It stops before any codegen plugin (composite is the identity serialization of the product) and does not touch the parked mapping layer, so it exercises what the package actually ships.

Closes #170

Rung 5 doubles as a regression guard for the whole 2026-07-20 session — catch, nested-intersection refine, wrapper-before-transform, meta-at-depth, records, discriminated-union-in-array — driven through the public entry point rather than unit-by-unit.

## Acceptance criteria mapping

### 1. Five schemas on a real simple→very-complex gradient, in their own fixture file

`test/integration/schemas.ts`. Each rung adds exactly one construct class the one below lacks: rung 1 flat scalars, rung 2 constraints, rung 3 nesting + `.meta()`, rung 4 composites, rung 5 the intersection/catch/transform cluster. The gradient is asserted, not just asserted-by-comment.

Evidence: `test/integration/stack.test.ts` "each rung introspects to at least as many fields as intended" pins the field counts `[4, 9, 6, 7, 11]`, and "only the complex rungs produce warnings" pins that warnings appear on rung 5 alone.

### 2. `generate()` with the composite target produces one artifact whose JSON is the descriptor

Run per rung. The composite target serializes the descriptor verbatim, so parsing the emitted file must reproduce exactly what a fresh `introspect()` returns — a deep-equality check, which catches any drop, reorder, or mutation the target might introduce.

Evidence: `test/integration/stack.test.ts` "generate() produces a composite artifact whose JSON is the descriptor" asserts `JSON.parse(file.content)` deep-equals `descriptorOf(schema)`, one file emitted, filename ending `.composite.json`.

### 3. A deterministic 16-hex version is stamped top-level in the artifact

Per rung, the parsed artifact carries a `version` matching `/^[0-9a-f]{16}$/` and equal to the descriptor's own — discoverable without re-deriving.

Evidence: `test/integration/stack.test.ts` "stamps a deterministic version into the artifact".

### 4. Round trip conserves the whole field tree and the version

Per rung: introspect → writeSchema → eval → introspect, asserting `after.fields` deep-equals `before.fields` — the whole-tree standard from #148, stronger than the field-by-field check the pre-existing stress suite uses. Version is conserved because it is computed from `fields`.

Evidence: `test/integration/stack.test.ts` "round-trips through the schema writer with an identical field tree".

### 5. Warnings asserted on the first pass only; the second pass is clean by design

The writer omits what it warns about (refine predicates, catch values), so the re-emitted schema produces *fewer* warnings on re-introspect. Asserting "warnings survive the round trip" would fail by design. So first-pass warning counts are pinned, and a separate assertion pins that the second pass is empty — which is itself a real property: a warning there would mean the writer emitted something the reader then failed to represent.

Evidence: `test/integration/stack.test.ts` "emits exactly the expected number of first-pass warnings" and "does not throw a warning it cannot re-emit on the way back out".

### 6. Rung 5 asserts each session fix fires end-to-end

Eight targeted assertions, each keyed to a specific observable rather than a blanket "it warns", so a regression names itself: the nested-intersection refine surfaces with its message (#153); the root refine with its message (#156); both report as form-level, not `Field "(form)"`; `contacts[0].verified` is a path-qualified catch inside an array-of-unions (#154, #158); `settings.display.theme` is a path-qualified catch three levels deep; `slug` resolves through a wrapper-before-transform (#149); `accountId` carries its `.meta()` label (#147); `priority` recovers its number constraints rather than degrading to string (#154).

Evidence: `test/integration/stack.test.ts` describe block "rung 5 exercises the 2026-07-20 fixes end to end", eight cases.

### 7. Runs in preflight

Both files import only from `src/`, so no build artifact is needed and they run as `.test.ts` in the fast every-commit path rather than as a spec.

Evidence: imports in both files resolve to `../../src/...` and `../helpers/...`; the full `pnpm flightcheck` passes at 478 tests.

## Not done

- **The pre-existing 11-schema stress suite is untouched.** Its third assertion pins the parked `resolveField` mapping layer; correcting that is a separate follow-up, not part of adding this suite.
- **Rung 5 does not exercise an intersection-typed FIELD**, because that degrades to a string — kelex flattens intersections only at the root. Filed as #169. Rung 5 exercises intersection refines at the root, where #153 fixed them.
- **No version literals are pinned here.** The canonical-fixture hash is already pinned in `version.test.ts` (#165) as the hash-algorithm guard; duplicating that for evolving test fixtures would be brittle without adding coverage.