### PR TITLE
feat(#223): renderForm pipeline + renderer floor

### DIFF
--- a/.changeset/engine-pipeline.md
+++ b/.changeset/engine-pipeline.md
@@ -1,0 +1,5 @@
+---
+"@rafters/kelex": minor
+---
+
+Add `renderForm(descriptor, renderer, handler?)` -- the engine pipeline (`wire . render`) -- and `validateRenderer` (the floor). The floor requires a TYPE-ONLY catch-all for every `FieldType` (a constrained entry does not prove the bare type is handled) and a composer for every named component; `renderForm` runs it and throws on gaps rather than dropping a field. Named to avoid colliding with the existing `generate()`/`CodegenTarget` target path, which is left untouched.

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -2,6 +2,7 @@
 // renderer. The match/config engine (`matches`, `resolveConfig`) and the join
 // (`controlPaths`) are internal and imported directly by the fold, never
 // re-exported here or from the root.
+export { renderForm, validateRenderer } from "./pipeline";
 export { render } from "./render";
 export type {
   Bound,

--- a/src/engine/pipeline.ts
+++ b/src/engine/pipeline.ts
@@ -1,0 +1,67 @@
+import type { FieldType, FormDescriptor } from "../introspection/types";
+import { controlPaths } from "./paths";
+import { render } from "./render";
+import type { Handler, Match, Renderer } from "./types";
+
+/** Every schema node-type the floor must be able to answer. */
+const ALL_FIELD_TYPES: readonly FieldType[] = [
+  "string",
+  "number",
+  "boolean",
+  "date",
+  "enum",
+  "literal",
+  "object",
+  "array",
+  "union",
+  "tuple",
+  "record",
+  "ref",
+];
+
+/** A match that pins only `type` -- the type-only catch-all the floor requires. */
+function isTypeOnly(m: Match): boolean {
+  return Object.keys(m).length === 1;
+}
+
+/**
+ * The floor check: does a renderer cover everything a descriptor can contain?
+ * Completeness is the only guarantee kelex can make (nothing dropped) -- and it
+ * is precise: a constrained entry (`string` + a length bucket) does NOT prove
+ * the bare `string` type is handled, so every `FieldType` needs a TYPE-ONLY
+ * catch-all. Also checks every named component resolves to a composer. Returns
+ * the gaps (empty when complete).
+ */
+export function validateRenderer<T>(renderer: Renderer<T>): string[] {
+  const gaps: string[] = [];
+  for (const type of ALL_FIELD_TYPES) {
+    if (!renderer.inventory.some((e) => e.match.type === type && isTypeOnly(e.match))) {
+      gaps.push(`no type-only catch-all for FieldType "${type}"`);
+    }
+  }
+  for (const entry of renderer.inventory) {
+    if (!renderer.compose[entry.component]) {
+      gaps.push(`inventory entry names component "${entry.component}" with no composer`);
+    }
+  }
+  return gaps;
+}
+
+/**
+ * The engine pipeline: fold the descriptor to a form, then (if a handler is
+ * given) wire it. Named `renderForm` so it does not collide with the existing
+ * `generate()`/`CodegenTarget` target path, which is left untouched. Rejects an
+ * incomplete renderer up front (the floor) rather than dropping a field silently.
+ */
+export function renderForm<T>(
+  descriptor: FormDescriptor,
+  renderer: Renderer<T>,
+  handler?: Handler<T>,
+): T {
+  const gaps = validateRenderer(renderer);
+  if (gaps.length > 0) {
+    throw new Error(`renderer is incomplete:\n  - ${gaps.join("\n  - ")}`);
+  }
+  const form = render(descriptor, renderer);
+  return handler ? handler.wire(form, controlPaths(descriptor), descriptor) : form;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ export { emitField, writeSchema } from "./schema-writer";
 // The plugin engine's public contract (form-word types) and the `render` fold.
 // The internal join (`controlPaths`) / match engine (`matches`, `resolveConfig`)
 // are NOT exported -- the plugin API never surfaces a CS term.
-export { render } from "./engine";
+export { render, renderForm, validateRenderer } from "./engine";
 export type {
   Bound,
   Child,

--- a/test/engine/pipeline.test.ts
+++ b/test/engine/pipeline.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod/v4";
+import { render } from "../../src/engine/render";
+import { renderForm, validateRenderer } from "../../src/engine/pipeline";
+import type { Handler, Renderer } from "../../src/engine/types";
+import { introspect } from "../../src/introspection";
+
+const OPTS = { formName: "F", schemaImportPath: "./f", schemaExportName: "s" };
+const d = (schema: Parameters<typeof introspect>[0]) => introspect(schema, OPTS);
+
+// A COMPLETE string renderer: a type-only catch-all for every FieldType.
+const complete: Renderer<string> = {
+  inventory: [
+    { match: { type: "string" }, component: "c" },
+    { match: { type: "number" }, component: "c" },
+    { match: { type: "boolean" }, component: "c" },
+    { match: { type: "date" }, component: "c" },
+    { match: { type: "enum" }, component: "c" },
+    { match: { type: "literal" }, component: "c" },
+    { match: { type: "object" }, component: "g" },
+    { match: { type: "tuple" }, component: "g" },
+    { match: { type: "array" }, component: "list" },
+    { match: { type: "record" }, component: "list" },
+    { match: { type: "union" }, component: "ch" },
+    { match: { type: "ref" }, component: "rec" },
+  ],
+  compose: {
+    c: (i) => `<c:${i.key}>`,
+    g: (i) => (i.shape === "group" ? `<g>${i.children.map((x) => x.rendered).join("")}</g>` : "?"),
+    list: (i) => (i.shape === "list" ? `<l>${i.item.rendered}</l>` : "?"),
+    ch: (i) =>
+      i.shape === "choice"
+        ? `<ch>${i.variants.map((v) => v.children.map((x) => x.rendered).join("")).join("")}</ch>`
+        : "?",
+    rec: (i) => `<rec:${i.key}>`,
+  },
+  form: (top) => `<form>${top.map((x) => x.rendered).join("")}</form>`,
+  fallback: (i) => `<fb:${i.key}>`,
+};
+
+describe("renderForm pipeline + floor (#223)", () => {
+  it("returns the rendered form when no handler is given", () => {
+    const desc = d(z.object({ a: z.string() }));
+    expect(renderForm(desc, complete)).toBe(render(desc, complete));
+  });
+
+  it("applies the handler to the rendered form, passing the control manifest", () => {
+    const handler: Handler<string> = {
+      wire: (form, controls) => `${form}|wired:${controls.length}`,
+    };
+    const desc = d(z.object({ a: z.string(), b: z.number() }));
+    expect(renderForm(desc, complete, handler)).toBe(`${render(desc, complete)}|wired:2`);
+  });
+
+  it("validateRenderer passes for a complete renderer", () => {
+    expect(validateRenderer(complete)).toEqual([]);
+  });
+
+  it("floor requires a TYPE-ONLY catch-all -- a constrained entry does not count", () => {
+    const partial: Renderer<string> = {
+      ...complete,
+      inventory: complete.inventory
+        .filter((e) => e.match.type !== "string")
+        .concat({ match: { type: "string", maxLength: { gt: 100 } }, component: "c" }),
+    };
+    expect(validateRenderer(partial).some((g) => g.includes('"string"'))).toBe(true);
+    expect(() => renderForm(d(z.object({ a: z.string() })), partial)).toThrow(/string/);
+  });
+
+  it("floor rejects an inventory entry with no composer", () => {
+    const bad: Renderer<string> = {
+      ...complete,
+      inventory: complete.inventory.concat({
+        match: { type: "string", format: "email" },
+        component: "missing",
+      }),
+    };
+    expect(validateRenderer(bad).some((g) => g.includes("missing"))).toBe(true);
+  });
+
+  it("keeps the old generate export alongside the new renderForm", async () => {
+    const mod = await import("../../src/index");
+    expect(typeof mod.generate).toBe("function"); // old target pipeline, untouched
+    expect(typeof mod.renderForm).toBe("function"); // new engine pipeline
+  });
+});


### PR DESCRIPTION
## Summary

Adds the engine pipeline `renderForm(descriptor, renderer, handler?)` (`wire . render`) and `validateRenderer` (the floor). The pipeline is named `renderForm` so it does not collide with the existing `generate()`/`CodegenTarget` target path, which is left untouched. The floor is precise: a constrained entry does not prove a bare type is handled, so every `FieldType` needs a TYPE-ONLY catch-all, and every named component needs a composer; `renderForm` runs the floor and throws on gaps rather than silently dropping a field.

## Acceptance criteria mapping

### 1. renderForm composes render then wire; no handler returns the rendered form
The pipeline is a two-stage fold-then-wire: `renderForm` first calls `render(descriptor, renderer)` to produce the form, then applies the handler only when one is supplied -- `handler ? handler.wire(form, controlPaths(descriptor), descriptor) : form`. It threads `controlPaths(descriptor)` (the join manifest) into `wire` so the handler binds by the same keys `render` stamped, and returns the wired form; with no handler the rendered form passes straight through unchanged, so a renderer is usable on its own.

Evidence: `test/engine/pipeline.test.ts` "returns the rendered form when no handler is given" (`renderForm(d, r) === render(d, r)`) and "applies the handler to the rendered form, passing the control manifest" (the stub handler appends `|wired:2`, the two controls of a two-field schema).

### 2. The floor requires a TYPE-ONLY catch-all per FieldType
`validateRenderer` checks, for each of the twelve `FieldType`s, that some entry pins ONLY `type` (`isTypeOnly` = `Object.keys(match).length === 1`); a constrained entry does not satisfy it.

Evidence: `test/engine/pipeline.test.ts` "floor requires a TYPE-ONLY catch-all" replaces the `string` catch-all with a `string` + `maxLength` entry and asserts the gap names `"string"`, and `renderForm` throws `/string/`.

### 3. The floor rejects an inventory entry with no composer
The second loop flags any entry whose `component` is missing from `renderer.compose`.

Evidence: `test/engine/pipeline.test.ts` "floor rejects an inventory entry with no composer" adds an entry naming `missing` and asserts the gap includes `"missing"`.

### 4. The existing generate/CodegenTarget/composite/CLI are unchanged
No file in the target path was touched; the full existing suite still passes (610 tests). The old `generate` remains exported.

Evidence: `test/engine/pipeline.test.ts` "keeps the old generate export alongside the new renderForm" imports the root and asserts both `generate` and `renderForm` are functions; the untouched target/CLI tests still pass under preflight.

### 5. renderForm + interfaces are exported; the old generate is not renamed or removed
`src/index.ts` exports `renderForm`/`validateRenderer` beside the pre-existing `generate` export, which is left in place.

Evidence: `src/index.ts` `export { render, renderForm, validateRenderer } from "./engine"` with the `export { generate } from "./codegen"` line unchanged above it.

## Not done
- `CodegenTarget` deprecation / reframing `composite` as a JSON renderer -- a later migration, out of scope here.
- The `~standard` route helper the handler uses is #224; this issue only threads `controlPaths` into `wire`.

Closes #223
