### PR TITLE
fix(introspection): z.readonly() no longer degrades a field's type

### DIFF
--- a/.changeset/readonly.md
+++ b/.changeset/readonly.md
@@ -1,0 +1,5 @@
+---
+"@rafters/kelex": patch
+---
+
+Fix `z.readonly()` degrading a field's type. `z.number().readonly()` introspected as type `"string"` (with a warning), losing the inner number type and its constraints, for one transparent wrapper. `readonly` now joins the peeled wrapper set, so the inner type and constraints survive and `.meta()` on the inner schema is still found. `z.lazy()` and recursive schemas remain a documented limitation (warn-and-degrade).

--- a/src/introspection/unwrap.ts
+++ b/src/introspection/unwrap.ts
@@ -14,6 +14,10 @@ export const FLAG_WRAPPERS: ReadonlySet<string> = new Set([
   "nullable",
   "default",
   "catch",
+  // readonly is a transparent wrapper: peeled so the inner type and constraints
+  // survive (z.number().readonly() must stay a number, not degrade to string),
+  // and traversed by the meta walk like any other wrapper (#190).
+  "readonly",
 ]);
 
 export interface UnwrapResult {
@@ -188,6 +192,8 @@ export function unwrapSchema(schema: $ZodType): UnwrapResult {
       isNullable = true;
     } else if (wrapper === "catch") {
       hasCatch = true;
+    } else if (wrapper === "readonly") {
+      // Transparent: peel to the inner type, carry no flag.
     } else if (!hasDefault) {
       // Default: the FIRST one reached is the OUTERMOST, which is the one Zod
       // applies -- `z.string().default("in").default("out")` yields "out". Only

--- a/test/introspection/readonly.test.ts
+++ b/test/introspection/readonly.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod/v4";
+import { introspect } from "../../src/introspection";
+import type { FieldDescriptor } from "../../src/introspection/types";
+import { writeSchema } from "../../src/schema-writer/writer";
+import { evaluateSchemaCode } from "../helpers/evaluate-schema";
+
+const OPTIONS = { formName: "F", schemaImportPath: "./f", schemaExportName: "testSchema" };
+const field = (s: Parameters<typeof introspect>[0]): FieldDescriptor =>
+  introspect(s, OPTIONS).fields[0];
+
+describe("z.readonly() (#190)", () => {
+  // M6: z.number().readonly() degraded to type "string".
+  it("keeps the inner number type and constraints", () => {
+    const f = field(z.object({ a: z.number().min(1).max(9).readonly() }));
+    expect(f.type).toBe("number");
+    expect(f.constraints).toMatchObject({ min: 1, max: 9 });
+  });
+
+  it("keeps a string's constraints through readonly", () => {
+    const f = field(z.object({ a: z.string().min(3).readonly() }));
+    expect(f.type).toBe("string");
+    expect(f.constraints.minLength).toBe(3);
+  });
+
+  it("does not emit an unsupported-type warning for readonly", () => {
+    const d = introspect(z.object({ a: z.number().readonly() }), OPTIONS);
+    expect(d.warnings.some((w) => w.includes("unsupported type"))).toBe(false);
+  });
+
+  // Composes with the other wrappers in any order (the #149 class).
+  it("composes with optional and nullable", () => {
+    const f = field(z.object({ a: z.string().min(1).readonly().optional() }));
+    expect(f.type).toBe("string");
+    expect(f.isOptional).toBe(true);
+    expect(f.constraints.minLength).toBe(1);
+  });
+
+  it("composes when readonly is the inner wrapper", () => {
+    const f = field(z.object({ a: z.string().optional().readonly() }));
+    expect(f.type).toBe("string");
+    expect(f.isOptional).toBe(true);
+  });
+
+  // Meta survives a readonly wrapper (readonly joined FLAG_WRAPPERS).
+  it("finds meta through a readonly wrapper", () => {
+    expect(field(z.object({ a: z.string().meta({ title: "Alpha" }).readonly() })).label).toBe(
+      "Alpha",
+    );
+  });
+
+  it("round-trips a readonly field's type and constraints", () => {
+    const before = introspect(z.object({ a: z.number().int().min(0).readonly() }), OPTIONS);
+    const after = introspect(evaluateSchemaCode(writeSchema({ form: before }).code), OPTIONS);
+    expect(after.fields[0].type).toBe("number");
+    expect(after.fields[0].constraints).toMatchObject({ isInt: true, min: 0 });
+  });
+});


### PR DESCRIPTION
## Summary

`z.number().readonly()` introspected as type `"string"` (with a warning), losing the inner number type and its constraints — for one transparent wrapper method. `readonly` was simply not in the peeled wrapper set, so it became the resolved inner schema and fell to the unsupported-type degrade path.

Closes #190

Found by the 2026-07-21 Fable audit (M6), independently reproduced.

## Acceptance criteria mapping

### 1. `z.number().min(1).readonly()` → type `number` with constraints intact

`readonly` joins `FLAG_WRAPPERS` with a transparent (flag-less) branch in the unwrap loop, so it is peeled to its inner schema and the type and constraints resolve from the number, not the readonly wrapper.

Evidence: `test/introspection/readonly.test.ts` "keeps the inner number type and constraints" (`type` number, `{min, max}`) and "does not emit an unsupported-type warning for readonly".

### 2. readonly composes with the other wrappers in any order

The transparent branch sits in the same unwrap loop that handles optional/nullable/default/catch and alternates with pipe-peeling, so readonly resolves whether it wraps or is wrapped by the others (the #149 wrapper-order class).

Evidence: `test/introspection/readonly.test.ts` "composes with optional and nullable" (readonly then optional) and "composes when readonly is the inner wrapper" (optional then readonly).

### 3. `z.lazy()`/recursive schemas still degrade, with a clear warning and a documented limitation

Unchanged — this PR only adds readonly to the peeled set; `z.lazy()` is not a transparent wrapper and remains warn-and-degrade, noted as a known limitation in the changeset.

Evidence: no change to the lazy path; the changeset documents it. The full suite passes at 546 tests.

### 4. Round-trip preserves the readonly field's type and constraints

Because readonly resolves to the inner schema, the descriptor carries the inner type and constraints, and the writer re-emits that inner schema — so the field round-trips as its real type. (readonly-ness itself is not carried; see Not done.)

Evidence: `test/introspection/readonly.test.ts` "round-trips a readonly field's type and constraints" asserts the re-emitted field keeps `number` with `{isInt, min}`; "finds meta through a readonly wrapper" pins that the meta walk traverses it.

## Not done

- **readonly-ness is not carried as a marker.** The wrapper is transparently peeled, so the descriptor does not record that the field was readonly (a form could render it disabled). The issue listed the marker as optional; carrying it is deferred. The type-degradation — the actual bug — is fixed.
- **`z.lazy()` / recursive schemas remain unrepresentable.** They warn and degrade, unchanged; a bounded-depth representation would be a separate feature.