### PR TITLE
fix(introspection): warn on unrecognized string formats instead of silent-widening

### DIFF
--- a/.changeset/unknown-formats.md
+++ b/.changeset/unknown-formats.md
@@ -1,0 +1,5 @@
+---
+"@rafters/kelex": patch
+---
+
+Warn on unrecognized string formats. `z.iso.date()`, `z.ipv4()`, `z.jwt()`, `z.base64()` and other Zod 4 string formats carry a def-level `format` with no check, so they slipped past the checks loop and degraded to an unconstrained string with no warning (the writer then re-emitted `z.string()`). An unrecognized def-level string format now produces a path-qualified warning; the five represented formats (email, url, uuid, cuid, datetime) are unchanged.

--- a/src/introspection/checks.ts
+++ b/src/introspection/checks.ts
@@ -57,6 +57,11 @@ export function extractConstraints(schema: $ZodType, unknownChecks?: string[]): 
       fmt === "datetime"
     ) {
       constraints.format = fmt;
+    } else {
+      // An unrecognized def-level string format (z.iso.date, z.ipv4, z.jwt,
+      // base64, nanoid, ...) carries no check and so slipped past the checks
+      // loop, degrading to an unconstrained string with no warning (#181).
+      unknownChecks?.push(`string_format:${fmt}`);
     }
   }
 

--- a/test/introspection/unknown-formats.test.ts
+++ b/test/introspection/unknown-formats.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod/v4";
+import { introspect } from "../../src/introspection";
+
+const OPTIONS = { formName: "F", schemaImportPath: "./f", schemaExportName: "s" };
+const warningsOf = (s: Parameters<typeof introspect>[0]) => introspect(s, OPTIONS).warnings;
+
+describe("unknown string formats (#181)", () => {
+  // H3: an unrecognized def-level format degraded to string with no warning.
+  it("warns for z.iso.date()", () => {
+    const w = warningsOf(z.object({ a: z.iso.date() }));
+    expect(w.some((x) => x.includes("string_format:date"))).toBe(true);
+  });
+
+  it("warns for z.ipv4()", () => {
+    const w = warningsOf(z.object({ a: (z as unknown as { ipv4: () => z.ZodType }).ipv4() }));
+    expect(w.some((x) => x.includes("string_format:ipv4"))).toBe(true);
+  });
+
+  it("warns for a non-string-format string like z.base64()", () => {
+    const zz = z as unknown as { base64?: () => z.ZodType };
+    if (!zz.base64) return; // skip if the helper is absent in this Zod build
+    const w = warningsOf(z.object({ a: zz.base64() }));
+    expect(w.some((x) => x.includes("string_format:"))).toBe(true);
+  });
+
+  // The five known formats are unchanged and do not warn.
+  it("does not warn for the known formats", () => {
+    expect(warningsOf(z.object({ a: z.email() }))).toEqual([]);
+    expect(warningsOf(z.object({ a: z.url() }))).toEqual([]);
+    expect(warningsOf(z.object({ a: z.uuid() }))).toEqual([]);
+  });
+
+  it("does not warn for a plain string", () => {
+    expect(warningsOf(z.object({ a: z.string() }))).toEqual([]);
+  });
+
+  // The warning is path-qualified.
+  it("path-qualifies the unknown-format warning", () => {
+    const w = warningsOf(z.object({ outer: z.object({ ip: z.iso.date() }) }));
+    expect(w.some((x) => x.includes('Field "outer.ip"'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

`extractConstraints` allowlisted five def-level string formats and silently ignored the rest. `z.iso.date()`, `z.ipv4()`, `z.jwt()`, base64/nanoid/ulid/cidr and others carry a def-level `format` with no `string_format` check, so they never reached the unknown-check fallback — they degraded to an unconstrained string with no warning, and the writer re-emitted `z.string()`.

Closes #181

Found by the 2026-07-21 Fable audit (H3), independently reproduced. Implements path (a) from the issue: warn (cheapest, nothing silent).

## Acceptance criteria mapping

### 1. An unrecognized def-level string format produces a path-qualified warning — never silent

The def-level format branch gained an `else` that pushes `string_format:<fmt>` to `unknownChecks`, the same channel the string_format CHECK branch already uses for unknowns. `introspectField` path-qualifies it. The bug was that a format on the def took a different code path than one on a check, and only the check path warned.

Evidence: `test/introspection/unknown-formats.test.ts` "warns for z.iso.date()", "warns for z.ipv4()", and "path-qualifies the unknown-format warning".

### 2. The five known formats are unchanged

`email`/`url`/`uuid`/`cuid`/`datetime` still assign `constraints.format` and never reach the `else`, so they neither warn nor change.

Evidence: `test/introspection/unknown-formats.test.ts` "does not warn for the known formats" (empty warnings for email, url, uuid).

### 3. The chosen behavior is consistent between reader and writer

The reader warns and does not set `constraints.format`; the writer, seeing no format, emits `z.string()` — the same widening it did before, now accompanied by a warning that tells the consumer to re-apply the format. Reader and writer agree that the format is unrepresented.

Evidence: an unknown format leaves `constraints.format` undefined (the reader change), which drives the writer's default `z.string()` branch — no writer change needed for consistency; the full suite passes at 526 tests.

### 4. Tests cover iso.date, ipv4, and one non-string-format string

`z.iso.date()` and `z.ipv4()` are covered directly; `z.base64()` covers a further format, guarded to skip on a Zod build lacking the helper.

Evidence: `test/introspection/unknown-formats.test.ts` "warns for a non-string-format string like z.base64()".

## Not done

- **The format name is warned, not carried.** This is path (a) from the issue. A consumer learns the format exists and its name but the descriptor does not represent it, so `z.iso.date()` still hashes like a plain string. Carrying the format as an opaque value (path b) is a descriptor addition deferred to the contract work.
- **No writer support for the unrecognized formats.** The writer widens to `z.string()`; re-emitting `z.iso.date()` would require the descriptor to carry the format first.