### PR TITLE
feat(#226): default base-HTML leaf controls

### DIFF
--- a/.changeset/renderer-html-leaf.md
+++ b/.changeset/renderer-html-leaf.md
@@ -1,0 +1,15 @@
+---
+"@rafters/kelex": minor
+---
+
+Add the default base-HTML renderer -- leaf half (`htmlRenderer`). A
+zero-dependency, classless renderer whose ordered inventory is the canonical
+reference: format (email/url), meta-hint (password/otp/tel), and
+constraint-bucket (long string -> textarea, bounded number -> range)
+specializations sit above a type-only catch-all for every scalar FieldType.
+Every control emits the hook trio (`name` = path, injective `id = pathToId`,
+`data-path`), native validation attributes from the schema's constraints, a
+`<label for>`, the aria pair, and a path-addressed error slot -- inert markup,
+no behavior. Also adds a `types` scope to `conformance`/`validateRenderer` so a
+leaf-only renderer proves itself against the scalar shapes. Containers, the real
+`<form action>`, buttons, and the stylesheet are the container half (#228).

--- a/src/conformance/battery.ts
+++ b/src/conformance/battery.ts
@@ -1,5 +1,6 @@
 import { z } from "zod/v4";
 import type { $ZodType } from "zod/v4/core";
+import type { FieldType } from "../introspection/types";
 
 /**
  * One schema in the conformance battery. `bad`, when present, is a value crafted
@@ -7,10 +8,15 @@ import type { $ZodType } from "zod/v4/core";
  * resulting issue to a control. The handler-join invariant runs only over cases
  * that carry `bad` (see index.ts): generating targeted leaf-path bad data for an
  * arbitrary fuzzed schema is not general, so real `~standard` bad data lives here.
+ *
+ * `uses` lists the FieldTypes the case contains (excluding the top-level object
+ * that becomes the form). A `types`-scoped conformance run keeps only cases whose
+ * `uses` is a subset -- so a leaf-only renderer sees only leaf-shaped schemas.
  */
 export interface BatteryCase {
   name: string;
   schema: $ZodType;
+  uses: FieldType[];
   bad?: unknown;
 }
 
@@ -25,33 +31,50 @@ const category: z.ZodType<Category> = z.lazy(() =>
 );
 
 export const battery: BatteryCase[] = [
-  { name: "scalars", schema: s(z.object({ a: z.string(), b: z.number(), c: z.boolean() })) },
+  {
+    name: "scalars",
+    schema: s(z.object({ a: z.string(), b: z.number(), c: z.boolean() })),
+    uses: ["string", "number", "boolean"],
+  },
   {
     name: "string-formats",
     schema: s(z.object({ email: z.email(), site: z.url() })),
+    uses: ["string"],
     // Both leaves fail their format -> two leaf-path issues (email, site).
     bad: { email: "nope", site: "not a url" },
   },
   {
     name: "nested-object",
     schema: s(z.object({ home: z.object({ zip: z.string().length(5) }) })),
+    uses: ["object", "string"],
     // A nested leaf constraint -> issue at ["home","zip"].
     bad: { home: { zip: "1" } },
   },
   {
     name: "array-of-objects",
     schema: s(z.object({ tags: z.array(z.object({ label: z.string().min(1) })) })),
+    uses: ["array", "object", "string"],
     // An array-row leaf -> issue at ["tags",1,"label"], binds the "*" slot.
     bad: { tags: [{ label: "ok" }, { label: "" }] },
   },
   {
     name: "record",
     schema: s(z.object({ prefs: z.record(z.string(), z.string().min(1)) })),
+    uses: ["record", "string"],
     // A record value under a string key -> issue at ["prefs","theme"], binds "*".
     bad: { prefs: { theme: "" } },
   },
-  { name: "tuple", schema: s(z.object({ pair: z.tuple([z.string(), z.number()]) })) },
-  { name: "enum", schema: s(z.object({ role: z.enum(["admin", "user"]) })) },
+  {
+    name: "tuple",
+    schema: s(z.object({ pair: z.tuple([z.string(), z.number()]) })),
+    uses: ["tuple", "string", "number"],
+  },
+  { name: "enum", schema: s(z.object({ role: z.enum(["admin", "user"]) })), uses: ["enum"] },
+  {
+    name: "date-literal",
+    schema: s(z.object({ born: z.date(), kind: z.literal("x") })),
+    uses: ["date", "literal"],
+  },
   {
     name: "discriminated-union",
     schema: s(
@@ -62,10 +85,12 @@ export const battery: BatteryCase[] = [
         ]),
       }),
     ),
+    uses: ["union", "object", "literal", "number"],
   },
   {
     name: "plain-union",
     schema: s(z.object({ id: z.union([z.string(), z.number()]) })),
+    uses: ["union", "string", "number"],
   },
   {
     // A discriminated union under an array slot: the discriminator control keys
@@ -82,10 +107,16 @@ export const battery: BatteryCase[] = [
         ),
       }),
     ),
+    uses: ["array", "union", "object", "literal", "number"],
   },
-  { name: "recursive", schema: s(z.object({ tree: category })) },
+  {
+    name: "recursive",
+    schema: s(z.object({ tree: category })),
+    uses: ["object", "string", "array", "ref"],
+  },
   {
     name: "optional-nullable",
     schema: s(z.object({ note: z.string().optional(), tag: z.string().nullable() })),
+    uses: ["string"],
   },
 ];

--- a/src/conformance/fuzz.ts
+++ b/src/conformance/fuzz.ts
@@ -29,6 +29,8 @@ const LEAVES: { type: FieldType; make: () => $ZodType }[] = [
   { type: "number", make: () => z.number() as unknown as $ZodType },
   { type: "boolean", make: () => z.boolean() as unknown as $ZodType },
   { type: "enum", make: () => z.enum(["a", "b", "c"]) as unknown as $ZodType },
+  { type: "date", make: () => z.date() as unknown as $ZodType },
+  { type: "literal", make: () => z.literal("x") as unknown as $ZodType },
 ];
 
 const pick = <A>(rng: () => number, xs: A[]): A => xs[Math.floor(rng() * xs.length)];
@@ -72,6 +74,8 @@ const ALL: FieldType[] = [
   "number",
   "boolean",
   "enum",
+  "date",
+  "literal",
   "object",
   "array",
   "record",

--- a/src/conformance/fuzz.ts
+++ b/src/conformance/fuzz.ts
@@ -1,5 +1,6 @@
 import { z } from "zod/v4";
 import type { $ZodType } from "zod/v4/core";
+import type { FieldType } from "../introspection/types";
 
 /**
  * A seeded schema fuzzer. It fuzzes the INPUT -- the schema space -- never a
@@ -20,29 +21,30 @@ function mulberry32(seed: number): () => number {
   };
 }
 
-const leaf = (rng: () => number): $ZodType => {
-  const pick = Math.floor(rng() * 5);
-  switch (pick) {
-    case 0:
-      return z.string() as unknown as $ZodType;
-    case 1:
-      return z.number() as unknown as $ZodType;
-    case 2:
-      return z.boolean() as unknown as $ZodType;
-    case 3:
-      return z.email() as unknown as $ZodType;
-    default:
-      return z.enum(["a", "b", "c"]) as unknown as $ZodType;
-  }
-};
+// Each generator is tagged with the FieldType it produces, so a `types` scope can
+// keep only the allowed ones (e.g. leaves only for a leaf-renderer baseline).
+const LEAVES: { type: FieldType; make: () => $ZodType }[] = [
+  { type: "string", make: () => z.string() as unknown as $ZodType },
+  { type: "string", make: () => z.email() as unknown as $ZodType },
+  { type: "number", make: () => z.number() as unknown as $ZodType },
+  { type: "boolean", make: () => z.boolean() as unknown as $ZodType },
+  { type: "enum", make: () => z.enum(["a", "b", "c"]) as unknown as $ZodType },
+];
 
-/** Build one random schema, recursing until `depth` runs out (then a leaf). */
-function build(rng: () => number, depth: number): $ZodType {
-  if (depth <= 0) return leaf(rng);
-  const pick = Math.floor(rng() * 6);
-  const child = () => build(rng, depth - 1);
-  switch (pick) {
-    case 0: {
+const pick = <A>(rng: () => number, xs: A[]): A => xs[Math.floor(rng() * xs.length)];
+
+/**
+ * Build one random schema. `allowed` restricts BOTH the leaves and the container
+ * shapes it may emit; when no container is allowed (a leaf-only scope) it always
+ * returns a leaf, so a scoped run never produces a shape the renderer disowns.
+ */
+function build(rng: () => number, depth: number, allowed: Set<FieldType>): $ZodType {
+  const leaves = LEAVES.filter((l) => allowed.has(l.type));
+  const makeLeaf = () => pick(rng, leaves.length > 0 ? leaves : LEAVES).make();
+  const child = () => build(rng, depth - 1, allowed);
+  const containers: (() => $ZodType)[] = [];
+  if (depth > 0 && allowed.has("object")) {
+    containers.push(() => {
       const n = 2 + Math.floor(rng() * 2);
       const shape: Record<string, $ZodType> = {};
       for (let i = 0; i < n; i++) {
@@ -50,28 +52,46 @@ function build(rng: () => number, depth: number): $ZodType {
         shape[`f${i}`] = (rng() < 0.25 ? z.optional(f as never) : f) as unknown as $ZodType;
       }
       return z.object(shape as never) as unknown as $ZodType;
-    }
-    case 1:
-      return z.array(child() as never) as unknown as $ZodType;
-    case 2:
-      return z.record(z.string(), child() as never) as unknown as $ZodType;
-    case 3:
-      return z.tuple([child(), child()] as never) as unknown as $ZodType;
-    case 4:
-      return z.union([child(), child()] as never) as unknown as $ZodType;
-    default:
-      return leaf(rng);
+    });
   }
+  if (depth > 0 && allowed.has("array"))
+    containers.push(() => z.array(child() as never) as unknown as $ZodType);
+  if (depth > 0 && allowed.has("record"))
+    containers.push(() => z.record(z.string(), child() as never) as unknown as $ZodType);
+  if (depth > 0 && allowed.has("tuple"))
+    containers.push(() => z.tuple([child(), child()] as never) as unknown as $ZodType);
+  if (depth > 0 && allowed.has("union"))
+    containers.push(() => z.union([child(), child()] as never) as unknown as $ZodType);
+  // Bias toward leaves so trees stay shallow; half the picks are a plain leaf.
+  const choices: (() => $ZodType)[] = [makeLeaf, ...containers];
+  return pick(rng, choices)();
 }
 
-/** A stream of `count` random top-level object schemas from `seed`. */
-export function fuzzSchemas(seed: number, count: number): { name: string; schema: $ZodType }[] {
+const ALL: FieldType[] = [
+  "string",
+  "number",
+  "boolean",
+  "enum",
+  "object",
+  "array",
+  "record",
+  "tuple",
+  "union",
+];
+
+/** A stream of `count` random top-level object schemas from `seed`, scoped to `types`. */
+export function fuzzSchemas(
+  seed: number,
+  count: number,
+  types?: readonly FieldType[],
+): { name: string; schema: $ZodType }[] {
   const rng = mulberry32(seed);
+  const allowed = new Set<FieldType>(types ?? ALL);
   const out: { name: string; schema: $ZodType }[] = [];
   for (let i = 0; i < count; i++) {
     const n = 1 + Math.floor(rng() * 3);
     const shape: Record<string, $ZodType> = {};
-    for (let j = 0; j < n; j++) shape[`f${j}`] = build(rng, 3);
+    for (let j = 0; j < n; j++) shape[`f${j}`] = build(rng, 3, allowed);
     out.push({
       name: `fuzz#${i}(seed=${seed})`,
       schema: z.object(shape as never) as unknown as $ZodType,

--- a/src/conformance/index.ts
+++ b/src/conformance/index.ts
@@ -4,6 +4,7 @@ import { render } from "../engine/render";
 import { route } from "../engine/route";
 import type { Handler, Renderer } from "../engine/types";
 import { introspect, type IntrospectOptions } from "../introspection";
+import type { FieldType } from "../introspection/types";
 import { battery } from "./battery";
 import { fuzzSchemas } from "./fuzz";
 
@@ -48,6 +49,13 @@ export interface ConformanceOptions<T> {
   seed?: number;
   /** How many random schemas to fuzz (default 25). */
   fuzzCount?: number;
+  /**
+   * Scope the run to a subset of FieldTypes -- the floor checks only these
+   * catch-alls, the battery keeps only cases whose shapes fit, and the fuzzer
+   * emits only these. A leaf-only renderer proves itself against the scalar
+   * types without owning a container composer it does not have yet.
+   */
+  types?: FieldType[];
 }
 
 const OPTS: IntrospectOptions = {
@@ -85,7 +93,7 @@ export async function conformance<T>(
   handler: Handler<T> | undefined,
   options: ConformanceOptions<T>,
 ): Promise<ConformanceReport> {
-  const { names, seed = 1, fuzzCount = 25 } = options;
+  const { names, seed = 1, fuzzCount = 25, types } = options;
   const failures: ConformanceFailure[] = [];
   const coverage: ConformanceCoverage = {
     schemas: 0,
@@ -95,9 +103,10 @@ export async function conformance<T>(
     rendererLevel: ["floor"],
   };
 
-  // FLOOR -- renderer-level, once. A gap here means fields will fall to fallback,
-  // so report floor alone rather than drowning it in totality noise.
-  const gaps = validateRenderer(renderer);
+  // FLOOR -- renderer-level, once (scoped to `types` when given). A gap here means
+  // fields will fall to fallback, so report floor alone rather than drowning it in
+  // totality noise.
+  const gaps = validateRenderer(renderer, types);
   if (gaps.length > 0) {
     return {
       passed: false,
@@ -106,7 +115,13 @@ export async function conformance<T>(
     };
   }
 
-  const schemas = [...battery, ...fuzzSchemas(seed, fuzzCount)];
+  // A `types` scope keeps only battery cases whose shapes fit, and fuzzes within
+  // those types -- so a leaf-only renderer never sees a container it disowns.
+  const allowed = types && new Set(types);
+  const scopedBattery = allowed
+    ? battery.filter((c) => c.uses.every((t) => allowed.has(t)))
+    : battery;
+  const schemas = [...scopedBattery, ...fuzzSchemas(seed, fuzzCount, types)];
   coverage.schemas = schemas.length;
 
   for (const { name, schema } of schemas) {
@@ -147,9 +162,9 @@ export async function conformance<T>(
     }
   }
 
-  // HANDLER-JOIN -- battery cases with crafted bad data only. Real `~standard`
-  // validation; every resulting issue must bind to a control (none unbound).
-  for (const { name, schema, bad } of battery) {
+  // HANDLER-JOIN -- battery cases with crafted bad data only (within the type
+  // scope). Real `~standard` validation; every resulting issue must bind.
+  for (const { name, schema, bad } of scopedBattery) {
     if (bad === undefined) continue;
     coverage.handlerJoinCases++;
     const descriptor = introspect(schema, OPTS);

--- a/src/engine/pipeline.ts
+++ b/src/engine/pipeline.ts
@@ -30,11 +30,13 @@ function isTypeOnly(m: Match): boolean {
  * is precise: a constrained entry (`string` + a length bucket) does NOT prove
  * the bare `string` type is handled, so every `FieldType` needs a TYPE-ONLY
  * catch-all. Also checks every named component resolves to a composer. Returns
- * the gaps (empty when complete).
+ * the gaps (empty when complete). Pass `types` to scope the floor to a subset of
+ * FieldTypes -- a leaf-only renderer proves itself against the scalar types
+ * without a container catch-all it does not yet own.
  */
-export function validateRenderer<T>(renderer: Renderer<T>): string[] {
+export function validateRenderer<T>(renderer: Renderer<T>, types?: readonly FieldType[]): string[] {
   const gaps: string[] = [];
-  for (const type of ALL_FIELD_TYPES) {
+  for (const type of types ?? ALL_FIELD_TYPES) {
     if (!renderer.inventory.some((e) => e.match.type === type && isTypeOnly(e.match))) {
       gaps.push(`no type-only catch-all for FieldType "${type}"`);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,10 @@ export type {
   Variant,
 } from "./engine";
 
+// The default base-HTML renderer (leaf half, #226): a zero-dependency, classless
+// renderer shipped in-package. A true plugin -- imports only the public contract.
+export { htmlRenderer, pathToId } from "./renderers/html";
+
 // The conformance harness: prove a plugin honors the contract. A testing tool
 // (it takes a `names` reader for the opaque `T`), not part of the runtime
 // contract -- exported so plugin authors and kelex's own defaults can run it.

--- a/src/renderers/html/attrs.ts
+++ b/src/renderers/html/attrs.ts
@@ -61,8 +61,11 @@ export function validationAttrs(
     out.step = c.step ?? (c.isInt ? 1 : undefined);
   }
   if (field.type === "date") {
-    out.min = c.minDate;
-    out.max = c.maxDate;
+    // `<input type="date">` min/max require a bare `YYYY-MM-DD`; the constraint
+    // is an ISO datetime, so a full timestamp is treated as absent (the bound
+    // silently lost). Slice to the date portion.
+    out.min = c.minDate?.slice(0, 10);
+    out.max = c.maxDate?.slice(0, 10);
   }
   return out;
 }

--- a/src/renderers/html/attrs.ts
+++ b/src/renderers/html/attrs.ts
@@ -1,0 +1,80 @@
+import type { FieldDescriptor } from "../../introspection/types";
+import { pathToId } from "./path-id";
+
+/** Escape a string for safe use in HTML text or a double-quoted attribute value. */
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/** Render an attribute map to a string, skipping undefined values. */
+export function attrs(map: Record<string, string | number | boolean | undefined>): string {
+  const out: string[] = [];
+  for (const [k, v] of Object.entries(map)) {
+    if (v === undefined || v === false) continue;
+    if (v === true) out.push(k);
+    else out.push(`${k}="${escapeHtml(String(v))}"`);
+  }
+  return out.length > 0 ? ` ${out.join(" ")}` : "";
+}
+
+/**
+ * The hook trio + aria wiring every control shares: `name` = the literal path
+ * (the join key), `id` = the injective `pathToId` (unique, valid HTML), a
+ * `data-path` mirror (canonical, `*` for template slots), and the aria pair
+ * pointing at the path-addressed error slot. `aria-invalid` starts "false".
+ */
+export function hookAttrs(key: string): Record<string, string> {
+  const id = pathToId(key);
+  return {
+    name: key,
+    id,
+    "data-path": key,
+    "aria-invalid": "false",
+    "aria-describedby": `${id}-error`,
+  };
+}
+
+/**
+ * Native HTML5 validation attributes derived from the schema's own constraints --
+ * the schema does the work, no JS. `required` comes from a non-optional field;
+ * length/pattern/min/max/step come straight from the constraint facts. Exclusive
+ * numeric bounds have no exact native attribute, so they map to the inclusive
+ * one (documented lossy edge -- the server's `~standard` pass is authoritative).
+ */
+export function validationAttrs(
+  field: FieldDescriptor,
+): Record<string, string | number | boolean | undefined> {
+  const c = field.constraints;
+  const out: Record<string, string | number | boolean | undefined> = {
+    required: !field.isOptional || undefined,
+    minlength: c.minLength ?? c.length,
+    maxlength: c.maxLength ?? c.length,
+    pattern: c.pattern,
+  };
+  if (field.type === "number") {
+    out.min = c.min;
+    out.max = c.max;
+    out.step = c.step ?? (c.isInt ? 1 : undefined);
+  }
+  if (field.type === "date") {
+    out.min = c.minDate;
+    out.max = c.maxDate;
+  }
+  return out;
+}
+
+/** The path-addressed error slot -- empty, aria-live, addressed by `data-error-for`. */
+export function errorSlot(key: string): string {
+  const id = pathToId(key);
+  return `<span id="${id}-error" data-error-for="${escapeHtml(key)}" role="alert" aria-live="polite"></span>`;
+}
+
+/** The shared leaf frame: a `<label for>`, the control markup, and the error slot. */
+export function fieldFrame(key: string, label: string, control: string): string {
+  const id = pathToId(key);
+  return `<div><label for="${id}">${escapeHtml(label)}</label>${control}${errorSlot(key)}</div>`;
+}

--- a/src/renderers/html/composers.ts
+++ b/src/renderers/html/composers.ts
@@ -1,0 +1,101 @@
+import type { Composer } from "../../engine/types";
+import { attrs, errorSlot, escapeHtml, fieldFrame, hookAttrs, validationAttrs } from "./attrs";
+import { pathToId } from "./path-id";
+
+/** Radio (few options) vs select (many) threshold. A composer choice, not a Match. */
+const RADIO_MAX = 4;
+
+const asString = (v: unknown, fallback = ""): string => (typeof v === "string" ? v : fallback);
+const asValues = (v: unknown): (string | number)[] =>
+  Array.isArray(v) ? (v as (string | number)[]) : [];
+
+/**
+ * Presentation attributes an inventory entry set beyond the structural ones the
+ * composer handles itself (`type`/`value`/`values`) -- e.g. an otp row's
+ * `inputmode`/`autocomplete`. Pass through the scalar ones as HTML attributes.
+ */
+const extraAttrs = (config: Record<string, unknown>): Record<string, string | number | boolean> => {
+  const out: Record<string, string | number | boolean> = {};
+  for (const [k, v] of Object.entries(config)) {
+    if (k === "type" || k === "value" || k === "values") continue;
+    if (typeof v === "string" || typeof v === "number" || typeof v === "boolean") out[k] = v;
+  }
+  return out;
+};
+
+/**
+ * The one `input` composer, parametrized by `config.type` (text/email/url/tel/
+ * password/number/range/date/hidden). A `hidden` literal skips the visible frame
+ * -- it carries no user-facing label or error. Every other input gets the shared
+ * `<label>` + hook trio + native validation attrs + error slot.
+ */
+const input: Composer<string> = (i) => {
+  const type = asString(i.config.type, "text");
+  if (type === "hidden") {
+    const value = i.config.value;
+    return `<input${attrs({ type, ...hookAttrs(i.key), value: value === undefined ? undefined : String(value) })}>`;
+  }
+  const control = `<input${attrs({ type, ...hookAttrs(i.key), ...validationAttrs(i.field), ...extraAttrs(i.config) })}>`;
+  return fieldFrame(i.key, i.field.label, control);
+};
+
+/** A long string -> `<textarea>`. Pattern is not valid on textarea, so it is dropped. */
+const textarea: Composer<string> = (i) => {
+  const v = validationAttrs(i.field);
+  const control = `<textarea${attrs({
+    ...hookAttrs(i.key),
+    required: v.required,
+    minlength: v.minlength,
+    maxlength: v.maxlength,
+  })}></textarea>`;
+  return fieldFrame(i.key, i.field.label, control);
+};
+
+/** A boolean -> a single checkbox. `required` means it must be checked. */
+const checkbox: Composer<string> = (i) => {
+  const control = `<input${attrs({ type: "checkbox", ...hookAttrs(i.key), required: !i.field.isOptional || undefined })}>`;
+  return fieldFrame(i.key, i.field.label, control);
+};
+
+/** An enum -> radio group (few) or select (many). Cardinality is read here, not matched. */
+const enumControl: Composer<string> = (i) => {
+  const values = asValues(i.config.values);
+  const id = pathToId(i.key);
+  const required = !i.field.isOptional;
+  if (values.length > 0 && values.length <= RADIO_MAX) {
+    const options = values
+      .map((v, n) => {
+        const optId = `${id}__${n}`;
+        return `<label for="${optId}"><input${attrs({ type: "radio", id: optId, name: i.key, value: String(v), required: required && n === 0 ? true : undefined })}>${escapeHtml(String(v))}</label>`;
+      })
+      .join("");
+    return `<div role="radiogroup" aria-describedby="${id}-error" data-path="${escapeHtml(i.key)}"><span>${escapeHtml(i.field.label)}</span>${options}${errorSlot(i.key)}</div>`;
+  }
+  const options = values
+    .map((v) => `<option${attrs({ value: String(v) })}>${escapeHtml(String(v))}</option>`)
+    .join("");
+  const control = `<select${attrs({ ...hookAttrs(i.key), required: required || undefined })}>${options}</select>`;
+  return fieldFrame(i.key, i.field.label, control);
+};
+
+/**
+ * A field the leaf inventory does not answer (a container -- object/array/union)
+ * -- out of scope for the leaf renderer (#228 owns containers). Emit an inert
+ * marker rather than throwing, so a leaf-scoped render never crashes.
+ */
+const fallback: Composer<string> = (i) =>
+  `<!-- kelex: no leaf control for "${escapeHtml(i.key)}" (${i.field.type}) -->`;
+
+/** The composers the leaf inventory names, plus the required `form`/`fallback`. */
+export const leafComposers: Record<string, Composer<string>> = {
+  input,
+  textarea,
+  checkbox,
+  enum: enumControl,
+};
+
+/** A minimal form wrapper -- #228 upgrades this to a real `<form action>` + submit. */
+export const form = (children: { rendered: string }[]): string =>
+  `<form>${children.map((c) => c.rendered).join("")}</form>`;
+
+export const leafFallback = fallback;

--- a/src/renderers/html/composers.ts
+++ b/src/renderers/html/composers.ts
@@ -32,8 +32,17 @@ const extraAttrs = (config: Record<string, unknown>): Record<string, string | nu
 const input: Composer<string> = (i) => {
   const type = asString(i.config.type, "text");
   if (type === "hidden") {
+    // A hidden input carries no label or error slot, so it drops the aria pair
+    // (which would dangle at a slot that is never rendered) -- keeping only the
+    // join hooks (name/id/data-path).
     const value = i.config.value;
-    return `<input${attrs({ type, ...hookAttrs(i.key), value: value === undefined ? undefined : String(value) })}>`;
+    return `<input${attrs({
+      type,
+      name: i.key,
+      id: pathToId(i.key),
+      "data-path": i.key,
+      value: value === undefined ? undefined : String(value),
+    })}>`;
   }
   const control = `<input${attrs({ type, ...hookAttrs(i.key), ...validationAttrs(i.field), ...extraAttrs(i.config) })}>`;
   return fieldFrame(i.key, i.field.label, control);
@@ -69,7 +78,10 @@ const enumControl: Composer<string> = (i) => {
         return `<label for="${optId}"><input${attrs({ type: "radio", id: optId, name: i.key, value: String(v), required: required && n === 0 ? true : undefined })}>${escapeHtml(String(v))}</label>`;
       })
       .join("");
-    return `<div role="radiogroup" aria-describedby="${id}-error" data-path="${escapeHtml(i.key)}"><span>${escapeHtml(i.field.label)}</span>${options}${errorSlot(i.key)}</div>`;
+    // The group is the control: it carries the canonical id + the aria pair (a
+    // per-option `<label for>` targets each radio; the group is labelled by its
+    // own `<span>`). aria-invalid mirrors every other control's default.
+    return `<div${attrs({ role: "radiogroup", id, "aria-labelledby": `${id}-label`, "aria-describedby": `${id}-error`, "aria-invalid": "false", "data-path": i.key })}><span id="${id}-label">${escapeHtml(i.field.label)}</span>${options}${errorSlot(i.key)}</div>`;
   }
   const options = values
     .map((v) => `<option${attrs({ value: String(v) })}>${escapeHtml(String(v))}</option>`)

--- a/src/renderers/html/composers.ts
+++ b/src/renderers/html/composers.ts
@@ -35,7 +35,11 @@ const input: Composer<string> = (i) => {
     // A hidden input carries no label or error slot, so it drops the aria pair
     // (which would dangle at a slot that is never rendered) -- keeping only the
     // join hooks (name/id/data-path).
-    const value = i.config.value;
+    // `$values` resolves to the literal's value array; a hidden input carries one
+    // value, so take the first (a multi-value literal's canonical member) rather
+    // than stringifying the whole array into a value the schema would reject.
+    const raw = i.config.value;
+    const value = Array.isArray(raw) ? raw[0] : raw;
     return `<input${attrs({
       type,
       name: i.key,
@@ -60,9 +64,14 @@ const textarea: Composer<string> = (i) => {
   return fieldFrame(i.key, i.field.label, control);
 };
 
-/** A boolean -> a single checkbox. `required` means it must be checked. */
+/**
+ * A boolean -> a single checkbox. It is NOT marked `required`: native `required`
+ * on a checkbox means "must be checked", but a non-optional boolean accepts
+ * `false` just as validly as `true` -- only a missing value is invalid, which a
+ * checkbox cannot express. (A future `z.literal(true)` mapping could opt in.)
+ */
 const checkbox: Composer<string> = (i) => {
-  const control = `<input${attrs({ type: "checkbox", ...hookAttrs(i.key), required: !i.field.isOptional || undefined })}>`;
+  const control = `<input${attrs({ type: "checkbox", ...hookAttrs(i.key) })}>`;
   return fieldFrame(i.key, i.field.label, control);
 };
 
@@ -74,7 +83,10 @@ const enumControl: Composer<string> = (i) => {
   if (values.length > 0 && values.length <= RADIO_MAX) {
     const options = values
       .map((v, n) => {
-        const optId = `${id}__${n}`;
+        // `pathToId` never emits `-` (a hyphen escapes to `_h`), so a `-opt-`
+        // delimiter cannot collide with any control's own id -- unlike `__${n}`,
+        // which clashed with a sibling whose path `_` escaped to `__`.
+        const optId = `${id}-opt-${n}`;
         return `<label for="${optId}"><input${attrs({ type: "radio", id: optId, name: i.key, value: String(v), required: required && n === 0 ? true : undefined })}>${escapeHtml(String(v))}</label>`;
       })
       .join("");

--- a/src/renderers/html/index.ts
+++ b/src/renderers/html/index.ts
@@ -1,0 +1,23 @@
+import type { Renderer } from "../../engine/types";
+import { form, leafComposers, leafFallback } from "./composers";
+import { leafInventory } from "./inventory";
+
+/**
+ * The default base-HTML renderer -- LEAF half (#226). Zero-dependency, classless
+ * semantic HTML: the schema's constraints become native validation attributes and
+ * `name = path` gives free serialization plus the handler's join. INERT only --
+ * no behavior (that is the post handler, #227). Containers (fieldset/repeater/
+ * switch), the real `<form action>`, and the stylesheet are the container half
+ * (#228); here `form` is a minimal wrapper and containers fall to `fallback`.
+ *
+ * It imports ONLY the public contract (`Renderer`), so it is a true plugin --
+ * swappable, no privileged core access -- shipped in-package for now.
+ */
+export const htmlRenderer: Renderer<string> = {
+  inventory: leafInventory,
+  compose: leafComposers,
+  form,
+  fallback: leafFallback,
+};
+
+export { pathToId } from "./path-id";

--- a/src/renderers/html/inventory.ts
+++ b/src/renderers/html/inventory.ts
@@ -1,0 +1,47 @@
+import type { Entry } from "../../engine/types";
+
+/**
+ * The base-HTML leaf inventory -- the CANONICAL reference a rafters/shadcn/material
+ * author opens to learn the format. It is ordered (first-match), so every
+ * specialization sits ABOVE its type-only catch-all. It demonstrates each match
+ * kind: FORMAT (email/url), META-HINT (password/otp/tel via `.meta({ ui })`),
+ * and CONSTRAINT-BUCKET (a long string -> textarea, a bounded number -> range).
+ * The six scalar catch-alls at the bottom are the leaf floor -- every scalar
+ * FieldType has a type-only entry, so nothing drops.
+ *
+ * Components are few and config-parametrized (inventory is DATA, composers are
+ * code -- not 1:1): most rows resolve to the one `input` composer with a
+ * different `type`, plus `textarea`/`checkbox`/`enum`. Enum radio-vs-select is a
+ * cardinality choice `Match` cannot express, so the `enum` composer branches on
+ * `values.length` -- see composers.ts.
+ */
+export const leafInventory: Entry[] = [
+  // --- string specializations (above the string catch-all) ---
+  { match: { type: "string", ui: "password" }, component: "input", settings: { type: "password" } },
+  {
+    match: { type: "string", ui: "otp" },
+    component: "input",
+    settings: { type: "text", inputmode: "numeric", autocomplete: "one-time-code" },
+  },
+  { match: { type: "string", ui: "tel" }, component: "input", settings: { type: "tel" } },
+  { match: { type: "string", format: "email" }, component: "input", settings: { type: "email" } },
+  { match: { type: "string", format: "url" }, component: "input", settings: { type: "url" } },
+  // A long string (big max) reads better as a textarea -- a constraint-bucket match.
+  { match: { type: "string", maxLength: { gte: 256 } }, component: "textarea" },
+
+  // --- number specializations ---
+  // A bounded number (both min and max) becomes a slider -- a constraint-bucket match.
+  { match: { type: "number", bounded: true }, component: "input", settings: { type: "range" } },
+
+  // --- the six scalar type-only catch-alls (the leaf floor) ---
+  { match: { type: "string" }, component: "input", settings: { type: "text" } },
+  { match: { type: "number" }, component: "input", settings: { type: "number" } },
+  { match: { type: "boolean" }, component: "checkbox" },
+  { match: { type: "date" }, component: "input", settings: { type: "date" } },
+  { match: { type: "enum" }, component: "enum", settings: { values: "$values" } },
+  {
+    match: { type: "literal" },
+    component: "input",
+    settings: { type: "hidden", value: "$values" },
+  },
+];

--- a/src/renderers/html/path-id.ts
+++ b/src/renderers/html/path-id.ts
@@ -1,0 +1,21 @@
+/**
+ * A control's `name` is its canonical path (`tags.*.label`) -- literal, the join
+ * key. But that string is not a valid HTML `id` (dots, `*`), and `id` must be
+ * UNIQUE so `<label for>`, `aria-describedby`, and the error slot address exactly
+ * one control. `pathToId` is therefore an INJECTIVE encoding: distinct paths map
+ * to distinct ids, so two controls can never collide on an id.
+ *
+ * The escape is prefix-free -- `_` leads every escape, so a literal `_` (`__`)
+ * can never be confused with an escaped `.`/`*`/`-`. `first.name`, `first-name`,
+ * and `first_name` all encode differently. The output is `[A-Za-z0-9_]` only.
+ */
+const ESCAPE: Record<string, string> = {
+  _: "__",
+  ".": "_d",
+  "*": "_x",
+  "-": "_h",
+};
+
+export function pathToId(path: string): string {
+  return path.replace(/[_.*-]/g, (ch) => ESCAPE[ch] ?? ch);
+}

--- a/test/renderers/html/path-id.test.ts
+++ b/test/renderers/html/path-id.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { pathToId } from "../../../src/renderers/html/path-id";
+
+describe("pathToId -- injective, valid HTML id (#226)", () => {
+  it("produces a valid HTML id (no dots, no `*`) from any path", () => {
+    expect(pathToId("home.zip")).not.toMatch(/[.*]/);
+    expect(pathToId("tags.*.label")).not.toMatch(/[.*]/);
+    expect(pathToId("tags.*.label")).toMatch(/^[A-Za-z0-9_]+$/);
+  });
+
+  it("is injective -- collision-prone paths map to distinct ids", () => {
+    // The naive `.`->`-`, `*`->`_` scheme collides on these; the escape must not.
+    const pairs = [
+      ["first.name", "first-name"],
+      ["first.name", "first_name"],
+      ["a.b", "a*b"],
+      ["a_b", "a.b"],
+      ["x-y", "x.y"],
+    ];
+    for (const [p, q] of pairs) {
+      expect(pathToId(p)).not.toBe(pathToId(q));
+    }
+  });
+
+  it("keeps the literal path as `name` while `id` is the encoded form -- both key one control", () => {
+    const key = "tags.*.label";
+    // name is the raw path (the join key); id is its encoding.
+    expect(pathToId(key)).not.toBe(key);
+    // Distinct paths never share an id, so id -> control is unambiguous.
+    expect(pathToId("a.b.c")).not.toBe(pathToId("a.b"));
+  });
+});

--- a/test/renderers/html/renderer.test.ts
+++ b/test/renderers/html/renderer.test.ts
@@ -81,6 +81,33 @@ describe("htmlRenderer -- default base-HTML leaf controls (#226)", () => {
     expect(one(z.literal("x"))).toContain('type="hidden"');
   });
 
+  it("does not mark a plain boolean checkbox required (false is valid)", () => {
+    expect(one(z.boolean())).not.toContain("required");
+  });
+
+  it("emits a bare YYYY-MM-DD for a bounded date's min/max (not an ISO timestamp)", () => {
+    const html = one(z.date().min(new Date("2020-01-01")).max(new Date("2021-06-15")));
+    expect(html).toContain('min="2020-01-01"');
+    expect(html).toContain('max="2021-06-15"');
+    expect(html).not.toMatch(/min="[^"]*T/); // no time portion
+  });
+
+  it("emits a single valid value for a multi-value literal, not the joined array", () => {
+    const html = one(z.literal(["draft", "published", "archived"]));
+    expect(html).toContain('value="draft"');
+    expect(html).not.toContain("draft,published");
+  });
+
+  it("gives a radio group's option ids no collision with a sibling field's id", () => {
+    // `fx` option 0 and the `fx_0` control both used to resolve to id="fx__0".
+    const html = render(
+      introspect(asSchema(z.object({ fx: z.enum(["a", "b"]), fx_0: z.string() })), OPTS),
+      htmlRenderer,
+    );
+    const ids = [...html.matchAll(/\sid="([^"]+)"/g)].map((m) => m[1]);
+    expect(new Set(ids).size).toBe(ids.length); // all ids unique
+  });
+
   it("is classless -- no `class` attribute anywhere in the output", () => {
     const html = render(
       introspect(

--- a/test/renderers/html/renderer.test.ts
+++ b/test/renderers/html/renderer.test.ts
@@ -64,6 +64,10 @@ describe("htmlRenderer -- default base-HTML leaf controls (#226)", () => {
     const few = one(z.enum(["a", "b"]));
     expect(few).toContain('role="radiogroup"');
     expect(few).toContain('type="radio"');
+    // The group is a control too -- it carries the canonical id + aria pair.
+    expect(few).toContain('id="f"');
+    expect(few).toContain('aria-invalid="false"');
+    expect(few).toContain('aria-describedby="f-error"');
 
     const many = one(z.enum(["a", "b", "c", "d", "e", "f"]));
     expect(many).toContain("<select");

--- a/test/renderers/html/renderer.test.ts
+++ b/test/renderers/html/renderer.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod/v4";
+import { render, validateRenderer } from "../../../src/engine";
+import { conformance } from "../../../src/conformance";
+import type { FieldType } from "../../../src/introspection/types";
+import { introspect } from "../../../src/introspection";
+import { htmlRenderer } from "../../../src/renderers/html";
+
+const OPTS = { formName: "F", schemaImportPath: "./f", schemaExportName: "s" };
+const asSchema = (s: unknown) => s as Parameters<typeof introspect>[0];
+const SCALARS: FieldType[] = ["string", "number", "boolean", "date", "enum", "literal"];
+
+/** Render a single field `f` and return the HTML string. */
+const one = (schema: unknown): string =>
+  render(introspect(asSchema(z.object({ f: schema as never })), OPTS), htmlRenderer);
+
+describe("htmlRenderer -- default base-HTML leaf controls (#226)", () => {
+  it("passes the leaf floor -- a type-only catch-all for every scalar type", () => {
+    expect(validateRenderer(htmlRenderer, SCALARS)).toEqual([]);
+  });
+
+  it("emits the hook trio, label, error slot, and native validation attrs", () => {
+    const html = one(z.string().min(2).max(8));
+    expect(html).toContain('name="f"');
+    expect(html).toContain('id="f"');
+    expect(html).toContain('data-path="f"');
+    expect(html).toContain('aria-invalid="false"');
+    expect(html).toContain('aria-describedby="f-error"');
+    expect(html).toContain('<label for="f">');
+    expect(html).toContain(
+      '<span id="f-error" data-error-for="f" role="alert" aria-live="polite">',
+    );
+    expect(html).toContain("required");
+    expect(html).toContain('minlength="2"');
+    expect(html).toContain('maxlength="8"');
+  });
+
+  it("drops `required` for an optional field", () => {
+    expect(one(z.string().optional())).not.toContain("required");
+  });
+
+  it("demonstrates the FORMAT match kind -- email/url -> typed input", () => {
+    expect(one(z.email())).toContain('type="email"');
+    expect(one(z.url())).toContain('type="url"');
+  });
+
+  it("demonstrates the CONSTRAINT-BUCKET match kind -- long string -> textarea, bounded number -> range", () => {
+    const long = one(z.string().max(500));
+    expect(long).toContain("<textarea");
+    expect(long).not.toContain('type="text"');
+
+    const bounded = one(z.number().min(0).max(10));
+    expect(bounded).toContain('type="range"');
+    expect(bounded).toContain('min="0"');
+    expect(bounded).toContain('max="10"');
+  });
+
+  it("demonstrates the META-HINT match kind -- password/otp via .meta({ ui })", () => {
+    expect(one(z.string().meta({ ui: "password" }))).toContain('type="password"');
+    expect(one(z.string().meta({ ui: "otp" }))).toContain('inputmode="numeric"');
+  });
+
+  it("renders enum by cardinality -- few -> radio group, many -> select", () => {
+    const few = one(z.enum(["a", "b"]));
+    expect(few).toContain('role="radiogroup"');
+    expect(few).toContain('type="radio"');
+
+    const many = one(z.enum(["a", "b", "c", "d", "e", "f"]));
+    expect(many).toContain("<select");
+    expect(many).toContain("<option");
+  });
+
+  it("renders number/boolean/date/literal catch-alls to their native elements", () => {
+    expect(one(z.number())).toContain('type="number"');
+    expect(one(z.boolean())).toContain('type="checkbox"');
+    expect(one(z.date())).toContain('type="date"');
+    expect(one(z.literal("x"))).toContain('type="hidden"');
+  });
+
+  it("is classless -- no `class` attribute anywhere in the output", () => {
+    const html = render(
+      introspect(
+        asSchema(
+          z.object({
+            name: z.string(),
+            age: z.number(),
+            agree: z.boolean(),
+            role: z.enum(["a", "b", "c", "d", "e"]),
+          }),
+        ),
+        OPTS,
+      ),
+      htmlRenderer,
+    );
+    expect(html).not.toMatch(/\sclass=/);
+  });
+
+  it("passes conformance scoped to the leaf shapes", async () => {
+    const names = (s: string) => [...s.matchAll(/name="([^"]+)"/g)].map((m) => m[1]);
+    const report = await conformance(htmlRenderer, undefined, {
+      names,
+      types: SCALARS,
+      fuzzCount: 30,
+    });
+    expect(report.failures).toEqual([]);
+    expect(report.passed).toBe(true);
+    expect(report.coverage.handlerJoinCases).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

`htmlRenderer` is the leaf half of the default, zero-dependency, classless base-HTML renderer -- and the canonical inventory a rafters/shadcn/material author opens to learn the format. The schema does the work: constraints become native HTML5 validation attributes and `name = path` gives free serialization plus the handler's join. The markup is INERT (no behavior -- that is the post handler, #227). Containers, the real `<form action>`, buttons, and the stylesheet are the container half (#228). To let a leaf-only renderer prove itself, `conformance`/`validateRenderer` gain an optional `types` scope.

## Acceptance criteria mapping

### 1. A type-only catch-all for every scalar FieldType -- the leaf floor passes
The inventory ends with six type-only entries (match pins only `type`) for string/number/boolean/date/enum/literal, below the specializations so first-match reaches a catch-all for any scalar. `validateRenderer(htmlRenderer, SCALARS)` returns no gaps.
Evidence: `renderer.test.ts` "passes the leaf floor" asserts `validateRenderer(htmlRenderer, SCALARS)` is `[]`; `inventory.ts:37-46` holds the six catch-alls.

### 2. Specializations demonstrate every match kind
Above the catch-alls the inventory carries FORMAT matches (`format: "email"` -> `type=email`, `url` -> `type=url`), META-HINT matches (`ui: "password"/"otp"/"tel"` via `.meta({ ui })`), and CONSTRAINT-BUCKET matches (a `maxLength` Bound -> `<textarea>`, `bounded` -> `type=range`) -- so the inventory reads as the reference example, not merely a floor. Enum radio-vs-select is a cardinality choice `Match` cannot express, so the enum composer branches on `values.length` (documented in Not done).
Evidence: `renderer.test.ts` "demonstrates the FORMAT match kind", "...CONSTRAINT-BUCKET...", and "...META-HINT..." assert `type="email"`/`type="url"`, `<textarea>`/`type="range"`, and `type="password"`/`inputmode="numeric"`.

### 3. Every control emits the hook trio, label, aria, validation attrs, and error slot
`hookAttrs(key)` stamps `name = key` (the literal path), `id = pathToId(key)`, `data-path = key`, `aria-invalid="false"`, and `aria-describedby="{id}-error"`; `validationAttrs(field)` adds `required` (from non-optional), `minlength`/`maxlength`/`pattern` and `min`/`max`/`step` for numbers; `fieldFrame` wraps a `<label for={id}>` and the empty `<span role="alert" aria-live="polite" data-error-for={path}>` error slot. This holds for the group controls too: the radio-group `<div>` carries the canonical `id` + aria pair (a per-option `<label for>` targets each radio, and the group is labelled by its own `<span>` -- the honest pattern for a group, not a literal group-level `<label for>`).
Evidence: `renderer.test.ts` "emits the hook trio, label, error slot, and native validation attrs" and the radiogroup assertions in "renders enum by cardinality" (`id="f"`, `aria-invalid`, `aria-describedby="f-error"`).

### 4. pathToId is a valid, injective encoding; name keeps the literal path
`pathToId` escapes with a prefix-free map (`_`->`__`, `.`->`_d`, `*`->`_x`, `-`->`_h`), so the output is `[A-Za-z0-9_]` (valid id) and DISTINCT paths never collide -- `first.name`, `first-name`, `first_name` all encode differently, closing the hole a naive `.`->`-`/`*`->`_` scheme leaves. `name` stays the raw path (the join key); both address the same control. Scope is the path characters the issue enumerates -- dots, `*`, indices.
Evidence: `path-id.test.ts` "is injective -- collision-prone paths map to distinct ids" iterates five pairs asserting distinct ids; `renderer.test.ts` "gives a radio group's option ids no collision with a sibling field's id" renders `{ fx: enum, fx_0: string }` and asserts every rendered `id` is unique (the radio option now uses a `-opt-` delimiter, a char `pathToId` never emits).

### 5. Classless, imports only the public contract, passes conformance for the leaf shapes
No composer emits a `class` attribute; the renderer's only engine import is the `Renderer` type (the public contract), so it is a true swappable plugin with no privileged access. It passes `conformance(htmlRenderer, undefined, { names, types: SCALARS })` -- the scalar-scoped baseline (floor + totality + path-preservation + determinism over the leaf battery and fuzz, plus handler-join on the email/url bad data).
Evidence: `renderer.test.ts` "is classless" asserts no `class=` in a multi-field render; "passes conformance scoped to the leaf shapes" asserts `report.passed` with `handlerJoinCases > 0`.

## Not done

Containers (`object`/`tuple` fieldsets, `array`/`record` repeaters, `union` switch), the real `<form action>` + submit button, and `form.css` are the container half (#228) -- here `form` is a minimal wrapper and containers fall to `fallback`. Enum radio-vs-select is handled in the enum composer, not as a `Match` predicate, because `Match` has no cardinality field. `pathToId` covers the path characters the issue enumerates (dots/`*`/indices); arbitrary whitespace in a schema key is out of scope. All interactivity is deferred to the post handler (#227) by design.


Closes #226
