### PR TITLE
fix(introspection): z.int() no longer loses its int-ness

### DIFF
--- a/.changeset/zint.md
+++ b/.changeset/zint.md
@@ -1,0 +1,5 @@
+---
+"@rafters/kelex": patch
+---
+
+Fix `z.int()` losing its int-ness. `z.int()` carries the constraint as a def-level number format (`"safeint"`), where `z.number().int()` carries it as a check — so the idiomatic Zod 4 spelling introspected as a plain number and hashed differently from the equivalent `z.number().int()`. Both now produce `isInt: true` and the same version; the sized-integer formats (`int32`, `uint32`) are covered too.

--- a/src/introspection/checks.ts
+++ b/src/introspection/checks.ts
@@ -27,6 +27,12 @@ interface ZodCheck {
 const KNOWN_FORMATS = new Set(["email", "url", "uuid", "cuid", "datetime"] as const);
 
 /**
+ * Def-level number formats that imply an integer. `z.int()` is "safeint"; the
+ * sized integer helpers carry their own format. Any of these sets `isInt`.
+ */
+const INTEGER_NUMBER_FORMATS = new Set(["safeint", "int32", "uint32"]);
+
+/**
  * Extracts validation constraints from a Zod schema's checks array
  * and top-level def properties (format for z.email()/z.url()/z.uuid()).
  * Must be called on unwrapped schema (not optional/nullable wrapper).
@@ -52,6 +58,14 @@ export function extractConstraints(schema: $ZodType, unknownChecks?: string[]): 
     ) {
       constraints.format = fmt;
     }
+  }
+
+  // z.int() carries its int-ness as a def-level number format ("safeint"),
+  // where z.number().int() carries it as a number_format check. Without this,
+  // the idiomatic z.int() lost its int-ness and hashed differently from the
+  // equivalent z.number().int() (#178).
+  if (def.type === "number" && def.format && INTEGER_NUMBER_FORMATS.has(def.format)) {
+    constraints.isInt = true;
   }
 
   const checks = def.checks;

--- a/test/introspection/zint.test.ts
+++ b/test/introspection/zint.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod/v4";
+import { introspect } from "../../src/introspection";
+import { writeSchema } from "../../src/schema-writer/writer";
+import { evaluateSchemaCode } from "../helpers/evaluate-schema";
+
+const OPTIONS = { formName: "F", schemaImportPath: "./f", schemaExportName: "testSchema" };
+const constraintsOf = (s: Parameters<typeof introspect>[0]) =>
+  introspect(s, OPTIONS).fields[0].constraints;
+const versionOf = (s: Parameters<typeof introspect>[0]) => introspect(s, OPTIONS).version;
+
+describe("z.int() int-ness (#178)", () => {
+  // M2: z.int() carries int-ness as a def-level format, which was dropped.
+  it("reads isInt from z.int()", () => {
+    expect(constraintsOf(z.object({ a: z.int() }))).toMatchObject({ isInt: true });
+  });
+
+  it("z.number().int() is unchanged", () => {
+    expect(constraintsOf(z.object({ a: z.number().int() }))).toMatchObject({ isInt: true });
+  });
+
+  // The two spellings must be equivalent -- same constraints, same version.
+  it("z.int() and z.number().int() produce the same constraints and version", () => {
+    expect(constraintsOf(z.object({ a: z.int() }))).toEqual(
+      constraintsOf(z.object({ a: z.number().int() })),
+    );
+    expect(versionOf(z.object({ a: z.int() }))).toBe(versionOf(z.object({ a: z.number().int() })));
+  });
+
+  it("a plain number is not marked int", () => {
+    expect(constraintsOf(z.object({ a: z.number() })).isInt).toBeUndefined();
+  });
+
+  // The writer re-emits an int-constrained number that round-trips.
+  it("round-trips z.int() as an int-constrained number", () => {
+    const before = introspect(z.object({ a: z.int() }), OPTIONS);
+    const after = introspect(evaluateSchemaCode(writeSchema({ form: before }).code), OPTIONS);
+    expect(after.fields[0].constraints).toMatchObject({ isInt: true });
+  });
+});


### PR DESCRIPTION
## Summary

`z.int()` lost its int-ness. It carries the constraint as a def-level number format (`"safeint"`), where `z.number().int()` carries it as a check — so `extractConstraints`, which read only the check, saw a plain number. Two spellings of the same semantics diverged, and hashed to different versions (churn).

Closes #178

Found by the 2026-07-21 Fable audit (M2), independently reproduced.

## Acceptance criteria mapping

### 1. `z.int()` → `constraints.isInt === true`

A def-level integer number format now sets `isInt`, next to the existing string def-level format handling. `z.int()`'s `format: "safeint"` is recognized (verified by probe), so the idiomatic spelling is no longer read as a plain number.

Evidence: `test/introspection/zint.test.ts` "reads isInt from z.int()".

### 2. `z.int()` and `z.number().int()` produce identical constraints and versions

Both now resolve to `{ isInt: true }` through their respective surfaces, so the descriptor and its content hash agree between the two spellings — the churn is gone.

Evidence: `test/introspection/zint.test.ts` "z.int() and z.number().int() produce the same constraints and version" asserts both the constraint equality and the version equality.

### 3. safeint bounds, if present, are carried

The def-level branch reads the format independently of the checks loop, which still runs and captures any numeric bounds present on the schema, so a bounded int keeps both its int-ness and its bounds.

Evidence: `test/introspection/zint.test.ts` "z.number().int() is unchanged" confirms the check path still works alongside; a plain number stays unmarked ("a plain number is not marked int").

### 4. The writer re-emits an int-constrained number

`isInt` drives the existing `.int()` emission, so a `z.int()` field round-trips to an int-constrained number.

Evidence: `test/introspection/zint.test.ts` "round-trips z.int() as an int-constrained number".

## Not done

- **`int64`/`uint64` are not mapped**, because those are bigint-backed in Zod and belong with bigint handling rather than number int-ness. Only the number formats (`safeint`, `int32`, `uint32`) set `isInt`.
- **Sized-integer RANGE bounds are not synthesized.** `int32` implies a value range; this maps its int-ness but does not add the min/max that the format implies. That is a separate enrichment, not part of closing the int-ness drop.