### PR TITLE
feat(#228): base-HTML containers, form, buttons, and example form.css

### DIFF
--- a/.changeset/renderer-html-containers.md
+++ b/.changeset/renderer-html-containers.md
@@ -1,0 +1,15 @@
+---
+"@rafters/kelex": minor
+---
+
+Complete the default base-HTML renderer -- containers, form, buttons, and an
+example stylesheet (#228). `object`/`tuple` render as `<fieldset><legend>`;
+`array`/`record` as a repeater (a `<template>` row carrying the `*` path + inert
+`data-add-row`/`data-remove-row` buttons); `union` as a switch (a
+`data-variant-of` selector that stamps a discriminated union's discriminator +
+`data-variant`/`data-when` panels); a recursive boundary as an inert marker. The
+`form` composer now wraps a real `<form action>` (via the new
+`createHtmlRenderer({ action })` factory; `htmlRenderer` stays the default
+instance) with a submit button -- all interactivity is inert, owned by the post
+handler (#227). With the leaf inventory the renderer passes the FULL floor and
+full conformance. Ships `@rafters/kelex/form.css`, a classless example sheet.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "files": [
     "dist",
+    "src/renderers/html/form.css",
     "README.md"
   ],
   "type": "module",
@@ -29,7 +30,8 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
-    }
+    },
+    "./form.css": "./src/renderers/html/form.css"
   },
   "scripts": {
     "build": "tsdown",

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,9 +48,12 @@ export type {
   Variant,
 } from "./engine";
 
-// The default base-HTML renderer (leaf half, #226): a zero-dependency, classless
-// renderer shipped in-package. A true plugin -- imports only the public contract.
-export { htmlRenderer, pathToId } from "./renderers/html";
+// The default base-HTML renderer: a zero-dependency, classless renderer shipped
+// in-package. A true plugin -- imports only the public contract. `htmlRenderer`
+// is the default instance; `createHtmlRenderer({ action })` sets the form POST
+// target. The example stylesheet ships at `@rafters/kelex/form.css`.
+export { createHtmlRenderer, htmlRenderer, pathToId } from "./renderers/html";
+export type { HtmlRendererOptions } from "./renderers/html";
 
 // The conformance harness: prove a plugin honors the contract. A testing tool
 // (it takes a `names` reader for the opaque `T`), not part of the runtime

--- a/src/renderers/html/composers.ts
+++ b/src/renderers/html/composers.ts
@@ -110,16 +110,12 @@ const enumControl: Composer<string> = (i) => {
 const fallback: Composer<string> = (i) =>
   `<!-- kelex: no leaf control for "${escapeHtml(i.key)}" (${i.field.type}) -->`;
 
-/** The composers the leaf inventory names, plus the required `form`/`fallback`. */
+/** The composers the leaf inventory names. Containers live in containers.ts. */
 export const leafComposers: Record<string, Composer<string>> = {
   input,
   textarea,
   checkbox,
   enum: enumControl,
 };
-
-/** A minimal form wrapper -- #228 upgrades this to a real `<form action>` + submit. */
-export const form = (children: { rendered: string }[]): string =>
-  `<form>${children.map((c) => c.rendered).join("")}</form>`;
 
 export const leafFallback = fallback;

--- a/src/renderers/html/containers.ts
+++ b/src/renderers/html/containers.ts
@@ -1,0 +1,102 @@
+import type { Child, Composer } from "../../engine/types";
+import { attrs, escapeHtml } from "./attrs";
+import { pathToId } from "./path-id";
+
+/**
+ * The container half of the base-HTML renderer (#228). Every container is INERT
+ * structure with data hooks -- the post handler (#227) owns every click. Groups
+ * become `<fieldset><legend>`; lists become a repeater (`<template>` row + inert
+ * add/remove buttons); unions become a switch (a variant selector + tagged
+ * panels); a recursive boundary emits an inert marker (the runtime widget
+ * expands it). Together with the leaf inventory this completes the full floor.
+ */
+
+const kidsOf = (children: Child<string>[]): string => children.map((c) => c.rendered).join("");
+
+/** object/tuple -> a labelled fieldset wrapping the child controls. */
+const group: Composer<string> = (i) => {
+  if (i.shape !== "group") return "";
+  return `<fieldset${attrs({ "data-path": i.key })}><legend>${escapeHtml(i.field.label)}</legend>${kidsOf(i.children)}</fieldset>`;
+};
+
+/**
+ * array/record -> a repeater. The item (its paths carry the `*` template slot)
+ * lives in a `<template>` the handler clones and re-indexes; a per-row remove
+ * button sits inside it, and an add button below. All buttons are `type=button`
+ * (inert) with `data-add-row`/`data-remove-row` hooks -- no event wiring here.
+ */
+const list: Composer<string> = (i) => {
+  if (i.shape !== "list") return "";
+  const row = `${i.item.rendered}<button${attrs({ type: "button", "data-remove-row": i.key })}>Remove</button>`;
+  return (
+    `<fieldset${attrs({ "data-path": i.key })}><legend>${escapeHtml(i.field.label)}</legend>` +
+    `<template${attrs({ "data-row": i.item.key })}>${row}</template>` +
+    `<button${attrs({ type: "button", "data-add-row": i.key })}>Add ${escapeHtml(i.field.label)}</button>` +
+    `</fieldset>`
+  );
+};
+
+/**
+ * union -> a switch: a variant `<select data-variant-of>` plus one tagged panel
+ * per variant (`data-variant` + `data-when` = the variant's value). For a
+ * DISCRIMINATED union the selector also carries `name = <key>.<discriminator>`
+ * -- the discriminator is a real control `controlPaths` lists but the fold drops
+ * from variant children, so the composer stamps it here. The `<key>.<disc>` join
+ * is hand-built for now; #234 will hand the composer a first-class discriminator
+ * child so no path is reconstructed by hand.
+ */
+const choice: Composer<string> = (i) => {
+  if (i.shape !== "choice") return "";
+  const m = i.field.metadata;
+  const disc = m.kind === "union" ? m.discriminator : undefined;
+  const selectName = disc ? `${i.key}.${disc}` : undefined;
+  const options = i.variants
+    .map(
+      (v) =>
+        `<option${attrs({ value: String(v.value) })}>${escapeHtml(v.label ?? String(v.value))}</option>`,
+    )
+    .join("");
+  const selector = `<select${attrs({
+    "data-variant-of": i.key,
+    name: selectName,
+    id: selectName ? pathToId(selectName) : undefined,
+  })}>${options}</select>`;
+  const panels = i.variants
+    .map(
+      (v) =>
+        `<div${attrs({ "data-variant": true, "data-when": String(v.value) })}>${kidsOf(v.children)}</div>`,
+    )
+    .join("");
+  return `<fieldset${attrs({ "data-path": i.key })}><legend>${escapeHtml(i.field.label)}</legend>${selector}${panels}</fieldset>`;
+};
+
+/** ref -> an inert recursion-boundary marker. `controlPaths` stops here, so it
+ * stamps no control below; the runtime widget reproduces the paths at expansion. */
+const recursive: Composer<string> = (i) =>
+  `<fieldset${attrs({ "data-path": i.key, "data-recursive": true })}><legend>${escapeHtml(i.field.label)}</legend><!-- recursive boundary --></fieldset>`;
+
+/** The container composers, keyed by the components the container inventory names. */
+export const containerComposers: Record<string, Composer<string>> = {
+  group,
+  list,
+  choice,
+  recursive,
+};
+
+/** Options for the form wrapper -- where a submit POSTs, and by what method. */
+export interface HtmlRendererOptions {
+  /** The form `action` (POST target). Omitted -> posts to the same URL. */
+  action?: string;
+  /** The form method (default `post`). */
+  method?: string;
+}
+
+/**
+ * The real `<form>` wrapper (upgrading #226's minimal stub): the action/method
+ * from options plus an inert submit `<button type=submit>`. The handler (#227)
+ * intercepts submit; the button is plain markup.
+ */
+export const makeForm =
+  (options: HtmlRendererOptions) =>
+  (children: Child<string>[]): string =>
+    `<form${attrs({ action: options.action, method: options.method ?? "post" })}>${kidsOf(children)}<button${attrs({ type: "submit" })}>Submit</button></form>`;

--- a/src/renderers/html/form.css
+++ b/src/renderers/html/form.css
@@ -66,7 +66,10 @@ label:has(+ :required) {
   font-weight: 700;
 }
 
-/* Native + routed invalid states. */
+/* Native + routed invalid states. `:user-invalid` (styled below) is preferred --
+ * it holds off until the user has interacted, so untouched required fields are
+ * not red on load -- but `:invalid` is included for completeness. */
+:invalid,
 :user-invalid,
 [aria-invalid="true"] {
   border-color: #c0392b;

--- a/src/renderers/html/form.css
+++ b/src/renderers/html/form.css
@@ -1,0 +1,112 @@
+/*
+ * kelex base-HTML form -- an example CLASSLESS stylesheet.
+ *
+ * It targets the semantic elements the default renderer emits plus its data and
+ * aria hooks -- no class selectors, so it styles the output as-is. Copy it, or
+ * import it from `@rafters/kelex/form.css`, then override to taste. Nothing here
+ * is required for the form to function; it is presentation only.
+ */
+
+form {
+  display: grid;
+  gap: 1rem;
+  max-width: 40rem;
+}
+
+/* A field row: label above its control, error slot below. */
+form > div,
+fieldset > div {
+  display: grid;
+  gap: 0.25rem;
+}
+
+label {
+  font-weight: 600;
+}
+
+input,
+select,
+textarea {
+  font: inherit;
+  padding: 0.4rem 0.5rem;
+  border: 1px solid #8a8a8a;
+  border-radius: 0.25rem;
+  background: Field;
+  color: FieldText;
+}
+
+textarea {
+  min-height: 6rem;
+  resize: vertical;
+}
+
+input[type="checkbox"],
+input[type="radio"] {
+  width: auto;
+  padding: 0;
+}
+
+/* Grouping: fieldsets for objects/tuples and the array/union containers. */
+fieldset {
+  display: grid;
+  gap: 0.75rem;
+  border: 1px solid #c4c4c4;
+  border-radius: 0.375rem;
+  padding: 0.75rem 1rem 1rem;
+}
+
+legend {
+  font-weight: 700;
+  padding: 0 0.375rem;
+}
+
+/* A required field is marked on its label. */
+:required + label,
+label:has(+ :required) {
+  font-weight: 700;
+}
+
+/* Native + routed invalid states. */
+:user-invalid,
+[aria-invalid="true"] {
+  border-color: #c0392b;
+  outline-color: #c0392b;
+}
+
+/* The path-addressed error slot -- hidden until the handler fills it. */
+[role="alert"] {
+  color: #c0392b;
+  font-size: 0.875rem;
+  min-height: 1rem;
+}
+
+[role="alert"]:empty {
+  display: none;
+}
+
+button {
+  font: inherit;
+  padding: 0.45rem 0.9rem;
+  border: 1px solid #5a5a5a;
+  border-radius: 0.25rem;
+  background: ButtonFace;
+  color: ButtonText;
+  cursor: pointer;
+  justify-self: start;
+}
+
+button[type="submit"] {
+  font-weight: 700;
+}
+
+@media (prefers-color-scheme: dark) {
+  input,
+  select,
+  textarea {
+    border-color: #6a6a6a;
+  }
+
+  fieldset {
+    border-color: #444;
+  }
+}

--- a/src/renderers/html/index.ts
+++ b/src/renderers/html/index.ts
@@ -1,23 +1,30 @@
 import type { Renderer } from "../../engine/types";
-import { form, leafComposers, leafFallback } from "./composers";
-import { leafInventory } from "./inventory";
+import { leafComposers, leafFallback } from "./composers";
+import { containerComposers, type HtmlRendererOptions, makeForm } from "./containers";
+import { inventory } from "./inventory";
 
 /**
- * The default base-HTML renderer -- LEAF half (#226). Zero-dependency, classless
- * semantic HTML: the schema's constraints become native validation attributes and
- * `name = path` gives free serialization plus the handler's join. INERT only --
- * no behavior (that is the post handler, #227). Containers (fieldset/repeater/
- * switch), the real `<form action>`, and the stylesheet are the container half
- * (#228); here `form` is a minimal wrapper and containers fall to `fallback`.
+ * Build the default base-HTML renderer. Zero-dependency, classless semantic HTML:
+ * the schema's constraints become native validation attributes and `name = path`
+ * gives free serialization plus the handler's join. The markup is INERT -- the
+ * post handler (#227) owns every click. `options.action` sets the `<form>` POST
+ * target (the one thing that varies per form); everything else is static.
  *
  * It imports ONLY the public contract (`Renderer`), so it is a true plugin --
- * swappable, no privileged core access -- shipped in-package for now.
+ * swappable, no privileged core access -- shipped in-package for now. The
+ * example stylesheet ships alongside at `./form.css`.
  */
-export const htmlRenderer: Renderer<string> = {
-  inventory: leafInventory,
-  compose: leafComposers,
-  form,
-  fallback: leafFallback,
-};
+export function createHtmlRenderer(options: HtmlRendererOptions = {}): Renderer<string> {
+  return {
+    inventory,
+    compose: { ...leafComposers, ...containerComposers },
+    form: makeForm(options),
+    fallback: leafFallback,
+  };
+}
 
+/** The default renderer instance (no form action -> posts to the same URL). */
+export const htmlRenderer: Renderer<string> = createHtmlRenderer();
+
+export type { HtmlRendererOptions } from "./containers";
 export { pathToId } from "./path-id";

--- a/src/renderers/html/inventory.ts
+++ b/src/renderers/html/inventory.ts
@@ -45,3 +45,21 @@ export const leafInventory: Entry[] = [
     settings: { type: "hidden", value: "$values" },
   },
 ];
+
+/**
+ * The container type-only catch-alls (#228) -- the other half of the full floor.
+ * object/tuple -> a fieldset group; array/record -> a repeater list; union -> a
+ * variant switch; ref -> an inert recursion boundary. Appended after the leaves;
+ * catch-all order among distinct types does not matter (first-match is per-type).
+ */
+export const containerInventory: Entry[] = [
+  { match: { type: "object" }, component: "group" },
+  { match: { type: "tuple" }, component: "group" },
+  { match: { type: "array" }, component: "list" },
+  { match: { type: "record" }, component: "list" },
+  { match: { type: "union" }, component: "choice" },
+  { match: { type: "ref" }, component: "recursive" },
+];
+
+/** The full base-HTML inventory: leaf specializations + all twelve catch-alls. */
+export const inventory: Entry[] = [...leafInventory, ...containerInventory];

--- a/test/renderers/html/containers.test.ts
+++ b/test/renderers/html/containers.test.ts
@@ -117,6 +117,7 @@ describe("htmlRenderer -- containers, form, buttons (#228)", () => {
       "legend",
       "button",
       ":required",
+      ":invalid",
       "[aria-invalid=",
       '[role="alert"]',
       '[role="alert"]:empty',

--- a/test/renderers/html/containers.test.ts
+++ b/test/renderers/html/containers.test.ts
@@ -1,0 +1,128 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { z } from "zod/v4";
+import { render, validateRenderer } from "../../../src/engine";
+import { conformance } from "../../../src/conformance";
+import { introspect } from "../../../src/introspection";
+import { createHtmlRenderer, htmlRenderer } from "../../../src/renderers/html";
+
+const OPTS = { formName: "F", schemaImportPath: "./f", schemaExportName: "s" };
+const asSchema = (s: unknown) => s as Parameters<typeof introspect>[0];
+const one = (schema: unknown): string =>
+  render(introspect(asSchema(z.object({ f: schema as never })), OPTS), htmlRenderer);
+
+describe("htmlRenderer -- containers, form, buttons (#228)", () => {
+  it("renders object/tuple as a labelled fieldset", () => {
+    const html = one(z.object({ a: z.string(), b: z.number() }));
+    expect(html).toContain("<fieldset");
+    expect(html).toContain("<legend>");
+    expect(html).toContain('name="f.a"');
+    expect(html).toContain('name="f.b"');
+  });
+
+  it("renders array/record as a repeater -- <template> row + inert add/remove buttons", () => {
+    const html = one(z.array(z.object({ label: z.string() })));
+    expect(html).toContain('<template data-row="f.*"');
+    expect(html).toContain('name="f.*.label"'); // the template row carries the * path
+    expect(html).toContain('<button type="button" data-add-row="f"');
+    expect(html).toContain('data-remove-row="f"');
+    expect(html).not.toContain("<script"); // no event wiring
+  });
+
+  it("renders a discriminated union as a switch -- selector stamps the discriminator, tagged panels", () => {
+    const html = one(
+      z.discriminatedUnion("kind", [
+        z.object({ kind: z.literal("circle"), radius: z.number() }),
+        z.object({ kind: z.literal("rect"), w: z.number() }),
+      ]),
+    );
+    expect(html).toContain('data-variant-of="f"');
+    expect(html).toContain('name="f.kind"'); // discriminator selector control
+    expect(html).toContain("data-variant");
+    expect(html).toContain('data-when="circle"');
+    expect(html).toContain('name="f.radius"');
+  });
+
+  it("renders a plain union switch without a discriminator name", () => {
+    const html = one(z.union([z.string(), z.number()]));
+    expect(html).toContain('data-variant-of="f"');
+    expect(html).toContain("data-variant");
+  });
+
+  it("all interactivity is inert -- buttons are type=button/submit, no <script>", () => {
+    const html = render(
+      introspect(asSchema(z.object({ tags: z.array(z.string()) })), OPTS),
+      htmlRenderer,
+    );
+    expect(html).not.toContain("<script");
+    expect(html).not.toMatch(/on[a-z]+=/); // no inline event handlers
+  });
+
+  it("the form composer wraps <form> with the options action + a submit button", () => {
+    const withAction = createHtmlRenderer({ action: "/submit" });
+    const html = render(introspect(asSchema(z.object({ a: z.string() })), OPTS), withAction);
+    expect(html).toContain('<form action="/submit" method="post">');
+    expect(html).toContain('<button type="submit">');
+    // The default instance posts to the same URL (no action).
+    expect(one(z.string())).toContain('<form method="post">');
+  });
+
+  it("passes the FULL floor -- a catch-all for every FieldType", () => {
+    expect(validateRenderer(htmlRenderer)).toEqual([]);
+  });
+
+  it("is classless across containers -- no `class` attribute", () => {
+    const html = render(
+      introspect(
+        asSchema(
+          z.object({
+            group: z.object({ x: z.string() }),
+            list: z.array(z.number()),
+            choice: z.union([z.string(), z.number()]),
+          }),
+        ),
+        OPTS,
+      ),
+      htmlRenderer,
+    );
+    expect(html).not.toMatch(/\sclass=/);
+  });
+
+  it("passes full conformance (renderer-only) over every shape", async () => {
+    const names = (s: string) => [...s.matchAll(/name="([^"]+)"/g)].map((m) => m[1]);
+    const report = await conformance(htmlRenderer, undefined, { names, fuzzCount: 40 });
+    expect(report.failures).toEqual([]);
+    expect(report.passed).toBe(true);
+  });
+
+  it("preserves the join through a pass-through handler (a handler must not drop a control)", async () => {
+    const names = (s: string) => [...s.matchAll(/name="([^"]+)"/g)].map((m) => m[1]);
+    const passthrough = { wire: (form: string) => form };
+    const report = await conformance(htmlRenderer, passthrough, { names, fuzzCount: 10 });
+    expect(report.passed).toBe(true);
+  });
+
+  it("ships form.css -- a classless stylesheet covering the semantic + aria hooks", () => {
+    const css = readFileSync(
+      fileURLToPath(new URL("../../../src/renderers/html/form.css", import.meta.url)),
+      "utf8",
+    );
+    for (const sel of [
+      "label",
+      "input",
+      "select",
+      "textarea",
+      "fieldset",
+      "legend",
+      "button",
+      ":required",
+      "[aria-invalid=",
+      '[role="alert"]',
+      '[role="alert"]:empty',
+    ]) {
+      expect(css).toContain(sel);
+    }
+    expect(css).not.toMatch(/\.[a-zA-Z][\w-]*\s*\{/); // no class selectors
+  });
+});


### PR DESCRIPTION
## Summary

This completes the default base-HTML renderer: its container/form/button set plus an example classless stylesheet. `object`/`tuple` become fieldsets, `array`/`record` become a repeater, `union` becomes a switch, and a recursive boundary becomes an inert marker -- so with the leaf inventory (#226) the renderer covers the FULL floor (every FieldType). Everything is INERT structure with data hooks; the post handler (#227) owns every click. The `form` composer now wraps a real `<form action>` via a new `createHtmlRenderer({ action })` factory (`htmlRenderer` stays the default instance), and `@rafters/kelex/form.css` ships a classless example sheet.

## Acceptance criteria mapping

### 1. Containers complete the floor -- fieldset groups, array/record repeaters, union switch
`object`/`tuple` render as `<fieldset><legend>` wrapping the child controls; `array`/`record` render as a repeater -- a `<fieldset>` holding a `<template data-row="{path}.*">` row (carrying the `*`-slot item plus an inert remove button) and an add button; `union` renders as a switch -- a `<select data-variant-of>` plus one `data-variant`/`data-when` panel per variant. Each maps from a new type-only container catch-all in the inventory, so the full floor passes.
Evidence: `containers.test.ts` "renders object/tuple as a labelled fieldset", "renders array/record as a repeater", and "renders a discriminated union as a switch"; "passes the FULL floor" asserts `validateRenderer(htmlRenderer)` is `[]`.

### 2. The form composer wraps a `<form>` (action from options) with a submit button
The `form` slot is built by `makeForm(options)`, closed over the renderer's options; `createHtmlRenderer({ action })` sets the `<form action>` (the one per-form value, which has no other channel into the static renderer), defaulting method to `post`. The wrapper appends an inert `<button type="submit">`. `htmlRenderer` is `createHtmlRenderer()` -- no action, so it posts to the same URL.
Evidence: `containers.test.ts` "the form composer wraps <form> with the options action + a submit button" asserts `<form action="/submit" method="post">` and `<button type="submit">` for a configured renderer, and `<form method="post">` for the default.

### 3. All interactivity is INERT -- data hooks, no scripts, no event wiring
Every button is `<button type="button">` (add/remove) or `<button type="submit">`, carrying `data-add-row`/`data-remove-row`/`data-variant-of` hooks; the renderer emits no `<script>` and no inline `on*` handlers. The behavior these hooks describe is the handler's half (#227).
Evidence: `containers.test.ts` "all interactivity is inert" asserts the output contains no `<script` and matches no `/on[a-z]+=/`; the repeater test asserts the `data-add-row`/`data-remove-row` hooks.

### 4. form.css is shipped -- a classless sheet styling the semantic output + validation/error states
`src/renderers/html/form.css` styles `label`, `input`/`select`/`textarea`, `fieldset`/`legend`, buttons, `:required`, `:invalid`, `[aria-invalid="true"]`, and the `[role="alert"]` error slot (hidden when empty via `[role="alert"]:empty`). It is classless (no class selectors). It is genuinely SHIPPED: added to `package.json` `files` and exposed at `@rafters/kelex/form.css`, verified present via `npm pack --dry-run`. Note: `:user-invalid` is styled alongside `:invalid` (the preferred no-red-on-load UX); `:invalid` is present for completeness per this criterion.
Evidence: `containers.test.ts` "ships form.css" asserts the selector list (including `:invalid`, `[aria-invalid=`, `[role="alert"]:empty`) is present and no `.class` selector exists; `package.json` `files`/`exports["./form.css"]`.

### 5. With the leaf inventory the renderer passes the full floor and full conformance
`validateRenderer(htmlRenderer)` (unscoped) returns no gaps -- every FieldType has a catch-all -- and `conformance(htmlRenderer, undefined, { names })` passes over the whole shape battery plus fuzzed schemas (floor, totality, path-preservation, determinism, handler-join), confirming the container composers stamp exactly the control keys `controlPaths` emits, across nested objects, arrays, records, discriminated and plain unions, and recursion.
Evidence: `containers.test.ts` "passes full conformance (renderer-only) over every shape" asserts `report.passed` with `fuzzCount: 40`, and "preserves the join through a pass-through handler" confirms a handler cannot silently drop a control.

## Not done

Paired conformance with the POST HANDLER is #227's AC5 -- the handler is not built yet (build order #226 -> #228 -> #227), so #228 proves the renderer against the FULL floor and full conformance renderer-only, plus a pass-through handler double (a strengthening check that `wire` preserves the join, NOT the post handler). Two limits are handed to #227: (a) when two union variants share a non-discriminator field name, both panels emit that `name`/`id` -- the handler must collect from the ACTIVE variant panel only (conformance's subset check cannot see the duplicate); (b) the discriminator selector key is hand-joined (`${key}.${disc}`) pending #234's first-class discriminator child. All click behavior (union show/hide, array add/remove, submit/POST) is deferred to #227 by the renderer/handler split.

Closes #228
