### PR TITLE
fix(#191): sanitize the composite target's derived filename

### DIFF
--- a/.changeset/composite-filename.md
+++ b/.changeset/composite-filename.md
@@ -1,0 +1,5 @@
+---
+"@rafters/kelex": patch
+---
+
+Sanitize the composite target's derived filename. The base name came straight from `form.name` (strip `Form`, kebab-case), so `form.name === "Form"` produced `.composite.json` -- a hidden dotfile -- and a name containing `/` or `\` put path separators in the filename. The CLI has a path-traversal guard, but a library consumer writing `files[]` directly does not. The composite target now replaces path separators with dashes, strips leading dots, and falls back to `form` when the derived name is empty. Normal PascalCase names are unchanged.

--- a/src/targets/composite/index.ts
+++ b/src/targets/composite/index.ts
@@ -4,6 +4,28 @@ import type { CompositeOptions } from "./types";
 
 export type { CompositeOptions };
 
+/** Fallback base name when a form name sanitizes to nothing (#191). */
+const DEFAULT_BASE_NAME = "form";
+
+/**
+ * Derives a filesystem-safe base name from the form name: strips the `Form`
+ * suffix, kebab-cases, then removes the hazards a library consumer -- which,
+ * unlike the CLI, has no path-traversal guard -- could otherwise be handed from
+ * an attacker- or user-controlled name (#191). Path separators become dashes so
+ * the artifact cannot escape its directory, leading dots are dropped so it is
+ * never a hidden dotfile, and an empty result falls back to `DEFAULT_BASE_NAME`.
+ * A normal PascalCase name (e.g. `UserProfileForm`) is unaffected.
+ */
+function toBaseName(formName: string): string {
+  const safe = formName
+    .replace(/Form$/, "")
+    .replace(/([a-z])([A-Z])/g, "$1-$2")
+    .toLowerCase()
+    .replace(/[/\\]+/g, "-")
+    .replace(/^\.+/, "");
+  return safe.length > 0 ? safe : DEFAULT_BASE_NAME;
+}
+
 export const compositeTarget: CodegenTarget<CompositeOptions> = {
   name: "composite",
   description: "JSON serialization of FormDescriptor",
@@ -21,10 +43,7 @@ export const compositeTarget: CodegenTarget<CompositeOptions> = {
       indent,
     );
 
-    const baseName = form.name
-      .replace(/Form$/, "")
-      .replace(/([a-z])([A-Z])/g, "$1-$2")
-      .toLowerCase();
+    const baseName = toBaseName(form.name);
 
     return {
       files: [

--- a/test/targets/composite.test.ts
+++ b/test/targets/composite.test.ts
@@ -103,6 +103,47 @@ describe("compositeTarget", () => {
     expect(result.files[0].filename).toBe("user-profile.composite.json");
   });
 
+  describe("filename edge cases (#191)", () => {
+    const filenameFor = (formName: string): string => {
+      const form = introspect(z.object({ name: z.string() }), {
+        formName,
+        schemaImportPath: "./schema",
+        schemaExportName: "schema",
+      });
+      return compositeTarget.generate(form, {}).files[0].filename;
+    };
+
+    // AC1: "Form" strips to "" -> would be ".composite.json", a hidden dotfile.
+    it("produces a non-dotfile filename when the name is just 'Form'", () => {
+      expect(filenameFor("Form")).toBe("form.composite.json");
+    });
+
+    // AC2: path separators and leading dots.
+    it("replaces path separators with a safe character", () => {
+      expect(filenameFor("a/b")).toBe("a-b.composite.json");
+      expect(filenameFor("a\\b")).toBe("a-b.composite.json");
+    });
+
+    it("strips a leading dot so the artifact is never hidden", () => {
+      expect(filenameFor(".hidden")).toBe("hidden.composite.json");
+    });
+
+    it("does not let a traversal-shaped name emit path separators", () => {
+      expect(filenameFor("../../etc/passwd")).not.toContain("/");
+      expect(filenameFor("..\\..\\secret")).not.toContain("\\");
+    });
+
+    // AC3: empty derived base name falls back to the documented default.
+    it("falls back to a default when the derived base name is empty", () => {
+      expect(filenameFor("...")).toBe("form.composite.json");
+    });
+
+    // AC4: a normal PascalCase name is unchanged.
+    it("leaves a normal PascalCase name unchanged", () => {
+      expect(filenameFor("UserProfileForm")).toBe("user-profile.composite.json");
+    });
+  });
+
   it("reports all fields", () => {
     const schema = z.object({ name: z.string(), age: z.number() });
     const form = introspect(schema, {


### PR DESCRIPTION
## Summary

The composite target derived its artifact filename straight from `form.name` (strip a `Form` suffix, kebab-case). `form.name === "Form"` stripped to `""`, producing `.composite.json` -- a hidden dotfile -- and a `form.name` containing `/` or `\` put path separators into the filename. The CLI has a path-traversal guard, but a library consumer that writes the returned `files[]` itself has none, so an attacker- or user-controlled form name could write outside the intended directory or produce an un-openable dotfile. The base-name derivation is now a `toBaseName` helper that replaces path separators with dashes, strips leading dots, and falls back to a documented default when the derived name is empty. The CLI guard stays as defense in depth.

Found by the 2026-07-21 Fable audit (L4).

## Acceptance criteria mapping

### 1. `form.name === "Form"` produces a non-dotfile filename

`toBaseName("Form")` strips the `Form` suffix to `""`, and the empty-string fallback returns `DEFAULT_BASE_NAME` (`"form"`), so the filename is `form.composite.json` -- a normal file, not the hidden `.composite.json` the old code produced.

Evidence: `test/targets/composite.test.ts` "produces a non-dotfile filename when the name is just 'Form'" asserts `filenameFor("Form") === "form.composite.json"`.

### 2. A `form.name` containing `/` or `\` or a leading `.` produces a safe, separator-free filename

The helper runs `.replace(/[/\\]+/g, "-")` (both separators to a dash) then `.replace(/^\.+/, "")` (leading dots removed), so no separator survives into the filename and the artifact is never hidden.

Evidence: `test/targets/composite.test.ts` "replaces path separators with a safe character" (`a/b` and `a\b` both -> `a-b.composite.json`), "strips a leading dot so the artifact is never hidden" (`.hidden` -> `hidden.composite.json`), and "does not let a traversal-shaped name emit path separators" (`../../etc/passwd` yields no `/`, `..\..\secret` yields no `\`).

### 3. An empty derived base name falls back to a documented default

When sanitizing yields an empty string (e.g. `"..."` -> stripped to `""`), the helper returns the named `DEFAULT_BASE_NAME` const, documented in a comment as the fallback.

Evidence: `test/targets/composite.test.ts` "falls back to a default when the derived base name is empty" asserts `filenameFor("...") === "form.composite.json"`.

### 4. The composite output for normal names is unchanged

A normal PascalCase name has no path separators and no leading dot, so the two new `.replace` steps are no-ops and the fallback is not reached; the kebab-case output is byte-identical to before.

Evidence: `test/targets/composite.test.ts` "leaves a normal PascalCase name unchanged" (`UserProfileForm` -> `user-profile.composite.json`), plus the pre-existing "derives filename from form name" test (same expectation) still passes unchanged.

## Not done

- **The CLI path-traversal guard is left in place**, not removed. The issue calls for keeping it as defense in depth; this change hardens the library seam without touching the CLI's independent guard.
- **No general slug normalization** (spaces, unicode, other punctuation) is added. The fix is scoped to the three documented filesystem hazards (dotfile, path separators, empty); a space in a filename is not a safety issue and normalizing it would risk changing output for existing names.

Closes #191
