### PR TITLE
feat(#224): ~standard route helper -- join by path

### DIFF
--- a/.changeset/engine-route.md
+++ b/.changeset/engine-route.md
@@ -1,0 +1,5 @@
+---
+"@rafters/kelex": minor
+---
+
+Add `route(controls, issues)` -- the join executed. It maps Standard Schema validation issues back to the controls a renderer stamped: each issue's runtime path (`tags.2.label`) binds to a control key (`tags.*.label`) by segment match with `*` as a wildcard for template slots, and `{key}`-wrapped segments are normalized. Standard Schema issue paths come back as raw `PathSegment[]` and match kelex's keys 1:1; an issue matching no control is surfaced with `control` undefined, never dropped. This is the helper every handler uses to route validation errors to error slots by path.

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -4,6 +4,8 @@
 // re-exported here or from the root.
 export { renderForm, validateRenderer } from "./pipeline";
 export { render } from "./render";
+export { route } from "./route";
+export type { Binding, Issue } from "./route";
 export type {
   Bound,
   Child,

--- a/src/engine/route.ts
+++ b/src/engine/route.ts
@@ -1,0 +1,50 @@
+import type { Control } from "./types";
+
+/**
+ * A Standard Schema issue: a message and an optional path. `~standard` returns
+ * paths as raw `PathSegment[]` -- strings and numbers -- but the spec also
+ * permits a `{ key }` wrapper per segment, so both are accepted and normalized.
+ */
+export interface Issue {
+  message: string;
+  path?: readonly unknown[];
+}
+
+/** An issue bound to the control it lands on. `control` is undefined when nothing matched. */
+export interface Binding {
+  key: string;
+  message: string;
+  control?: Control;
+}
+
+function normalize(raw: readonly unknown[]): (string | number)[] {
+  return raw.map((seg) => {
+    const s = seg && typeof seg === "object" && "key" in seg ? (seg as { key: unknown }).key : seg;
+    return typeof s === "number" ? s : String(s);
+  });
+}
+
+/** Whether a control key binds an issue path -- segment-equal, with `*` matching any index/key. */
+function binds(controlKey: string, issue: (string | number)[]): boolean {
+  const control = controlKey.split(".");
+  if (control.length !== issue.length) return false;
+  return control.every((seg, i) => seg === "*" || seg === String(issue[i]));
+}
+
+/**
+ * Routes `~standard` validation issues to the controls a renderer stamped -- the
+ * handler's join, executed. Each issue's path (a runtime instance like
+ * `tags.2.label`) binds to a control key (a canonical template like
+ * `tags.*.label`) by wildcard, so an array-row error finds the right control. An
+ * issue matching no control is returned with `control` undefined, never dropped.
+ */
+export function route(controls: Control[], issues: readonly Issue[]): Binding[] {
+  return issues.map((issue) => {
+    const segments = normalize(issue.path ?? []);
+    return {
+      key: segments.join("."),
+      message: issue.message,
+      control: controls.find((c) => binds(c.key, segments)),
+    };
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,8 +30,9 @@ export { emitField, writeSchema } from "./schema-writer";
 // The plugin engine's public contract (form-word types) and the `render` fold.
 // The internal join (`controlPaths`) / match engine (`matches`, `resolveConfig`)
 // are NOT exported -- the plugin API never surfaces a CS term.
-export { render, renderForm, validateRenderer } from "./engine";
+export { render, renderForm, route, validateRenderer } from "./engine";
 export type {
+  Binding,
   Bound,
   Child,
   Composer,
@@ -40,6 +41,7 @@ export type {
   Entry,
   Handler,
   Input,
+  Issue,
   Match,
   Renderer,
   Setting,

--- a/test/engine/route.test.ts
+++ b/test/engine/route.test.ts
@@ -34,6 +34,17 @@ describe("route -- the join executed (#224)", () => {
     expect(b.control?.key).toBe("tags.*.label");
   });
 
+  it("binds a record-key issue to the * template by wildcard", () => {
+    // A record's value control uses the same "*" slot as an array row, so a
+    // string key must bind exactly as a numeric index does.
+    const recordControls = controlPaths(
+      introspect(asSchema(z.object({ prefs: z.record(z.string(), z.string().min(1)) })), OPTS),
+    );
+    const [b] = route(recordControls, [{ message: "Too small", path: ["prefs", "theme"] }]);
+    expect(b.key).toBe("prefs.theme");
+    expect(b.control?.key).toBe("prefs.*");
+  });
+
   it("normalizes a {key}-wrapped path", () => {
     const [b] = route(controls, [
       { message: "x", path: [{ key: "tags" }, { key: 5 }, { key: "label" }] },

--- a/test/engine/route.test.ts
+++ b/test/engine/route.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod/v4";
+import { controlPaths } from "../../src/engine/paths";
+import { route } from "../../src/engine/route";
+import type { Issue } from "../../src/engine/route";
+import { introspect } from "../../src/introspection";
+
+const OPTS = { formName: "F", schemaImportPath: "./f", schemaExportName: "s" };
+const asSchema = (s: unknown) => s as Parameters<typeof introspect>[0];
+
+// Real controls (home.zip, tags.*.label) from a real descriptor -- no fakes.
+const controls = controlPaths(
+  introspect(
+    asSchema(
+      z.object({
+        home: z.object({ zip: z.string() }),
+        tags: z.array(z.object({ label: z.string() })),
+      }),
+    ),
+    OPTS,
+  ),
+);
+
+describe("route -- the join executed (#224)", () => {
+  it("binds an issue to a control by exact path", () => {
+    const [b] = route(controls, [{ message: "Required", path: ["home", "zip"] }]);
+    expect(b.key).toBe("home.zip");
+    expect(b.control?.key).toBe("home.zip");
+  });
+
+  it("binds an array-row issue to the * template by wildcard", () => {
+    const [b] = route(controls, [{ message: "Too small", path: ["tags", 2, "label"] }]);
+    expect(b.key).toBe("tags.2.label");
+    expect(b.control?.key).toBe("tags.*.label");
+  });
+
+  it("normalizes a {key}-wrapped path", () => {
+    const [b] = route(controls, [
+      { message: "x", path: [{ key: "tags" }, { key: 5 }, { key: "label" }] },
+    ]);
+    expect(b.control?.key).toBe("tags.*.label");
+  });
+
+  it("surfaces an unbound issue (control undefined), never dropping it", () => {
+    const [b] = route(controls, [{ message: "?", path: ["nope"] }]);
+    expect(b.control).toBeUndefined();
+    expect(b.message).toBe("?");
+  });
+
+  it("routes real Standard Schema issues from bad data", async () => {
+    const schema = z.object({
+      email: z.string().email(),
+      home: z.object({ zip: z.string().length(5) }),
+      tags: z.array(z.object({ label: z.string().min(1) })),
+    });
+    const cs = controlPaths(introspect(asSchema(schema), OPTS));
+    const bad = { email: "nope", home: { zip: "1" }, tags: [{ label: "ok" }, { label: "" }] };
+    const result = await schema["~standard"].validate(bad);
+    const issues: readonly Issue[] = "issues" in result && result.issues ? result.issues : [];
+
+    const bindings = route(cs, issues);
+    expect(bindings.length).toBeGreaterThan(0);
+    expect(bindings.every((b) => b.control !== undefined)).toBe(true); // all bound
+    const tagBinding = bindings.find((b) => b.key.startsWith("tags."));
+    expect(tagBinding?.control?.key).toBe("tags.*.label"); // array row -> * template
+  });
+});


### PR DESCRIPTION
## Summary

`route` makes the handler's join executable: it maps `~standard` validation issues back to the controls a renderer stamped, by path. Each issue's path (a runtime instance like `tags.2.label`) binds to a control's canonical key (a template like `tags.*.label`) via a segment-by-segment compare where `*` is the one wildcard, so array-row and record-key errors land on the right template control. It lives in `src/engine/route.ts` and is exported from the engine and the root; the binding type is named `Binding` to avoid colliding with the numeric-threshold `Bound` in `types.ts`.

## Acceptance criteria mapping

### 1. An exact nested path binds to its control
`route` calls `controls.find(c => binds(c.key, segments))`; `binds` splits the control key on `.` and compares segment-by-segment against the normalized issue path, requiring equal length. `home.zip` (two segments, no wildcard) matches only the control whose key is exactly `home.zip`, so a `["home","zip"]` issue binds there and nowhere shallower or deeper.
Evidence: `route.test.ts` "binds an issue to a control by exact path" asserts `b.control?.key === "home.zip"`.

### 2. An array-row / record-key issue binds to the `*` template by wildcard
In `binds`, a control segment of `"*"` short-circuits the equality (`seg === "*" || seg === String(issue[i])`), so any concrete index or key at that position matches. `controlPaths` emits array item and record value controls with `RECORD_VALUE = "*"` at the slot, so a runtime issue path `tags.2.label` binds to the control key `tags.*.label`; a record-key issue matches identically because record values use the same `*` slot.
Evidence: `route.test.ts` "binds an array-row issue to the * template by wildcard" asserts `tags.*.label` from `["tags", 2, "label"]`; "binds a record-key issue to the * template by wildcard" builds a `z.record` and asserts a string key `["prefs","theme"]` binds to `prefs.*`.

### 3. Raw `PathSegment[]` read, `{ key }` wrapper normalized
`normalize` maps each raw segment: if it is an object carrying `key`, it unwraps to that inner value, otherwise it takes the segment as-is; a numeric segment stays a number, everything else is stringified. This accepts both the raw `string | number` form `~standard` returns and the spec-permitted `{ key }`-wrapped form, collapsing both to a plain segment list before matching.
Evidence: `route.test.ts` "normalizes a {key}-wrapped path" feeds `[{key:"tags"},{key:5},{key:"label"}]` and binds it to `tags.*.label`.

### 4. Unbound issues surfaced, never dropped
`route` maps over every issue and always returns a `Binding`; when `controls.find` finds nothing, `control` is simply `undefined` on the returned binding, with the issue's key and message preserved. Nothing is filtered out, so an issue matching no control is visible to the caller rather than silently lost.
Evidence: `route.test.ts` "surfaces an unbound issue (control undefined), never dropping it" asserts `b.control` is `undefined` while `b.message` is retained.

### 5. Tested end-to-end against a real zod schema on bad data
The final test builds a real `z.object` with an email-format rule, a nested `home.zip` length rule, and an array of `{ label }` with a min-length rule, then runs the live `schema["~standard"].validate` on deliberately bad data and routes the returned issues against the real `controlPaths` of that schema. It asserts every issue binds to a control and that the array-row failure lands on `tags.*.label` — proving the join over genuine `~standard` output, not fixtures.
Evidence: `route.test.ts` "routes real Standard Schema issues from bad data" asserts `bindings.every(b => b.control !== undefined)` and the tag binding resolves to `tags.*.label`.

## Not done

Nothing out of scope for this issue. The deep-recursion join (paths deeper than a `recursive` boundary, e.g. `root.kids.0.kids.1.name`) is a named limit documented in the spec and deferred to a runtime test in the handler package; `route` matches whatever control keys `controlPaths` emits, so it needs no change when that limit is lifted.


Closes #224
