### PR TITLE
feat(#222): the fold -- render(descriptor, renderer)

### DIFF
--- a/.changeset/engine-fold.md
+++ b/.changeset/engine-fold.md
@@ -1,0 +1,5 @@
+---
+"@rafters/kelex": minor
+---
+
+Add `render(descriptor, renderer): T` -- the plugin engine's fold. One recursive rule over the schema's topology: each field is matched to an inventory entry (first match), its config resolved, and a shape-specific `Input` (control/group/list/choice/recursive) handed to the matched composer or the renderer's fallback. Every control's `key` is its canonical path (`*` for template slots), a union folds to a `choice` with the discriminator dropped from variant fields, and a `ref` folds to a `recursive` boundary without recursing. Generic in `T`; names nothing about markup.

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -1,6 +1,8 @@
-// The plugin engine's PUBLIC surface -- form-word types only. The match/config
-// engine (`matches`, `resolveConfig`) and the join (`controlPaths`) are internal
-// and imported directly by the fold, never re-exported here or from the root.
+// The plugin engine's PUBLIC surface. `render` folds a descriptor through a
+// renderer. The match/config engine (`matches`, `resolveConfig`) and the join
+// (`controlPaths`) are internal and imported directly by the fold, never
+// re-exported here or from the root.
+export { render } from "./render";
 export type {
   Bound,
   Child,

--- a/src/engine/render.ts
+++ b/src/engine/render.ts
@@ -1,0 +1,77 @@
+import { type PathSegment, pathKey, RECORD_VALUE } from "../introspection/path";
+import type { FieldDescriptor, FieldMetadata, FormDescriptor } from "../introspection/types";
+import { matches, resolveConfig } from "./match";
+import type { Child, Composer, Renderer, Variant } from "./types";
+
+/**
+ * The fold. One recursive rule -- `render(field) = compose(match(field),
+ * children.map(render))` -- over the schema's own topology. Each field is
+ * matched against the renderer's inventory (first match), its config resolved,
+ * and a shape-specific `Input` handed to the matched composer (or `fallback`).
+ * The composer's `key` is the canonical path (`*` for template slots), so every
+ * control is addressable by the same key the handler later routes to. Generic
+ * in `T`; names nothing about markup.
+ */
+export function render<T>(descriptor: FormDescriptor, renderer: Renderer<T>): T {
+  const top = descriptor.fields.map((f) => child(f, [f.name], renderer));
+  return renderer.form(top);
+}
+
+function child<T>(field: FieldDescriptor, path: PathSegment[], renderer: Renderer<T>): Child<T> {
+  return { field, key: pathKey(path), rendered: renderField(field, path, renderer) };
+}
+
+function renderField<T>(field: FieldDescriptor, path: PathSegment[], renderer: Renderer<T>): T {
+  const entry = matches(field, renderer.inventory);
+  const composer: Composer<T> = (entry && renderer.compose[entry.component]) ?? renderer.fallback;
+  const base = { field, key: pathKey(path), config: resolveConfig(field, entry?.settings) };
+  const m = field.metadata;
+
+  switch (m.kind) {
+    case "object":
+    case "tuple": {
+      const kids = childFields(m).map((c) => child(c, [...path, c.name], renderer));
+      return composer({ ...base, shape: "group", children: kids });
+    }
+    case "array":
+      return composer({
+        ...base,
+        shape: "list",
+        item: child(m.element, [...path, RECORD_VALUE], renderer),
+      });
+    case "record":
+      return composer({
+        ...base,
+        shape: "list",
+        item: child(m.valueDescriptor, [...path, RECORD_VALUE], renderer),
+      });
+    case "union":
+      return composer({ ...base, shape: "choice", variants: variantsOf(m, path, renderer) });
+    case "ref":
+      return composer({ ...base, shape: "recursive" });
+    default:
+      return composer({ ...base, shape: "control" });
+  }
+}
+
+function childFields(
+  m: Extract<FieldMetadata, { kind: "object" } | { kind: "tuple" }>,
+): FieldDescriptor[] {
+  return m.kind === "object" ? m.fields : m.elements;
+}
+
+function variantsOf<T>(
+  m: Extract<FieldMetadata, { kind: "union" }>,
+  path: PathSegment[],
+  renderer: Renderer<T>,
+): Variant<T>[] {
+  return m.variants.map((v) => ({
+    value: v.value,
+    label: typeof v.meta?.["title"] === "string" ? (v.meta["title"] as string) : undefined,
+    // The discriminator is the selector, not a rendered field -- drop it here so a
+    // variant carries only its own non-discriminator controls.
+    children: v.fields
+      .filter((c) => c.name !== m.discriminator)
+      .map((c) => child(c, [...path, c.name], renderer)),
+  }));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,9 +27,10 @@ export type { SchemaWriterOptions, SchemaWriterResult } from "./schema-writer";
 
 export { emitField, writeSchema } from "./schema-writer";
 
-// The plugin engine's public contract (form-word types). The fold, the pipeline,
-// and the internal join (`controlPaths`) / match engine (`matches`,
-// `resolveConfig`) are NOT exported -- the plugin API never surfaces a CS term.
+// The plugin engine's public contract (form-word types) and the `render` fold.
+// The internal join (`controlPaths`) / match engine (`matches`, `resolveConfig`)
+// are NOT exported -- the plugin API never surfaces a CS term.
+export { render } from "./engine";
 export type {
   Bound,
   Child,

--- a/test/engine/render.test.ts
+++ b/test/engine/render.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod/v4";
+import { render } from "../../src/engine/render";
+import type { Renderer } from "../../src/engine/types";
+import { introspect } from "../../src/introspection";
+
+const OPTS = { formName: "F", schemaImportPath: "./f", schemaExportName: "s" };
+const run = (schema: Parameters<typeof introspect>[0], r: Renderer<string>): string =>
+  render(introspect(schema, OPTS), r);
+
+// A trivial string renderer -- one composer per shape, keyed by component.
+const R: Renderer<string> = {
+  inventory: [
+    { match: { type: "string" }, component: "text" },
+    { match: { type: "number" }, component: "text" },
+    { match: { type: "boolean" }, component: "text" },
+    { match: { type: "enum" }, component: "text" },
+    { match: { type: "date" }, component: "text" },
+    { match: { type: "literal" }, component: "text" },
+    { match: { type: "object" }, component: "group" },
+    { match: { type: "tuple" }, component: "group" },
+    { match: { type: "array" }, component: "list" },
+    { match: { type: "record" }, component: "list" },
+    { match: { type: "union" }, component: "choice" },
+    { match: { type: "ref" }, component: "rec" },
+  ],
+  compose: {
+    text: (i) => `<t:${i.key}>`,
+    group: (i) =>
+      i.shape === "group" ? `<g>${i.children.map((c) => c.rendered).join("")}</g>` : "?",
+    list: (i) => (i.shape === "list" ? `<l>${i.item.rendered}</l>` : "?"),
+    choice: (i) =>
+      i.shape === "choice"
+        ? `<ch>${i.variants.map((v) => `[${v.value}:${v.children.map((c) => c.rendered).join("")}]`).join("")}</ch>`
+        : "?",
+    rec: (i) => `<rec:${i.key}>`,
+  },
+  form: (top) => `<form>${top.map((c) => c.rendered).join("")}</form>`,
+  fallback: (i) => `<fb:${i.field.type}:${i.key}>`,
+};
+
+describe("render fold (#222)", () => {
+  it("folds all five shapes with name = path", () => {
+    const out = run(
+      z.object({
+        name: z.string(),
+        user: z.object({ email: z.string() }),
+        tags: z.array(z.object({ label: z.string() })),
+      }),
+      R,
+    );
+    expect(out).toBe("<form><t:name><g><t:user.email></g><l><g><t:tags.*.label></g></l></form>");
+  });
+
+  it("folds a union as a choice, dropping the discriminator from variant fields", () => {
+    const out = run(
+      z.object({
+        pay: z.discriminatedUnion("kind", [
+          z.object({ kind: z.literal("card"), num: z.string() }),
+          z.object({ kind: z.literal("bank"), acct: z.string() }),
+        ]),
+      }),
+      R,
+    );
+    expect(out).toBe("<form><ch>[card:<t:pay.num>][bank:<t:pay.acct>]</ch></form>");
+    expect(out).not.toContain("pay.kind"); // discriminator is the selector, not a field
+  });
+
+  it("folds a ref as a recursive boundary (no infinite recursion)", () => {
+    const Cat: z.ZodType = z.lazy(() => z.object({ name: z.string(), kids: z.array(Cat) }));
+    const out = run(z.object({ root: Cat }), R);
+    expect(out).toBe("<form><g><t:root.name><l><rec:root.kids.*></l></g></form>");
+  });
+
+  it("routes an unmatched field to fallback (never dropped)", () => {
+    const partial: Renderer<string> = {
+      ...R,
+      inventory: R.inventory.filter((e) => e.match.type !== "boolean"),
+    };
+    expect(run(z.object({ ok: z.boolean() }), partial)).toBe("<form><fb:boolean:ok></form>");
+  });
+
+  it("is deterministic", () => {
+    const s = z.object({ a: z.string(), b: z.array(z.number()) });
+    expect(run(s, R)).toBe(run(s, R));
+  });
+});


### PR DESCRIPTION
## Summary

Adds `render(descriptor, renderer): T` -- the plugin engine's fold. One recursive rule over the schema's own topology: each field is matched to an inventory entry (first match, via #221's `matches`), its config resolved (`resolveConfig`), and a shape-specific `Input` handed to the matched composer -- or the renderer's `fallback` when nothing matches. Every control's `key` is its canonical path (`*` for template slots), so it is addressable by the same key the handler later routes to. Generic in `T`; the engine names nothing about markup.

## Acceptance criteria mapping

### 1. A schema exercising all five shapes renders, each folded correctly
The `switch` over `metadata.kind` maps scalar->control, object/tuple->group, array/record->list, union->choice, ref->recursive, recursing children for the container shapes.

Evidence: `test/engine/render.test.ts` "folds all five shapes with name = path" renders a schema with scalars, a nested object, and an array-of-object and asserts the exact structured output (`<g>`, `<l>`, control leaves).

### 2. Every control's name is its canonical path
`child` and the `Input.key` are `pathKey(path)`; nested fields join with `.`, array elements use the `*` template slot.

Evidence: `test/engine/render.test.ts` "folds all five shapes with name = path" asserts `<t:user.email>` (nested) and `<t:tags.*.label>` (array template).

### 3. An unmatched field routes to fallback (never dropped)
When `matches` returns undefined, the composer is `renderer.fallback`, which still emits output for the field.

Evidence: `test/engine/render.test.ts` "routes an unmatched field to fallback" -- a renderer with the `boolean` entry removed renders a boolean field as `<fb:boolean:ok>`.

### 4. A union folds as choice; an array as list; a ref is a boundary
`variantsOf` builds the `choice` variants, dropping the discriminator (it is the selector); array/record fold to `list` with one `*`-slot element; `ref` folds to `recursive` and does NOT recurse.

Evidence: `test/engine/render.test.ts` "folds a union as a choice, dropping the discriminator" (`<ch>[card:<t:pay.num>][bank:<t:pay.acct>]</ch>`, no `pay.kind`) and "folds a ref as a recursive boundary" (`<rec:root.kids.*>`, no infinite recursion).

### 5. render is deterministic and generic in T
`render` has no nondeterministic input; the whole test uses `Renderer<string>`, proving `T` is opaque to the engine.

Evidence: `test/engine/render.test.ts` "is deterministic" (two renders are byte-identical), and every test instantiates `Renderer<string>`.

## Not done
- The `wire` pipeline (`renderForm = wire . render`) and the floor check are #223; this issue is `render` only.
- Composers still narrow on `i.shape` (no typed shape constructors yet) -- a later ergonomics improvement, not required for the fold.

Closes #222
