### PR TITLE
feat(#225): plugin conformance + fuzz harness

### DIFF
--- a/.changeset/conformance-harness.md
+++ b/.changeset/conformance-harness.md
@@ -1,0 +1,12 @@
+---
+"@rafters/kelex": minor
+---
+
+Add the plugin conformance harness (`conformance`). Runs the five contract
+invariants -- floor, totality, path-preservation, determinism, and handler-join
+-- over a shape battery plus seeded fuzzed schemas, so a plugin author (and
+kelex's own defaults) can prove a renderer/handler honors the contract.
+Path-preservation reads stamped names out of the actual rendered output via a
+caller-supplied `names` reader (the output `T` is opaque to the engine);
+handler-join validates crafted bad data with real Standard Schema and asserts
+every issue binds. Fuzzing targets the schema space, never a plugin's components.

--- a/src/conformance/battery.ts
+++ b/src/conformance/battery.ts
@@ -1,0 +1,91 @@
+import { z } from "zod/v4";
+import type { $ZodType } from "zod/v4/core";
+
+/**
+ * One schema in the conformance battery. `bad`, when present, is a value crafted
+ * to fail validation with LEAF-path issues only -- so `route` can bind every
+ * resulting issue to a control. The handler-join invariant runs only over cases
+ * that carry `bad` (see index.ts): generating targeted leaf-path bad data for an
+ * arbitrary fuzzed schema is not general, so real `~standard` bad data lives here.
+ */
+export interface BatteryCase {
+  name: string;
+  schema: $ZodType;
+  bad?: unknown;
+}
+
+// z-builder results are cast to the introspection input type; the schemas here
+// deliberately span every shape (scalar, group, list, choice, recursive) plus
+// optional/nullable wrappers, so the schema-only invariants see the whole space.
+const s = (schema: unknown): $ZodType => schema as $ZodType;
+
+type Category = { name: string; children: Category[] };
+const category: z.ZodType<Category> = z.lazy(() =>
+  z.object({ name: z.string(), children: z.array(category) }),
+);
+
+export const battery: BatteryCase[] = [
+  { name: "scalars", schema: s(z.object({ a: z.string(), b: z.number(), c: z.boolean() })) },
+  {
+    name: "string-formats",
+    schema: s(z.object({ email: z.email(), site: z.url() })),
+    // Both leaves fail their format -> two leaf-path issues (email, site).
+    bad: { email: "nope", site: "not a url" },
+  },
+  {
+    name: "nested-object",
+    schema: s(z.object({ home: z.object({ zip: z.string().length(5) }) })),
+    // A nested leaf constraint -> issue at ["home","zip"].
+    bad: { home: { zip: "1" } },
+  },
+  {
+    name: "array-of-objects",
+    schema: s(z.object({ tags: z.array(z.object({ label: z.string().min(1) })) })),
+    // An array-row leaf -> issue at ["tags",1,"label"], binds the "*" slot.
+    bad: { tags: [{ label: "ok" }, { label: "" }] },
+  },
+  {
+    name: "record",
+    schema: s(z.object({ prefs: z.record(z.string(), z.string().min(1)) })),
+    // A record value under a string key -> issue at ["prefs","theme"], binds "*".
+    bad: { prefs: { theme: "" } },
+  },
+  { name: "tuple", schema: s(z.object({ pair: z.tuple([z.string(), z.number()]) })) },
+  { name: "enum", schema: s(z.object({ role: z.enum(["admin", "user"]) })) },
+  {
+    name: "discriminated-union",
+    schema: s(
+      z.object({
+        shape: z.discriminatedUnion("kind", [
+          z.object({ kind: z.literal("circle"), radius: z.number() }),
+          z.object({ kind: z.literal("rect"), w: z.number(), h: z.number() }),
+        ]),
+      }),
+    ),
+  },
+  {
+    name: "plain-union",
+    schema: s(z.object({ id: z.union([z.string(), z.number()]) })),
+  },
+  {
+    // A discriminated union under an array slot: the discriminator control keys
+    // off `*` (e.g. `shapes.*.kind`), so path-preservation exercises the choice
+    // selector at a template position, not just at the top level.
+    name: "array-of-discriminated-union",
+    schema: s(
+      z.object({
+        shapes: z.array(
+          z.discriminatedUnion("kind", [
+            z.object({ kind: z.literal("circle"), radius: z.number() }),
+            z.object({ kind: z.literal("rect"), w: z.number() }),
+          ]),
+        ),
+      }),
+    ),
+  },
+  { name: "recursive", schema: s(z.object({ tree: category })) },
+  {
+    name: "optional-nullable",
+    schema: s(z.object({ note: z.string().optional(), tag: z.string().nullable() })),
+  },
+];

--- a/src/conformance/fuzz.ts
+++ b/src/conformance/fuzz.ts
@@ -1,0 +1,81 @@
+import { z } from "zod/v4";
+import type { $ZodType } from "zod/v4/core";
+
+/**
+ * A seeded schema fuzzer. It fuzzes the INPUT -- the schema space -- never a
+ * renderer's components, because kelex cannot know a plugin's components; the
+ * only testable surface of an open contract is the schema. Seeded (mulberry32)
+ * so a conformance failure reproduces from its seed. Stays within the shapes
+ * introspection handles (scalar/object/array/record/union/tuple/enum + optional).
+ */
+
+/** A small deterministic PRNG -- same seed, same schema stream. */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const leaf = (rng: () => number): $ZodType => {
+  const pick = Math.floor(rng() * 5);
+  switch (pick) {
+    case 0:
+      return z.string() as unknown as $ZodType;
+    case 1:
+      return z.number() as unknown as $ZodType;
+    case 2:
+      return z.boolean() as unknown as $ZodType;
+    case 3:
+      return z.email() as unknown as $ZodType;
+    default:
+      return z.enum(["a", "b", "c"]) as unknown as $ZodType;
+  }
+};
+
+/** Build one random schema, recursing until `depth` runs out (then a leaf). */
+function build(rng: () => number, depth: number): $ZodType {
+  if (depth <= 0) return leaf(rng);
+  const pick = Math.floor(rng() * 6);
+  const child = () => build(rng, depth - 1);
+  switch (pick) {
+    case 0: {
+      const n = 2 + Math.floor(rng() * 2);
+      const shape: Record<string, $ZodType> = {};
+      for (let i = 0; i < n; i++) {
+        const f = child();
+        shape[`f${i}`] = (rng() < 0.25 ? z.optional(f as never) : f) as unknown as $ZodType;
+      }
+      return z.object(shape as never) as unknown as $ZodType;
+    }
+    case 1:
+      return z.array(child() as never) as unknown as $ZodType;
+    case 2:
+      return z.record(z.string(), child() as never) as unknown as $ZodType;
+    case 3:
+      return z.tuple([child(), child()] as never) as unknown as $ZodType;
+    case 4:
+      return z.union([child(), child()] as never) as unknown as $ZodType;
+    default:
+      return leaf(rng);
+  }
+}
+
+/** A stream of `count` random top-level object schemas from `seed`. */
+export function fuzzSchemas(seed: number, count: number): { name: string; schema: $ZodType }[] {
+  const rng = mulberry32(seed);
+  const out: { name: string; schema: $ZodType }[] = [];
+  for (let i = 0; i < count; i++) {
+    const n = 1 + Math.floor(rng() * 3);
+    const shape: Record<string, $ZodType> = {};
+    for (let j = 0; j < n; j++) shape[`f${j}`] = build(rng, 3);
+    out.push({
+      name: `fuzz#${i}(seed=${seed})`,
+      schema: z.object(shape as never) as unknown as $ZodType,
+    });
+  }
+  return out;
+}

--- a/src/conformance/index.ts
+++ b/src/conformance/index.ts
@@ -1,0 +1,177 @@
+import { controlPaths } from "../engine/paths";
+import { validateRenderer } from "../engine/pipeline";
+import { render } from "../engine/render";
+import { route } from "../engine/route";
+import type { Handler, Renderer } from "../engine/types";
+import { introspect, type IntrospectOptions } from "../introspection";
+import { battery } from "./battery";
+import { fuzzSchemas } from "./fuzz";
+
+/** The five contract invariants a conforming plugin must honor. */
+export type Invariant = "floor" | "totality" | "path-preservation" | "handler-join" | "determinism";
+
+/** One invariant broken by one schema, with the detail needed to reproduce it. */
+export interface ConformanceFailure {
+  invariant: Invariant;
+  schema: string;
+  detail: string;
+}
+
+/** What conformance actually exercised -- surfaced so no coverage is silently capped. */
+export interface ConformanceCoverage {
+  /** Schemas run through the schema-only invariants (battery + fuzz). */
+  schemas: number;
+  /** Battery cases carrying crafted bad data -- the handler-join surface. */
+  handlerJoinCases: number;
+  /** Invariants that ran over every schema, only the battery, or once per renderer. */
+  everySchema: Invariant[];
+  batteryOnly: Invariant[];
+  rendererLevel: Invariant[];
+}
+
+export interface ConformanceReport {
+  passed: boolean;
+  failures: ConformanceFailure[];
+  coverage: ConformanceCoverage;
+}
+
+/**
+ * How to read the stamped control names out of a rendered `T`. Path-preservation
+ * asserts against the ACTUAL output, and `T` is opaque to the engine, so the
+ * caller supplies the reader (regex `name="..."` for a string renderer, a tree
+ * walk for a structured one). Deliberately NOT part of `Renderer<T>` -- it is a
+ * conformance concern, not the runtime contract a plugin ships.
+ */
+export interface ConformanceOptions<T> {
+  names: (rendered: T) => string[];
+  /** Fuzzer seed (default 1) -- a failure reproduces from it. */
+  seed?: number;
+  /** How many random schemas to fuzz (default 25). */
+  fuzzCount?: number;
+}
+
+const OPTS: IntrospectOptions = {
+  formName: "ConformanceForm",
+  schemaImportPath: "./schema",
+  schemaExportName: "schema",
+};
+
+/** `~standard`'s validate surface, narrowed from the schema without a hard zod dep. */
+interface StandardValidatable {
+  "~standard": {
+    validate: (
+      value: unknown,
+    ) =>
+      | { issues?: readonly { message: string; path?: readonly unknown[] }[] }
+      | Promise<{ issues?: readonly { message: string; path?: readonly unknown[] }[] }>;
+  };
+}
+
+const serialize = (value: unknown): string => JSON.stringify(value);
+
+/**
+ * Prove a plugin honors the contract. Runs the five invariants over a shape
+ * battery plus fuzzed schemas: FLOOR (the renderer covers every FieldType),
+ * TOTALITY (no field falls to `fallback`), PATH-PRESERVATION (every control path
+ * appears as a stamped name in the OUTPUT), DETERMINISM (two renders are
+ * identical), and HANDLER-JOIN (real bad data validates and every issue binds).
+ * Floor is renderer-level and short-circuits (a floor gap dooms totality too, so
+ * report it alone). Handler-join needs crafted leaf-path bad data, so it runs
+ * over the battery only; the fuzzer drives the other three. Returns the failures
+ * and a coverage summary -- nothing is silently skipped.
+ */
+export async function conformance<T>(
+  renderer: Renderer<T>,
+  handler: Handler<T> | undefined,
+  options: ConformanceOptions<T>,
+): Promise<ConformanceReport> {
+  const { names, seed = 1, fuzzCount = 25 } = options;
+  const failures: ConformanceFailure[] = [];
+  const coverage: ConformanceCoverage = {
+    schemas: 0,
+    handlerJoinCases: 0,
+    everySchema: ["totality", "path-preservation", "determinism"],
+    batteryOnly: ["handler-join"],
+    rendererLevel: ["floor"],
+  };
+
+  // FLOOR -- renderer-level, once. A gap here means fields will fall to fallback,
+  // so report floor alone rather than drowning it in totality noise.
+  const gaps = validateRenderer(renderer);
+  if (gaps.length > 0) {
+    return {
+      passed: false,
+      failures: gaps.map((detail) => ({ invariant: "floor", schema: "(renderer)", detail })),
+      coverage,
+    };
+  }
+
+  const schemas = [...battery, ...fuzzSchemas(seed, fuzzCount)];
+  coverage.schemas = schemas.length;
+
+  for (const { name, schema } of schemas) {
+    const descriptor = introspect(schema, OPTS);
+    const controlKeys = controlPaths(descriptor).map((c) => c.key);
+
+    // DETERMINISM -- two renders, byte-identical once serialized.
+    const first = render(descriptor, renderer);
+    const second = render(descriptor, renderer);
+    if (serialize(first) !== serialize(second)) {
+      failures.push({ invariant: "determinism", schema: name, detail: "two renders differ" });
+    }
+
+    // TOTALITY -- probe fallback; a conforming renderer never reaches it here.
+    let fellBack = false;
+    render(descriptor, {
+      ...renderer,
+      fallback: (input) => {
+        fellBack = true;
+        return renderer.fallback(input);
+      },
+    });
+    if (fellBack) {
+      failures.push({ invariant: "totality", schema: name, detail: "a field hit fallback" });
+    }
+
+    // PATH-PRESERVATION -- read names from the ACTUAL output (wired, if a handler
+    // is given: a handler must not drop a control either).
+    const output = handler ? handler.wire(first, controlPaths(descriptor), descriptor) : first;
+    const stamped = new Set(names(output));
+    const missing = controlKeys.filter((k) => !stamped.has(k));
+    if (missing.length > 0) {
+      failures.push({
+        invariant: "path-preservation",
+        schema: name,
+        detail: `unstamped control(s): ${missing.join(", ")}`,
+      });
+    }
+  }
+
+  // HANDLER-JOIN -- battery cases with crafted bad data only. Real `~standard`
+  // validation; every resulting issue must bind to a control (none unbound).
+  for (const { name, schema, bad } of battery) {
+    if (bad === undefined) continue;
+    coverage.handlerJoinCases++;
+    const descriptor = introspect(schema, OPTS);
+    const result = await (schema as unknown as StandardValidatable)["~standard"].validate(bad);
+    const issues = result.issues ?? [];
+    if (issues.length === 0) {
+      failures.push({
+        invariant: "handler-join",
+        schema: name,
+        detail: "bad data produced no issues",
+      });
+      continue;
+    }
+    const unbound = route(controlPaths(descriptor), issues).filter((b) => b.control === undefined);
+    if (unbound.length > 0) {
+      failures.push({
+        invariant: "handler-join",
+        schema: name,
+        detail: `unbound issue(s): ${unbound.map((b) => b.key).join(", ")}`,
+      });
+    }
+  }
+
+  return { passed: failures.length === 0, failures, coverage };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,18 @@ export type {
   Variant,
 } from "./engine";
 
+// The conformance harness: prove a plugin honors the contract. A testing tool
+// (it takes a `names` reader for the opaque `T`), not part of the runtime
+// contract -- exported so plugin authors and kelex's own defaults can run it.
+export { conformance } from "./conformance";
+export type {
+  ConformanceCoverage,
+  ConformanceFailure,
+  ConformanceOptions,
+  ConformanceReport,
+  Invariant,
+} from "./conformance";
+
 export type {
   CodegenTarget,
   CompositeOptions,

--- a/test/conformance/conformance.test.ts
+++ b/test/conformance/conformance.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod/v4";
+import { conformance } from "../../src/conformance";
+import type { FieldType } from "../../src/introspection/types";
+import type { Composer, Entry, Input, Renderer } from "../../src/engine/types";
+
+// A minimal COMPLETE renderer whose T is a string. Every FieldType gets a
+// type-only catch-all (the floor), and every composer stamps `name="<key>"` so
+// the conformance names-reader can find it in the output.
+const ALL_TYPES: FieldType[] = [
+  "string",
+  "number",
+  "boolean",
+  "date",
+  "enum",
+  "literal",
+  "object",
+  "array",
+  "union",
+  "tuple",
+  "record",
+  "ref",
+];
+
+const COMPONENT: Record<FieldType, string> = {
+  string: "control",
+  number: "control",
+  boolean: "control",
+  date: "control",
+  enum: "control",
+  literal: "control",
+  object: "group",
+  tuple: "group",
+  array: "list",
+  record: "list",
+  union: "choice",
+  ref: "recursive",
+};
+
+const inventory: Entry[] = ALL_TYPES.map((type) => ({
+  match: { type },
+  component: COMPONENT[type],
+}));
+
+const kids = (input: Extract<Input<string>, { shape: "group" }>) =>
+  input.children.map((c) => c.rendered).join("");
+
+function composers(): Record<string, Composer<string>> {
+  return {
+    control: (i) => `<control name="${i.key}"/>`,
+    group: (i) => (i.shape === "group" ? `<group name="${i.key}">${kids(i)}</group>` : ""),
+    list: (i) => (i.shape === "list" ? `<list name="${i.key}">${i.item.rendered}</list>` : ""),
+    choice: (i) => {
+      if (i.shape !== "choice") return "";
+      // A discriminated union's discriminator is the selector, dropped from the
+      // variant children by the fold -- so the choice composer stamps it here, at
+      // `<key>.<discriminator>`. controlPaths lists it, so path-preservation
+      // forces a conforming renderer to actually render the selector.
+      const disc = i.field.metadata.kind === "union" ? i.field.metadata.discriminator : undefined;
+      const selector = disc ? `<control name="${i.key}.${disc}"/>` : "";
+      const variants = i.variants.flatMap((v) => v.children.map((c) => c.rendered)).join("");
+      return `<choice name="${i.key}">${selector}${variants}</choice>`;
+    },
+    recursive: (i) => `<recursive name="${i.key}"/>`,
+  };
+}
+
+const complete: Renderer<string> = {
+  inventory,
+  compose: composers(),
+  form: (children) => `<form>${children.map((c) => c.rendered).join("")}</form>`,
+  fallback: (i) => `<fallback name="${i.key}"/>`,
+};
+
+// Reads stamped names out of the string output.
+const names = (rendered: string) => [...rendered.matchAll(/name="([^"]+)"/g)].map((m) => m[1]);
+
+describe("conformance -- the contract, proven (#225)", () => {
+  it("passes for a complete renderer, running all five invariants", async () => {
+    const report = await conformance(complete, undefined, { names, fuzzCount: 20 });
+    expect(report.passed).toBe(true);
+    expect(report.failures).toEqual([]);
+    // AC1: the five invariants ran over battery + fuzz, and handler-join over the battery.
+    expect(report.coverage.schemas).toBeGreaterThan(20);
+    expect(report.coverage.handlerJoinCases).toBeGreaterThan(0);
+    expect(report.coverage.everySchema).toContain("path-preservation");
+    expect(report.coverage.batteryOnly).toEqual(["handler-join"]);
+    // All five invariants are accounted for -- none silently skipped.
+    const ran = [
+      ...report.coverage.everySchema,
+      ...report.coverage.batteryOnly,
+      ...report.coverage.rendererLevel,
+    ];
+    expect([...ran].sort()).toEqual(
+      ["determinism", "floor", "handler-join", "path-preservation", "totality"].sort(),
+    );
+  });
+
+  it("FAILS naming floor for a renderer missing a type-only catch-all", async () => {
+    // Drop the "date" catch-all -- the floor gap.
+    const broken: Renderer<string> = {
+      ...complete,
+      inventory: inventory.filter((e) => e.match.type !== "date"),
+    };
+    const report = await conformance(broken, undefined, { names, fuzzCount: 5 });
+    expect(report.passed).toBe(false);
+    expect(report.failures.every((f) => f.invariant === "floor")).toBe(true);
+    expect(report.failures.some((f) => f.detail.includes("date"))).toBe(true);
+  });
+
+  it("FAILS naming path-preservation for a renderer that drops a field", async () => {
+    // A group composer that omits its first child -> a leaf never reaches output.
+    const dropped: Renderer<string> = {
+      ...complete,
+      compose: {
+        ...composers(),
+        group: (i) =>
+          i.shape === "group"
+            ? `<group name="${i.key}">${i.children
+                .slice(1)
+                .map((c) => c.rendered)
+                .join("")}</group>`
+            : "",
+      },
+    };
+    const report = await conformance(dropped, undefined, { names, fuzzCount: 0 });
+    expect(report.passed).toBe(false);
+    expect(report.failures.some((f) => f.invariant === "path-preservation")).toBe(true);
+  });
+
+  it("FAILS naming path-preservation for a choice composer that omits the selector", async () => {
+    // The discriminator (`shape.kind`) is a real control listed by controlPaths
+    // but dropped from the variant children -- a choice composer that does not
+    // stamp its selector loses it. This locks that implicit contract clause.
+    const noSelector: Renderer<string> = {
+      ...complete,
+      compose: {
+        ...composers(),
+        choice: (i) =>
+          i.shape === "choice"
+            ? `<choice name="${i.key}">${i.variants
+                .flatMap((v) => v.children.map((c) => c.rendered))
+                .join("")}</choice>`
+            : "",
+      },
+    };
+    const report = await conformance(noSelector, undefined, { names, fuzzCount: 0 });
+    expect(report.passed).toBe(false);
+    const pp = report.failures.filter((f) => f.invariant === "path-preservation");
+    expect(pp.some((f) => f.detail.includes(".kind"))).toBe(true);
+  });
+
+  it("FAILS naming path-preservation for a handler that drops a control", async () => {
+    // A handler that strips every stamped name -> the join is lost.
+    const stripping = { wire: (form: string) => form.replace(/ name="[^"]+"/g, "") };
+    const report = await conformance(complete, stripping, { names, fuzzCount: 3 });
+    expect(report.passed).toBe(false);
+    expect(report.failures.some((f) => f.invariant === "path-preservation")).toBe(true);
+  });
+
+  it("reproduces from a seed -- same seed, same schemas, same verdict", async () => {
+    const a = await conformance(complete, undefined, { names, seed: 42, fuzzCount: 10 });
+    const b = await conformance(complete, undefined, { names, seed: 42, fuzzCount: 10 });
+    expect(a).toEqual(b);
+  });
+
+  it("binds real Standard Schema issues from the battery's bad data", async () => {
+    // The handler-join battery: bad data on email/nested/array-row/record cases,
+    // every issue bound. Proven here directly with one of the battery shapes.
+    const schema = z.object({ tags: z.array(z.object({ label: z.string().min(1) })) });
+    const result = await schema["~standard"].validate({ tags: [{ label: "" }] });
+    expect("issues" in result && result.issues && result.issues.length).toBeTruthy();
+    // The full battery is exercised inside conformance; the complete-renderer run
+    // above asserts passed === true, i.e. every battery issue bound.
+    const report = await conformance(complete, undefined, { names, fuzzCount: 0 });
+    expect(report.failures.some((f) => f.invariant === "handler-join")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`conformance(renderer, handler?, { names })` proves a plugin honors the engine contract. Because kelex cannot know a plugin's components, the only testable surface of an open API is the contract against the schema space -- so the harness runs five invariants over a hand-built shape battery plus seeded, reproducible fuzzed schemas, fuzzing the INPUT (the schema space) and never the components. It returns the failing invariant(s) with the schema that broke them, plus a coverage summary so nothing is silently skipped.

## Acceptance criteria mapping

### 1. Runs the five invariants over a shape battery plus fuzzed schemas
`conformance` concatenates the battery (`src/conformance/battery.ts` -- scalar, string-formats, nested object, array-of-objects, record, tuple, enum, discriminated + plain union, recursive, optional/nullable, array-of-discriminated-union) with `fuzzSchemas(seed, fuzzCount)` and runs totality, path-preservation, and determinism over every schema; floor once at the renderer level; handler-join over the battery's bad-data cases. The returned `coverage` accounts for all five invariants (`everySchema` + `batteryOnly` + `rendererLevel`) so a caller can confirm none was skipped.
Evidence: `conformance.test.ts` "passes for a complete renderer, running all five invariants" asserts `coverage.schemas > 20`, `coverage.handlerJoinCases > 0`, and that the union of the three coverage lists equals all five invariant names.

### 2. Passes for a complete renderer and FAILS -- naming the invariant -- for a broken one
A complete string-emitting test-double renderer (type-only catch-all per FieldType, a composer per component) yields `passed: true`. Two deliberately broken renderers fail with the right name: one missing the `date` catch-all reports only `floor` (short-circuited before per-schema work); one whose group composer drops its first child reports `path-preservation`. The harness names the specific invariant on each `ConformanceFailure`, not a generic failure.
Evidence: `conformance.test.ts` "FAILS naming floor for a renderer missing a type-only catch-all" (every failure `invariant === "floor"`, detail includes "date") and "FAILS naming path-preservation for a renderer that drops a field".

### 3. Path-preservation asserts controlPaths(d) is a subset of the stamped names in the rendered output
The output `T` is opaque to the engine, so the caller supplies a `names(rendered): string[]` reader; path-preservation renders the descriptor, reads the stamped names out of the ACTUAL output (the wired output when a handler is given), and reports any control key from `controlPaths(d)` not present. This is what forces a choice composer to actually stamp a discriminated union's discriminator selector -- a control `controlPaths` lists but the fold drops from variant children.
Evidence: `conformance.test.ts` "FAILS naming path-preservation for a handler that drops a control" (a handler stripping every `name` loses the join) and "...for a choice composer that omits the selector" (detail includes `.kind`).

### 4. The handler-join invariant validates bad data and asserts every issue binds
For each battery case carrying crafted leaf-path `bad` data, the harness runs the real `schema["~standard"].validate(bad)`, routes the resulting issues against `controlPaths(d)` via `route`, and fails if any issue is unbound. The bad data spans an email-format failure, a nested field, an array row, and a record key -- exactly the join's hard cases. Handler-join is battery-scoped (crafted leaf-path bad data is not general over fuzzed schemas), and that scoping is surfaced in `coverage.batteryOnly`, not hidden.
Evidence: `conformance.test.ts` "binds real Standard Schema issues from the battery's bad data" asserts no `handler-join` failure for the complete renderer; `battery.ts` carries `bad` on the string-formats/nested/array/record cases.

### 5. Determinism asserts two renders of the same descriptor are identical
For every schema, `conformance` renders the descriptor twice with the same renderer and compares the serialized outputs; a mismatch is a `determinism` failure. Reproducibility extends to the whole run: the fuzzer is seeded (mulberry32), so the same seed yields the same schema stream and the same verdict.
Evidence: `conformance.test.ts` "reproduces from a seed -- same seed, same schemas, same verdict" asserts two seeded runs are deeply equal; determinism is checked at `index.ts` via `serialize(first) !== serialize(second)`.

## Not done

No base-HTML renderer or handler here -- the complete/broken renderers are inline string test-doubles, which is all the harness needs; the real defaults are #226/#228/#227 and will run this harness as their baseline. The harness also surfaced an implicit contract clause (a choice composer must stamp the discriminator selector at `<key>.<discriminator>`); making the fold hand the choice Input a first-class discriminator child is an engine change touching #221/#222 and is filed separately, not scoped into #225.

Closes #225
