### PR TITLE
fix(schema-writer): preserve regex flags on round-trip

### DIFF
--- a/.changeset/regex-flags.md
+++ b/.changeset/regex-flags.md
@@ -1,0 +1,5 @@
+---
+"@rafters/kelex": patch
+---
+
+Preserve regex flags. `FieldConstraints.pattern` carried only `RegExp.source`, so `z.string().regex(/abc/i)` round-tripped to `/abc/` — silently flipping case-sensitivity and narrowing the schema. A `patternFlags` slot now carries the flags, the writer re-emits `/abc/i`, and because flags change what validates they participate in the version hash.

--- a/src/introspection/checks.ts
+++ b/src/introspection/checks.ts
@@ -94,6 +94,11 @@ export function extractConstraints(schema: $ZodType, unknownChecks?: string[]): 
       case "string_format":
         if (checkDef.format === "regex" && checkDef.pattern) {
           constraints.pattern = checkDef.pattern.source;
+          // Flags change what validates (/abc/i vs /abc/); dropping them silently
+          // narrowed the schema on round-trip (#179).
+          if (checkDef.pattern.flags) {
+            constraints.patternFlags = checkDef.pattern.flags;
+          }
         } else if (checkDef.format === "starts_with" && checkDef.prefix !== undefined) {
           constraints.startsWith = checkDef.prefix;
         } else if (checkDef.format === "ends_with" && checkDef.suffix !== undefined) {

--- a/src/introspection/types.ts
+++ b/src/introspection/types.ts
@@ -19,6 +19,8 @@ export interface FieldConstraints {
   /** Exact length from z.string().length(n) */
   length?: number;
   pattern?: string;
+  /** Flags of a `.regex()` pattern (e.g. "i", "gm"). Absent when there are none. */
+  patternFlags?: string;
   /** Literal prefix from z.string().startsWith(p) */
   startsWith?: string;
   /** Literal suffix from z.string().endsWith(s) */

--- a/src/schema-writer/field-emitter.ts
+++ b/src/schema-writer/field-emitter.ts
@@ -209,7 +209,7 @@ function emitString(field: FieldDescriptor): string {
     base += `.endsWith(${JSON.stringify(constraints.endsWith)})`;
   }
   if (constraints.pattern !== undefined) {
-    base += `.regex(/${constraints.pattern}/)`;
+    base += `.regex(/${constraints.pattern}/${constraints.patternFlags ?? ""})`;
   }
 
   return base;

--- a/test/introspection/regex-flags.test.ts
+++ b/test/introspection/regex-flags.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod/v4";
+import { introspect } from "../../src/introspection";
+import { writeSchema } from "../../src/schema-writer/writer";
+import { evaluateSchemaCode } from "../helpers/evaluate-schema";
+
+const OPTIONS = { formName: "F", schemaImportPath: "./f", schemaExportName: "testSchema" };
+const constraintsOf = (s: Parameters<typeof introspect>[0]) =>
+  introspect(s, OPTIONS).fields[0].constraints;
+const versionOf = (s: Parameters<typeof introspect>[0]) => introspect(s, OPTIONS).version;
+
+describe("regex flags (#179)", () => {
+  // M4: flags were dropped, flipping case-sensitivity on round-trip.
+  it("captures the i flag", () => {
+    expect(constraintsOf(z.object({ a: z.string().regex(/abc/i) })).patternFlags).toBe("i");
+  });
+
+  it("captures multiple flags", () => {
+    expect(constraintsOf(z.object({ a: z.string().regex(/abc/gm) })).patternFlags).toBe("gm");
+  });
+
+  it("carries no patternFlags for a flagless pattern", () => {
+    expect(constraintsOf(z.object({ a: z.string().regex(/abc/) })).patternFlags).toBeUndefined();
+  });
+
+  it("re-emits the flags and round-trips", () => {
+    const before = introspect(z.object({ a: z.string().regex(/abc/i) }), OPTIONS);
+    expect(writeSchema({ form: before }).code).toContain("/abc/i");
+    const after = introspect(evaluateSchemaCode(writeSchema({ form: before }).code), OPTIONS);
+    expect(after.fields).toEqual(before.fields);
+  });
+
+  // Flags change what validates, so a flag change must move the version.
+  it("moves the version when the flags change", () => {
+    expect(versionOf(z.object({ a: z.string().regex(/abc/i) }))).not.toBe(
+      versionOf(z.object({ a: z.string().regex(/abc/) })),
+    );
+  });
+
+  // The re-emitted case-insensitive pattern actually accepts what the original did.
+  it("re-emits a pattern that still accepts the same inputs", () => {
+    const before = introspect(z.object({ a: z.string().regex(/abc/i) }), OPTIONS);
+    const schema = evaluateSchemaCode(writeSchema({ form: before }).code) as z.ZodObject;
+    expect(schema.shape.a.parse("ABC")).toBe("ABC");
+  });
+});


### PR DESCRIPTION
## Summary

`FieldConstraints.pattern` carried only `RegExp.source`, so `z.string().regex(/abc/i)` round-tripped to `/abc/` — silently flipping case-sensitivity and narrowing the schema. A consumer reading `pattern` also could not reconstruct the intended matcher.

Closes #179

Found by the 2026-07-21 Fable audit (M4), independently reproduced.

## Acceptance criteria mapping

### 1. `z.string().regex(/abc/i)` captures the `i` flag

A `patternFlags` slot on `FieldConstraints` now carries `RegExp.flags`, captured in the string_format regex branch beside the existing `.source` capture.

Evidence: `test/introspection/regex-flags.test.ts` "captures the i flag" and "captures multiple flags" (`gm`).

### 2. The writer re-emits `/abc/i` and it round-trips

`emitString` appends the flags to the emitted literal (`/${source}/${flags}`), so the re-emitted schema re-introspects to the same `patternFlags` and the whole field tree is conserved.

Evidence: `test/introspection/regex-flags.test.ts` "re-emits the flags and round-trips" asserts the emitted `/abc/i` and whole-`fields` equality; "re-emits a pattern that still accepts the same inputs" parses `"ABC"` against the re-emitted case-insensitive pattern, confirming the flag took effect.

### 3. A flag change moves the version

`patternFlags` lives in `constraints`, which is structural (not presentation), so it participates in the content hash. `/abc/i` and `/abc/` — which accept different inputs — now hash differently, where before they collided.

Evidence: `test/introspection/regex-flags.test.ts` "moves the version when the flags change".

### 4. No-flag patterns are unchanged

`RegExp.flags` is `""` for a flagless pattern, and the capture is guarded on non-empty, so a flagless pattern carries no `patternFlags` key and emits `/abc/` exactly as before — no version churn for existing flagless patterns.

Evidence: `test/introspection/regex-flags.test.ts` "carries no patternFlags for a flagless pattern".

## Not done

- **A hand-built descriptor with an already-escaped or malformed `pattern` string is not validated.** Introspection-sourced `.source` is well-formed; this PR does not add validation of a consumer-authored pattern string, which the audit noted as a separate (PLAUSIBLE) concern.
- **Flag semantics are not interpreted** — the flags string is carried and re-emitted verbatim, not decomposed into per-flag booleans. A consumer that wants to reason about `i` vs `g` reads the string.