### PR TITLE
fix(introspection): version hash no longer crashes on bigint or collides on presentation keys

### DIFF
--- a/.changeset/version-hardening.md
+++ b/.changeset/version-hardening.md
@@ -1,0 +1,11 @@
+---
+"@rafters/kelex": patch
+---
+
+Fix two defects in the descriptor content hash.
+
+**A bigint no longer crashes `introspect()`.** `computeVersion` serialized fields with `JSON.stringify`, which throws on bigint, so any bigint literal or default (`z.literal(1n)`, `z.bigint().default(5n)`) killed the whole pipeline. Hashing now uses a bigint- and Date-aware stable serializer. The composite target, which had the same `JSON.stringify` landmine independently, renders a bigint as its decimal string rather than throwing.
+
+**Presentation keys no longer collide inside value payloads.** The `label`/`description`/`meta`/`schemaRef` exclusion was applied at every object depth, including the CONTENTS of a `defaultValue` object, so three defaults `{label:"aaa",x:1}`, `{label:"bbb",x:1}`, `{x:1}` all hashed the same -- skew-detection blindness. The exclusion now applies only to an object recognized as a FieldDescriptor, never to a user value payload.
+
+No version churns for existing schemas: the canonical fixture still hashes to `11617b63d9d43a33`, and a field-level `.meta()` label is still excluded.

--- a/src/introspection/version.ts
+++ b/src/introspection/version.ts
@@ -2,35 +2,63 @@ import { sha256Hex } from "./sha256";
 import type { FieldDescriptor, FormDescriptor } from "./types";
 
 /**
- * Field-level keys excluded from the version hash at every depth.
+ * FieldDescriptor property names excluded from the version hash.
  *
  * These are presentation, not contract: they describe how a field is labelled,
  * not what data conforms to it. Renaming a label must not invalidate captured
  * records or trigger a schema evolution downstream. `label` is additionally
  * redundant -- absent an explicit title it is derived from `name`, which is
  * hashed.
+ *
+ * They are stripped ONLY from an object recognized as a FieldDescriptor (see
+ * `looksLikeFieldDescriptor`), never recursively from a user value payload such
+ * as a `defaultValue` or a literal value -- a default `{ label: "x" }` is data,
+ * and stripping its `label` there made three different defaults collide (#176).
  */
 const PRESENTATION_KEYS = new Set(["label", "description", "meta", "schemaRef"]);
+
+/**
+ * Whether an object is a FieldDescriptor (vs a user value payload). Requires
+ * several structural markers together so a `defaultValue`/literal object that
+ * merely happens to carry one of them is not mistaken for a descriptor.
+ */
+function looksLikeFieldDescriptor(o: Record<string, unknown>): boolean {
+  return (
+    typeof o.name === "string" &&
+    typeof o.type === "string" &&
+    typeof o.isOptional === "boolean" &&
+    typeof o.isNullable === "boolean"
+  );
+}
 
 /**
  * Produces a canonical, order-stable structure for hashing.
  *
  * Object keys are sorted so a property reordering in the reader does not churn
  * the version, while ARRAYS keep their order -- field declaration order is
- * semantic, and so is tuple element and union variant order. Excluded keys and
- * undefined values are dropped so an absent key and an explicitly-undefined one
- * hash identically.
+ * semantic, and so is tuple element and union variant order. Undefined values
+ * are dropped so an absent key and an explicitly-undefined one hash identically.
+ * Dates and bigints pass through as-is; `stableSerialize` renders them (JSON
+ * cannot).
+ *
+ * Presentation keys are stripped only from an object that IS a descriptor, so a
+ * value payload keeps every key it carries.
  */
 function canonicalize(value: unknown): unknown {
+  if (value instanceof Date) {
+    return value;
+  }
+
   if (Array.isArray(value)) {
     return value.map(canonicalize);
   }
 
   if (value !== null && typeof value === "object") {
     const source = value as Record<string, unknown>;
+    const strip = looksLikeFieldDescriptor(source);
     const result: Record<string, unknown> = {};
     for (const key of Object.keys(source).sort()) {
-      if (PRESENTATION_KEYS.has(key) || source[key] === undefined) {
+      if ((strip && PRESENTATION_KEYS.has(key)) || source[key] === undefined) {
         continue;
       }
       result[key] = canonicalize(source[key]);
@@ -39,6 +67,46 @@ function canonicalize(value: unknown): unknown {
   }
 
   return value;
+}
+
+/**
+ * Deterministic serialization of a canonicalized structure.
+ *
+ * Replaces `JSON.stringify`, which throws on bigint (`z.literal(1n)` /
+ * `z.bigint().default(5n)` crashed the whole pipeline -- #176) and cannot render
+ * a Date. Keys arrive already sorted from `canonicalize`, so insertion order is
+ * canonical; this only turns the structure into a string, tagging bigint and
+ * Date so they cannot collide with a string that happens to look the same.
+ */
+function stableSerialize(value: unknown): string {
+  if (value === null) {
+    return "null";
+  }
+  if (value instanceof Date) {
+    return `Date(${value.getTime()})`;
+  }
+  const t = typeof value;
+  if (t === "bigint") {
+    return `${value as bigint}n`;
+  }
+  if (t === "string") {
+    return JSON.stringify(value);
+  }
+  if (t === "number" || t === "boolean") {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableSerialize).join(",")}]`;
+  }
+  if (t === "object") {
+    const source = value as Record<string, unknown>;
+    return `{${Object.keys(source)
+      .map((k) => `${JSON.stringify(k)}:${stableSerialize(source[k])}`)
+      .join(",")}}`;
+  }
+  // undefined / function / symbol -- canonicalize drops undefined; anything else
+  // reaching here is not structural content and is tagged rather than crashing.
+  return `<${t}>`;
 }
 
 /**
@@ -56,7 +124,7 @@ function canonicalize(value: unknown): unknown {
  * would churn the version without the data contract having moved.
  */
 export function computeVersion(fields: FieldDescriptor[]): string {
-  const canonical = JSON.stringify(canonicalize(fields));
+  const canonical = stableSerialize(canonicalize(fields));
   return sha256Hex(canonical).slice(0, 16);
 }
 

--- a/src/targets/composite/index.ts
+++ b/src/targets/composite/index.ts
@@ -11,7 +11,15 @@ export const compositeTarget: CodegenTarget<CompositeOptions> = {
 
   generate(form: FormDescriptor, options: CompositeOptions): TargetResult {
     const indent = options.indent ?? 2;
-    const content = JSON.stringify(form, null, indent);
+    // JSON has no bigint, and a raw bigint anywhere in the descriptor (a literal
+    // value or a captured default) makes JSON.stringify throw (#176). Render it
+    // as its decimal string so the artifact is emitted rather than crashing; a
+    // consumer reading a bigint field sees a string, a documented JSON limit.
+    const content = JSON.stringify(
+      form,
+      (_key, value) => (typeof value === "bigint" ? value.toString() : value),
+      indent,
+    );
 
     const baseName = form.name
       .replace(/Form$/, "")

--- a/test/introspection/version-hardening.test.ts
+++ b/test/introspection/version-hardening.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod/v4";
+import { introspect } from "../../src/introspection";
+import { compositeTarget } from "../../src/targets";
+
+const OPTIONS = { formName: "F", schemaImportPath: "./f", schemaExportName: "s" };
+const versionOf = (s: Parameters<typeof introspect>[0]) => introspect(s, OPTIONS).version;
+
+describe("version hardening (#176)", () => {
+  // B4: a bigint anywhere used to crash computeVersion via JSON.stringify.
+  it("does not crash on a bigint literal", () => {
+    expect(() => versionOf(z.object({ a: z.literal(1n) }))).not.toThrow();
+    expect(versionOf(z.object({ a: z.literal(1n) }))).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it("does not crash on a bigint default", () => {
+    expect(() => versionOf(z.object({ a: z.bigint().default(5n) }))).not.toThrow();
+  });
+
+  it("distinguishes different bigint literals", () => {
+    expect(versionOf(z.object({ a: z.literal(1n) }))).not.toBe(
+      versionOf(z.object({ a: z.literal(2n) })),
+    );
+  });
+
+  // H2: presentation keys were stripped at every depth, including inside a
+  // default value object -- so two different defaults collided.
+  it("distinguishes defaults that differ only in a presentation-named key", () => {
+    const mk = (label: string) =>
+      z.object({ a: z.object({ label: z.string(), x: z.number() }).default({ label, x: 1 }) });
+    expect(versionOf(mk("aaa"))).not.toBe(versionOf(mk("bbb")));
+  });
+
+  it("distinguishes a default with vs without a presentation-named key", () => {
+    const withLabel = z.object({
+      a: z.object({ label: z.string(), x: z.number() }).default({ label: "l", x: 1 }),
+    });
+    const withoutLabel = z.object({
+      a: z.object({ label: z.string(), x: z.number() }).default({ label: "", x: 1 }),
+    });
+    expect(versionOf(withLabel)).not.toBe(versionOf(withoutLabel));
+  });
+
+  // The FieldDescriptor-level exclusion still holds: a label edit does not churn.
+  it("still ignores a field-level .meta() label", () => {
+    expect(versionOf(z.object({ a: z.string().meta({ title: "Alpha" }) }))).toBe(
+      versionOf(z.object({ a: z.string() })),
+    );
+  });
+
+  it("still ignores a field-level description", () => {
+    expect(versionOf(z.object({ a: z.string().describe("a note") }))).toBe(
+      versionOf(z.object({ a: z.string() })),
+    );
+  });
+
+  // Determinism preserved.
+  it("is deterministic across runs", () => {
+    const s = z.object({ a: z.string().min(2), b: z.number().int() });
+    expect(versionOf(s)).toBe(versionOf(s));
+  });
+
+  // The composite target had the same JSON.stringify(bigint) landmine.
+  it("composite target serializes a bigint field without crashing", () => {
+    const descriptor = introspect(z.object({ a: z.literal(1n) }), OPTIONS);
+    expect(() => compositeTarget.generate(descriptor, {})).not.toThrow();
+    const parsed = JSON.parse(compositeTarget.generate(descriptor, {}).files[0].content);
+    expect(parsed.version).toBe(descriptor.version);
+  });
+});


### PR DESCRIPTION
## Summary

Two defects in the descriptor content hash (`version.ts`), plus the same crash independently in the composite target. Found by the 2026-07-21 Fable audit (B4, H2), independently reproduced.

Closes #176

## Acceptance criteria mapping

### 1. `introspect(z.object({ a: z.literal(1n) }))` returns a stable version, no throw

`computeVersion` serialized with `JSON.stringify`, which throws on bigint, so any bigint literal or default crashed `introspect()` from inside version hashing. Hashing now uses `stableSerialize`, a bigint- and Date-aware canonical serializer that never calls `JSON.stringify`.

Evidence: `test/introspection/version-hardening.test.ts` "does not crash on a bigint literal" asserts no-throw and a valid 16-hex hash; "distinguishes different bigint literals" pins that the fix hashes rather than swallowing.

### 2. A bigint default survives to the composite JSON without crashing

The composite target's own `JSON.stringify(form)` had the same landmine. A replacer now renders a bigint as its decimal string (JSON has no bigint), so the artifact is emitted rather than throwing.

Evidence: `test/introspection/version-hardening.test.ts` "composite target serializes a bigint field without crashing" parses the emitted artifact and checks the version; "does not crash on a bigint default".

### 3. Defaults differing only in a presentation-named key produce different versions

The `label`/`description`/`meta`/`schemaRef` exclusion was applied at every object depth, including the contents of a `defaultValue`, so `{label:"aaa",x:1}` and `{label:"bbb",x:1}` and `{x:1}` all collided. Exclusion now fires only for an object recognized as a FieldDescriptor (`looksLikeFieldDescriptor`: name + type + isOptional + isNullable), never for a user value payload.

Evidence: `test/introspection/version-hardening.test.ts` "distinguishes defaults that differ only in a presentation-named key" and "distinguishes a default with vs without a presentation-named key".

### 4. Existing version pins are unchanged

`stableSerialize` produces byte-identical output to `JSON.stringify` for JSON-safe content (keys pre-sorted, `JSON.stringify` for strings, `String()` for number/boolean, `null`), so no schema without bigint or presentation-keyed values rerolls.

Evidence: the canonical fixture still hashes to `11617b63d9d43a33` (the untouched `version.test.ts` pin passes); `test/introspection/version-hardening.test.ts` "is deterministic across runs".

### 5. FieldDescriptor-level presentation exclusion still holds

A field-level `.meta()` label or `.describe()` description still does not churn the version — the exclusion moved scope (descriptor-only) rather than being removed.

Evidence: `test/introspection/version-hardening.test.ts` "still ignores a field-level .meta() label" and "still ignores a field-level description".

## Not done

- **bigint is represented as a string in the composite artifact.** JSON has no bigint; a consumer reading a bigint field sees a decimal string. Documented in the changeset and code. A tagged representation could distinguish it from a genuine string, but that is a composite-format change beyond this crash fix.
- **`looksLikeFieldDescriptor` is a structural heuristic.** A user default object carrying `name` + `type` (strings) and `isOptional` + `isNullable` (booleans) all at once would be misread as a descriptor and have those keys stripped. Four simultaneous markers make this negligible; noted rather than solved with a shape-coupled walk.