### PR TITLE
fix(introspection): z.date() bounds no longer land in a numeric constraint

### DIFF
--- a/.changeset/date-bounds.md
+++ b/.changeset/date-bounds.md
@@ -1,0 +1,5 @@
+---
+"@rafters/kelex": patch
+---
+
+Fix `z.date()` bounds putting a Date into a number-typed constraint. `z.date().min(new Date(...))` assigned the Date to `constraints.min`, which is typed `number` — so the composite JSON carried a string where the contract said number, aimed straight at a Rust reader deserializing it as a float, and the writer dropped the bound entirely on round-trip. Date bounds now live in dedicated `minDate`/`maxDate` ISO-string slots; numeric `min`/`max` stay strictly numeric, and the writer re-emits `.min(new Date(...))`.

--- a/src/introspection/checks.ts
+++ b/src/introspection/checks.ts
@@ -131,19 +131,29 @@ export function extractConstraints(schema: $ZodType, unknownChecks?: string[]): 
 
       case "greater_than":
         if (checkDef.value !== undefined) {
-          constraints.min = checkDef.value;
-          // .positive()/.gt() are exclusive; .nonnegative()/.gte()/.min() are inclusive
-          if (checkDef.inclusive === false) {
-            constraints.minExclusive = true;
+          // A z.date() bound is a Date, not a number: route it to minDate as an
+          // ISO string so constraints.min stays strictly numeric (#182).
+          if (def.type === "date" && (checkDef.value as unknown) instanceof Date) {
+            constraints.minDate = (checkDef.value as unknown as Date).toISOString();
+          } else {
+            constraints.min = checkDef.value;
+            // .positive()/.gt() are exclusive; .nonnegative()/.gte()/.min() are inclusive
+            if (checkDef.inclusive === false) {
+              constraints.minExclusive = true;
+            }
           }
         }
         break;
 
       case "less_than":
         if (checkDef.value !== undefined) {
-          constraints.max = checkDef.value;
-          if (checkDef.inclusive === false) {
-            constraints.maxExclusive = true;
+          if (def.type === "date" && (checkDef.value as unknown) instanceof Date) {
+            constraints.maxDate = (checkDef.value as unknown as Date).toISOString();
+          } else {
+            constraints.max = checkDef.value;
+            if (checkDef.inclusive === false) {
+              constraints.maxExclusive = true;
+            }
           }
         }
         break;

--- a/src/introspection/types.ts
+++ b/src/introspection/types.ts
@@ -27,6 +27,12 @@ export interface FieldConstraints {
   endsWith?: string;
   format?: "email" | "url" | "uuid" | "cuid" | "datetime";
 
+  // Date constraints (ISO strings, so numeric min/max stay strictly numeric)
+  /** Lower bound of a z.date(), as an ISO 8601 string. */
+  minDate?: string;
+  /** Upper bound of a z.date(), as an ISO 8601 string. */
+  maxDate?: string;
+
   // Number constraints
   min?: number;
   max?: number;

--- a/src/schema-writer/field-emitter.ts
+++ b/src/schema-writer/field-emitter.ts
@@ -149,7 +149,7 @@ function emitBaseExpression(field: FieldDescriptor, warnings?: string[]): string
     case "boolean":
       return "z.boolean()";
     case "date":
-      return "z.date()";
+      return emitDate(field);
     case "enum":
       return emitEnum(field);
     case "array":
@@ -165,6 +165,18 @@ function emitBaseExpression(field: FieldDescriptor, warnings?: string[]): string
     default:
       throw new Error(`Unexpected field type: ${field.type}`);
   }
+}
+
+function emitDate(field: FieldDescriptor): string {
+  const { constraints } = field;
+  let base = "z.date()";
+  if (constraints.minDate !== undefined) {
+    base += `.min(new Date(${JSON.stringify(constraints.minDate)}))`;
+  }
+  if (constraints.maxDate !== undefined) {
+    base += `.max(new Date(${JSON.stringify(constraints.maxDate)}))`;
+  }
+  return base;
 }
 
 function emitString(field: FieldDescriptor): string {

--- a/test/introspection/date-bounds.test.ts
+++ b/test/introspection/date-bounds.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod/v4";
+import { introspect } from "../../src/introspection";
+import { compositeTarget } from "../../src/targets";
+import { writeSchema } from "../../src/schema-writer/writer";
+import { evaluateSchemaCode } from "../helpers/evaluate-schema";
+
+const OPTIONS = { formName: "F", schemaImportPath: "./f", schemaExportName: "testSchema" };
+const constraintsOf = (s: Parameters<typeof introspect>[0]) =>
+  introspect(s, OPTIONS).fields[0].constraints;
+
+const lo = new Date("2020-01-01");
+const hi = new Date("2021-06-15");
+
+describe("date bounds (#182)", () => {
+  // H5: a date bound was assigned to constraints.min (typed number).
+  it("carries a date bound in minDate/maxDate as ISO strings", () => {
+    const c = constraintsOf(z.object({ a: z.date().min(lo).max(hi) }));
+    expect(c.minDate).toBe(lo.toISOString());
+    expect(c.maxDate).toBe(hi.toISOString());
+  });
+
+  it("keeps numeric min/max strictly numeric (never a Date)", () => {
+    const c = constraintsOf(z.object({ a: z.date().min(lo) }));
+    expect(c.min).toBeUndefined();
+    expect(typeof c.minDate).toBe("string");
+  });
+
+  it("does not put a non-number in a numeric constraint in the composite artifact", () => {
+    const descriptor = introspect(z.object({ a: z.date().min(lo).max(hi) }), OPTIONS);
+    const parsed = JSON.parse(compositeTarget.generate(descriptor, {}).files[0].content);
+    expect(parsed.fields[0].constraints.min).toBeUndefined();
+    expect(parsed.fields[0].constraints.max).toBeUndefined();
+    expect(parsed.fields[0].constraints.minDate).toBe(lo.toISOString());
+  });
+
+  // Numeric bounds are unaffected.
+  it("leaves numeric bounds unchanged", () => {
+    const c = constraintsOf(z.object({ a: z.number().min(5).max(10) }));
+    expect(c.min).toBe(5);
+    expect(c.max).toBe(10);
+    expect(c.minDate).toBeUndefined();
+  });
+
+  it("round-trips a bounded date", () => {
+    const before = introspect(z.object({ a: z.date().min(lo).max(hi) }), OPTIONS);
+    const after = introspect(evaluateSchemaCode(writeSchema({ form: before }).code), OPTIONS);
+    expect(after.fields).toEqual(before.fields);
+  });
+
+  it("re-emits a date whose bounds still validate", () => {
+    const before = introspect(z.object({ a: z.date().min(lo) }), OPTIONS);
+    const schema = evaluateSchemaCode(writeSchema({ form: before }).code) as z.ZodObject;
+    expect(() => schema.shape.a.parse(new Date("2019-01-01"))).toThrow();
+    expect(schema.shape.a.parse(new Date("2020-06-01"))).toBeInstanceOf(Date);
+  });
+
+  it("a plain z.date() with no bounds carries neither", () => {
+    const c = constraintsOf(z.object({ a: z.date() }));
+    expect(c.minDate).toBeUndefined();
+    expect(c.maxDate).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

`z.date().min(new Date(...))` assigned the Date to `constraints.min`, which is typed `number`. So the composite JSON carried a string where the contract said number — aimed straight at a Rust reader deserializing `min` as a float — and the writer emitted a bare `z.date()`, dropping the bound on round-trip.

Closes #182

Found by the 2026-07-21 Fable audit (H5), independently reproduced.

## Acceptance criteria mapping

### 1. `z.date().min(d)` carries the bound in a date-typed slot, not numeric min

`greater_than`/`less_than` now branch on `def.type === "date"` and route the Date to `minDate`/`maxDate` as ISO strings. The numeric `min`/`max` path is untouched for number schemas.

Evidence: `test/introspection/date-bounds.test.ts` "carries a date bound in minDate/maxDate as ISO strings".

### 2. `constraints.min`/`max` remain `number` in both type and runtime value

A date bound never reaches `min`/`max` — the `instanceof Date` guard routes it away — so a date field's `min` is `undefined`, not a Date.

Evidence: `test/introspection/date-bounds.test.ts` "keeps numeric min/max strictly numeric (never a Date)"; "leaves numeric bounds unchanged" confirms number schemas still populate `min`/`max`.

### 3. The writer re-emits the date bound and it round-trips

`emitDate` appends `.min(new Date("...ISO..."))`/`.max(...)`, which re-parses to the same instant, so a bounded date round-trips with an identical field tree, and the re-emitted bound still validates.

Evidence: `test/introspection/date-bounds.test.ts` "round-trips a bounded date" (whole-`fields` equality) and "re-emits a date whose bounds still validate" (a below-bound Date throws, an in-bound one passes).

### 4. The composite JSON never puts a non-number in `constraints.min`/`max`

Because the Date is routed to `minDate` (a string) and never to `min`, the serialized artifact has no non-number in the numeric slots.

Evidence: `test/introspection/date-bounds.test.ts` "does not put a non-number in a numeric constraint in the composite artifact" parses the emitted JSON and asserts `min`/`max` are undefined while `minDate` is the ISO string.

## Not done

- **Exclusive date bounds are not modeled.** `z.date()` exposes inclusive `.min()`/`.max()` only, so there is no exclusive flag to carry; the exclusive handling stays on the numeric branch where `.gt()`/`.lt()` exist.
- **Date bounds are ISO strings, not Date objects, in the descriptor.** The descriptor serializes to JSON, so a string is the faithful cross-runtime representation; a consumer reconstructs a Date with `new Date(iso)`.