### PR TITLE
feat(#189): validate target output at the generate() seam

### DIFF
--- a/.changeset/generate-validation.md
+++ b/.changeset/generate-validation.md
@@ -1,0 +1,5 @@
+---
+"@rafters/kelex": minor
+---
+
+Validate a target's output at the `generate()` seam. `generate()` passed a target's result straight through, so a buggy (especially third-party) target could throw a raw error deep in the caller, return a `files: []` / malformed shape the compile-time `TargetResult` type could not catch, or silently drop a descriptor field. `generate()` -- the single seam every target passes through -- now wraps a target throw with the target name and form context, runtime-validates the result shape with a clear error naming the target, and appends a `target-field-unprocessed` warning (new `WarningCode`, emitted only here, never by `introspect()`) for each descriptor field the target did not report processing. The composite target passes cleanly.

--- a/src/codegen/generator.ts
+++ b/src/codegen/generator.ts
@@ -1,7 +1,12 @@
 import type { $ZodType } from "zod/v4/core";
 import { introspect } from "../introspection";
-import type { Warning } from "../introspection/types";
-import type { CodegenTarget, TargetOptions, TargetOutputFile } from "../targets/types";
+import type { FormDescriptor, Warning } from "../introspection/types";
+import type {
+  CodegenTarget,
+  TargetOptions,
+  TargetOutputFile,
+  TargetResult,
+} from "../targets/types";
 
 export interface GenerateOptions {
   /** The Zod schema to generate from */
@@ -40,6 +45,12 @@ export interface GenerateResult {
 
 /**
  * Generates form artifacts from a Zod schema via the given target.
+ *
+ * This is the one seam every target -- built-in or third-party -- passes
+ * through, so it is where a user is protected from a buggy plugin (#189): a
+ * target that throws, returns a shape that lies about its compile-time
+ * `TargetResult` contract, or silently drops a descriptor field is caught here
+ * with a message naming the target rather than a raw failure deep in the caller.
  */
 export function generate(options: GenerateOptions): GenerateResult {
   const { schema, formName, schemaImportPath, schemaExportName, target } = options;
@@ -50,13 +61,26 @@ export function generate(options: GenerateOptions): GenerateResult {
     schemaExportName,
   });
 
-  const targetResult = target.generate(formDescriptor, options.targetOptions ?? {});
+  let targetResult: TargetResult;
+  try {
+    targetResult = target.generate(formDescriptor, options.targetOptions ?? {});
+  } catch (cause) {
+    throw new Error(
+      `Target "${target.name}" threw while generating form "${formName}": ${describeError(cause)}`,
+      { cause },
+    );
+  }
+
+  // Validate OUTSIDE the try: a malformed (non-throwing) return must surface its
+  // own precise message, not be re-wrapped as "target threw".
+  validateTargetResult(targetResult, target.name);
 
   return {
     files: targetResult.files,
     fields: targetResult.fields,
     warnings: [
       ...formDescriptor.warnings,
+      ...unprocessedFieldWarnings(formDescriptor, targetResult, target.name),
       // A target reports prose; wrap it as a structured warning so the combined
       // list is uniform. Targets do not track a field path.
       ...targetResult.warnings.map(
@@ -64,4 +88,77 @@ export function generate(options: GenerateOptions): GenerateResult {
       ),
     ],
   };
+}
+
+function describeError(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause);
+}
+
+/**
+ * Runtime-checks a TargetResult's shape before its data is trusted. The type is
+ * compile-time only, so a JS plugin can return anything; a clear error naming
+ * the target beats a raw property-access failure deep in the caller (#189).
+ */
+function validateTargetResult(result: TargetResult, targetName: string): void {
+  const malformed = (detail: string): never => {
+    throw new Error(`Target "${targetName}" returned a malformed result: ${detail}.`);
+  };
+
+  const r: unknown = result;
+  if (typeof r !== "object" || r === null) {
+    return malformed(`expected an object, got ${r === null ? "null" : typeof r}`);
+  }
+
+  const record = r as Record<string, unknown>;
+  if (!Array.isArray(record.files) || record.files.length === 0) {
+    return malformed("`files` must be a non-empty array");
+  }
+  record.files.forEach((file: unknown, i: number) => {
+    const f = file as Record<string, unknown> | null;
+    if (
+      typeof f !== "object" ||
+      f === null ||
+      typeof f.filename !== "string" ||
+      typeof f.content !== "string"
+    ) {
+      malformed(`files[${i}] must be a { filename: string, content: string }`);
+    }
+  });
+  if (
+    !Array.isArray(record.fields) ||
+    !record.fields.every((n: unknown) => typeof n === "string")
+  ) {
+    return malformed("`fields` must be an array of strings");
+  }
+  if (
+    !Array.isArray(record.warnings) ||
+    !record.warnings.every((w: unknown) => typeof w === "string")
+  ) {
+    return malformed("`warnings` must be an array of strings");
+  }
+}
+
+/**
+ * Warns for each descriptor field the target did not report processing. A
+ * target may legitimately choose not to render a field, so this is a warning
+ * naming the field and target, not an error -- but a silently dropped field is
+ * exactly the failure the target cut was meant to end, so it is surfaced (#189).
+ */
+function unprocessedFieldWarnings(
+  form: FormDescriptor,
+  result: TargetResult,
+  targetName: string,
+): Warning[] {
+  const processed = new Set(result.fields);
+  const warnings: Warning[] = [];
+  for (const field of form.fields) {
+    if (!processed.has(field.name)) {
+      warnings.push({
+        path: [field.name],
+        code: "target-field-unprocessed",
+        message: `Target "${targetName}" did not process descriptor field "${field.name}"; the generated output may be missing it.`,
+      });
+    }
+  }
+  return warnings;
 }

--- a/src/introspection/types.ts
+++ b/src/introspection/types.ts
@@ -67,7 +67,11 @@ export type WarningCode =
   | "intersection-key-overlap"
   | "numeric-enum-as-union"
   | "discriminator-unresolved"
-  | "target-warning";
+  | "target-warning"
+  // Emitted only at the generate() seam (never by introspect() into a
+  // FormDescriptor): a target did not report processing a descriptor field, so
+  // its output may be missing it (#189).
+  | "target-field-unprocessed";
 
 /**
  * A structured introspection warning. `path` follows Standard Schema's

--- a/test/codegen/generator.test.ts
+++ b/test/codegen/generator.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod/v4";
+import { generate } from "../../src/codegen";
+import { compositeTarget } from "../../src/targets";
+import type { CodegenTarget, TargetResult } from "../../src/targets/types";
+
+const schema = z.object({ name: z.string(), age: z.number() });
+
+const BASE = {
+  schema,
+  formName: "TestForm",
+  schemaImportPath: "./schema",
+  schemaExportName: "testSchema",
+};
+
+function fakeTarget(name: string, gen: CodegenTarget["generate"]): CodegenTarget {
+  return { name, description: "fake", defaultExtension: ".fake", generate: gen };
+}
+
+describe("generate() target validation (#189)", () => {
+  // AC1: omitted descriptor field -> warning naming the field and the target.
+  it("warns naming the field and the target when a target omits a descriptor field", () => {
+    const target = fakeTarget("partial", () => ({
+      files: [{ filename: "f.fake", content: "" }],
+      fields: ["name"], // "age" omitted
+      warnings: [],
+    }));
+    const result = generate({ ...BASE, target });
+    const omissions = result.warnings.filter((w) => w.code === "target-field-unprocessed");
+    expect(omissions).toHaveLength(1);
+    expect(omissions[0].message).toContain("age");
+    expect(omissions[0].message).toContain("partial");
+    expect(omissions[0].path).toEqual(["age"]);
+  });
+
+  // AC2: malformed result -> clear error naming the target, not a raw access failure.
+  it("rejects a non-object result, naming the target", () => {
+    const target = fakeTarget("null-result", () => null as unknown as TargetResult);
+    expect(() => generate({ ...BASE, target })).toThrow(/null-result.*malformed/);
+  });
+
+  it("rejects an empty files array, naming the target", () => {
+    const target = fakeTarget(
+      "no-files",
+      () => ({ files: [], fields: [], warnings: [] }) as unknown as TargetResult,
+    );
+    expect(() => generate({ ...BASE, target })).toThrow(/no-files/);
+    expect(() => generate({ ...BASE, target })).toThrow(/files/);
+  });
+
+  it("rejects a file entry missing content, pointing at the entry not a raw property access", () => {
+    const target = fakeTarget(
+      "bad-file",
+      () =>
+        ({ files: [{ filename: "f.fake" }], fields: [], warnings: [] }) as unknown as TargetResult,
+    );
+    expect(() => generate({ ...BASE, target })).toThrow(/bad-file/);
+    expect(() => generate({ ...BASE, target })).toThrow(/files\[0\]/);
+  });
+
+  it("rejects a non-string entry in fields, naming the target", () => {
+    const target = fakeTarget(
+      "bad-fields",
+      () =>
+        ({
+          files: [{ filename: "f.fake", content: "x" }],
+          fields: [1, 2],
+          warnings: [],
+        }) as unknown as TargetResult,
+    );
+    expect(() => generate({ ...BASE, target })).toThrow(/bad-fields.*fields/);
+  });
+
+  // AC3: a target throw surfaces an error naming the target and enough context.
+  it("wraps a target throw with the target name and form context", () => {
+    const target = fakeTarget("boom", () => {
+      throw new Error("inner detail");
+    });
+    expect(() => generate({ ...BASE, target })).toThrow(/boom/);
+    expect(() => generate({ ...BASE, target })).toThrow(/TestForm/);
+    expect(() => generate({ ...BASE, target })).toThrow(/inner detail/);
+  });
+
+  it("preserves the original throw as the error cause", () => {
+    const inner = new Error("inner");
+    const target = fakeTarget("boom2", () => {
+      throw inner;
+    });
+    try {
+      generate({ ...BASE, target });
+      expect.unreachable("generate should have thrown");
+    } catch (e) {
+      expect((e as Error).cause).toBe(inner);
+    }
+  });
+
+  // AC4: the composite target passes cleanly, no new warnings.
+  it("adds no warnings for the composite target, which processes every field", () => {
+    const result = generate({ ...BASE, target: compositeTarget });
+    expect(result.warnings).toEqual([]);
+  });
+
+  // AC5: the check runs for a third-party target too (well-formed one passes).
+  it("runs the checks for a third-party target and passes a well-formed one through", () => {
+    const target = fakeTarget("third-party", () => ({
+      files: [{ filename: "f.fake", content: "x" }],
+      fields: ["name", "age"],
+      warnings: ["custom prose"],
+    }));
+    const result = generate({ ...BASE, target });
+    expect(result.warnings.some((w) => w.code === "target-field-unprocessed")).toBe(false);
+    expect(result.warnings).toContainEqual({
+      path: [],
+      code: "target-warning",
+      message: "custom prose",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`generate()` passed a target's result straight through: `TargetResult.fields` was self-reported and never cross-checked, the `TargetOutputFile[]` tuple is compile-time-only so a JS plugin returning `files: []` or a malformed shape flowed through unchecked, and a target throw propagated raw with no target-name context. `generate()` is the single seam every target -- built-in or third-party -- passes through, so it is now where a user is protected from a buggy plugin: it wraps a target throw with the target name and form context, runtime-validates the result shape with a clear error naming the target, and appends a `target-field-unprocessed` warning for each descriptor field the target did not report processing.

Found by the 2026-07-21 Fable audit (H7).

## Acceptance criteria mapping

### 1. A target that omits a descriptor field produces a warning naming the field and the target

After validation, `unprocessedFieldWarnings` diffs the descriptor's top-level field names against `targetResult.fields` (a `Set` membership test) and, for each name the target did not report, appends a `Warning` with code `target-field-unprocessed`, `path: [fieldName]`, and a message naming both the field and the target. It is a warning, not an error, because a target may legitimately choose not to render a field -- but a silent drop is surfaced.

Evidence: `test/codegen/generator.test.ts` "warns naming the field and the target when a target omits a descriptor field" -- a target reporting only `["name"]` for a `{ name, age }` schema yields exactly one omission warning whose message contains `"age"` and the target name, with `path: ["age"]`.

### 2. A target returning a malformed `TargetResult` is caught with a clear error naming the target, not a raw property access failure

`validateTargetResult` runs before any field of the result is trusted. It checks the result is a non-null object, `files` is a non-empty array of `{ filename: string, content: string }`, and `fields`/`warnings` are arrays of strings; any violation throws `Target "<name>" returned a malformed result: <detail>` -- naming the target and the specific defect (e.g. `files[0]`), never a raw `undefined is not iterable`.

Evidence: `test/codegen/generator.test.ts` cases "rejects a non-object result", "rejects an empty files array", "rejects a file entry missing content" (asserts the message contains `files[0]`), and "rejects a non-string entry in fields" -- each asserts the thrown message names the target.

### 3. A target that throws surfaces an error naming the target and enough context to locate it

The `target.generate()` call is wrapped in a try/catch that re-throws `Target "<name>" threw while generating form "<formName>": <inner message>` and attaches the original error as `{ cause }`, so both the human-readable context and the original stack are preserved.

Evidence: `test/codegen/generator.test.ts` "wraps a target throw with the target name and form context" (message contains the target name, `TestForm`, and the inner message) and "preserves the original throw as the error cause" (`err.cause` is the original error).

### 4. The composite target passes cleanly with no new warnings

The composite target reports `fields: form.fields.map(f => f.name)` -- every descriptor field -- so the omission diff is empty, and its result shape is well-formed, so validation does not throw. `generate()` with the composite target therefore adds nothing to the descriptor's own warnings.

Evidence: `test/codegen/generator.test.ts` "adds no warnings for the composite target" (`result.warnings` deep-equals `[]` for a clean 2-field schema); the untouched `test/integration/stack.test.ts` rungs, which assert `result.warnings` equals the descriptor's warnings across all five rungs, still pass under flightcheck.

### 5. The check runs in `generate()` for every target, built-in or third-party

The wrap, validation, and omission diff live in the body of `generate()` itself, after the single `target.generate()` call site (`legion sym refs` confirms `generate()` is the sole caller of the target method -- the CLI calls the `generate()` wrapper), so every target routes through them regardless of origin.

Evidence: `test/codegen/generator.test.ts` "runs the checks for a third-party target and passes a well-formed one through" exercises the path with an ad-hoc non-registered target; the composite (built-in) case exercises the same path.

## Not done

- **Extra fields are not warned.** A target reporting a field name not in the descriptor is left unflagged; the issue's Approach mentions extras but no acceptance criterion requires them, and an extra is far less dangerous than a silent omission. Left as a deliberate scope line.
- **`TargetOptions {}` is not validated.** The issue notes it is unvalidated; options are target-specific and opaque to the orchestrator, so validating them belongs to each target, not this seam.

Closes #189
