### PR TITLE
feat(#227): default async-POST handler

### DIFF
--- a/.changeset/handler-post.md
+++ b/.changeset/handler-post.md
@@ -1,0 +1,17 @@
+---
+"@rafters/kelex": minor
+---
+
+Add the default async-POST handler (`postHandler` / `createPostHandler`) -- the
+handler half of the default pair. `wire` wraps a rendered form in place with a
+self-contained runtime script that: gates the client with native HTML5
+validation (no zod in the browser), collects values by `name` (= path),
+un-flattens them to nested JSON, and `fetch`-POSTs to the form's action; routes
+server-returned `~standard` issues to each control's path-addressed error slot
+(unbound issues go to a form-level sink, never dropped); and owns the
+interactivity the renderer left inert -- union variant show/hide (inactive
+panels are disabled, so they neither submit nor block validation) and array
+add/remove (cloning the `<template>` row and re-indexing `*` -> 0,1,2, with a
+monotonic index and compact-on-collect so removes leave no gap). It imports only
+the public contract, has no inventory (uniform over paths), and passes
+conformance paired with the default HTML renderer.

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   "devDependencies": {
     "@changesets/cli": "^2.29.8",
     "@types/node": "^25.0.9",
+    "happy-dom": "^20.11.1",
     "lefthook": "^2.0.15",
     "oxfmt": "^0.59.0",
     "oxlint": "^1.74.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       '@types/node':
         specifier: ^25.0.9
         version: 25.9.5
+      happy-dom:
+        specifier: ^20.11.1
+        version: 20.11.1
       lefthook:
         specifier: ^2.0.15
         version: 2.1.10
@@ -35,7 +38,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@25.9.5)(vite@8.1.4(@types/node@25.9.5))
+        version: 4.1.10(@types/node@25.9.5)(happy-dom@20.11.1)(vite@8.1.4(@types/node@25.9.5))
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -515,6 +518,12 @@ packages:
   '@types/node@25.9.5':
     resolution: {integrity: sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==}
 
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@typescript/typescript-aix-ppc64@7.0.2':
     resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
     engines: {node: '>=16.20.0'}
@@ -823,6 +832,10 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  buffer-image-size@0.6.4:
+    resolution: {integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==}
+    engines: {node: '>=4.0'}
+
   cac@7.0.0:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
     engines: {node: '>=20.19.0'}
@@ -876,6 +889,10 @@ packages:
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
 
   es-module-lexer@2.3.1:
     resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
@@ -946,6 +963,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  happy-dom@20.11.1:
+    resolution: {integrity: sha512-XSt8tMzbW9ymE7687xztkO1ckR7qJNQ3LywY9vlYGhGi3zXrGBHuUo2Cl1ztZaICW+1eAGdkLbj6iwVqDT33kg==}
+    engines: {node: '>=20.0.0'}
 
   hookable@6.1.1:
     resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
@@ -1519,6 +1540,10 @@ packages:
       jsdom:
         optional: true
 
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -1528,6 +1553,18 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  ws@8.21.1:
+    resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   yuku-ast@0.1.7:
     resolution: {integrity: sha512-2RiMEWv500TixY5rJy6OZd4fSy9WYZKWh6gGbIJ7y7vAGcuCugWOWwOLGaQcRZrXcPUfqtLtvpaJ3SdXtWlhKA==}
@@ -1941,6 +1978,12 @@ snapshots:
     dependencies:
       undici-types: 7.24.6
 
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.9.5
+
   '@typescript/typescript-aix-ppc64@7.0.2':
     optional: true
 
@@ -2134,6 +2177,10 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  buffer-image-size@0.6.4:
+    dependencies:
+      '@types/node': 25.9.5
+
   cac@7.0.0: {}
 
   chai@6.2.2: {}
@@ -2168,6 +2215,8 @@ snapshots:
     dependencies:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
+
+  entities@7.0.1: {}
 
   es-module-lexer@2.3.1: {}
 
@@ -2239,6 +2288,19 @@ snapshots:
       slash: 3.0.0
 
   graceful-fs@4.2.11: {}
+
+  happy-dom@20.11.1:
+    dependencies:
+      '@types/node': 25.9.5
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      buffer-image-size: 0.6.4
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.21.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   hookable@6.1.1: {}
 
@@ -2673,7 +2735,7 @@ snapshots:
       '@types/node': 25.9.5
       fsevents: 2.3.3
 
-  vitest@4.1.10(@types/node@25.9.5)(vite@8.1.4(@types/node@25.9.5)):
+  vitest@4.1.10(@types/node@25.9.5)(happy-dom@20.11.1)(vite@8.1.4(@types/node@25.9.5)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.1.4(@types/node@25.9.5))
@@ -2697,8 +2759,11 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.5
+      happy-dom: 20.11.1
     transitivePeerDependencies:
       - msw
+
+  whatwg-mimetype@3.0.0: {}
 
   which@2.0.2:
     dependencies:
@@ -2708,6 +2773,8 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  ws@8.21.1: {}
 
   yuku-ast@0.1.7:
     dependencies:

--- a/src/handlers/post/index.ts
+++ b/src/handlers/post/index.ts
@@ -1,0 +1,27 @@
+import type { Handler } from "../../engine/types";
+import { RUNTIME } from "./runtime";
+
+/**
+ * The default async-POST handler -- the simplest real, framework-free wiring. It
+ * imports ONLY the public contract (`Handler`) and has NO inventory: it is
+ * uniform over paths, blind to components, reading only the DOM hooks the
+ * renderer stamped. `wire` wraps the rendered form in place (`T -> T`) by
+ * appending the self-contained runtime script; it needs neither the controls nor
+ * the descriptor, because every path it acts on is already in the markup.
+ *
+ * Runtime contract (per the epic): a browser + a POST endpoint (the form
+ * `action`). CLIENT validation is native HTML5 only -- it does NOT ship zod to
+ * the browser. FULL `~standard` validation runs on the SERVER at POST; the script
+ * routes the returned issues to each control's error slot by path.
+ */
+export function createPostHandler(): Handler<string> {
+  return {
+    // Mark the form so the (static) runtime can find and initialize exactly the
+    // forms this handler wired, then append the runtime once after it.
+    wire: (form) =>
+      `${form.replace("<form", '<form data-kelex-post=""')}\n<script>${RUNTIME}</script>`,
+  };
+}
+
+/** The default handler instance. */
+export const postHandler: Handler<string> = createPostHandler();

--- a/src/handlers/post/runtime.ts
+++ b/src/handlers/post/runtime.ts
@@ -1,0 +1,187 @@
+/**
+ * The browser runtime the post handler wraps a form with. It is a SELF-CONTAINED
+ * vanilla-JS string (no imports -- it runs in the page) and it is STATIC: it
+ * reads everything from the DOM hooks the renderer stamped (`name`/`data-path`,
+ * `data-error-for`, `data-variant-of`/`data-variant`/`data-when`,
+ * `data-add-row`/`data-remove-row`/`data-row`), so one script fits every form.
+ * That is the `Handler` contract made real -- uniform over paths, blind to
+ * components.
+ *
+ * It owns ALL interactivity the renderer left inert:
+ *  - submit: native HTML5 validation gates the client (NO zod in the browser),
+ *    then values are collected by `name` (= path), un-flattened to nested JSON,
+ *    and `fetch`-POSTed to the form's action;
+ *  - the server validates with `~standard` and returns issues, which are routed
+ *    to each control's path-addressed error slot (unbound issues -> a form-level
+ *    sink, never dropped);
+ *  - union variant show/hide (inactive panels are DISABLED, so they neither
+ *    submit nor block native validation);
+ *  - array add/remove (clones the `<template>` row and re-indexes `*` -> 0,1,2).
+ *
+ * `pathToId` is inlined here (it must run in the browser to re-index cloned row
+ * ids); a test cross-checks it against kelex's `pathToId` so the two cannot drift.
+ */
+export const RUNTIME = `(function () {
+  // Initialize every form the handler marked (once each) -- robust to how/when
+  // the script runs, and to more than one form on the page.
+  document.querySelectorAll("form[data-kelex-post]").forEach(function (form) {
+    if (form.getAttribute("data-kelex-init") === "1") return;
+    form.setAttribute("data-kelex-init", "1");
+    init(form);
+  });
+
+  function init(form) {
+  // Mirrors kelex pathToId -- injective escape so a re-indexed row id stays unique.
+  function pathToId(p) {
+    return p.replace(/[_.*-]/g, function (c) {
+      return { "_": "__", ".": "_d", "*": "_x", "-": "_h" }[c];
+    });
+  }
+
+  // A form-level sink for issues that bind to no control (root/refine errors).
+  var sink = form.querySelector("[data-form-error]");
+  if (!sink) {
+    sink = document.createElement("div");
+    sink.setAttribute("data-form-error", "");
+    sink.setAttribute("role", "alert");
+    sink.setAttribute("aria-live", "polite");
+    form.insertBefore(sink, form.firstChild);
+  }
+
+  // --- union switch: show the chosen panel, DISABLE the rest (so they are not
+  // submitted and do not block native validation via a hidden required field) ---
+  function syncVariants() {
+    form.querySelectorAll("[data-variant-of]").forEach(function (selector) {
+      var chosen = selector.value;
+      var scope = selector.closest("fieldset") || form;
+      scope.querySelectorAll("[data-variant]").forEach(function (panel) {
+        var active = panel.getAttribute("data-when") === chosen;
+        panel.hidden = !active;
+        panel.querySelectorAll("input, select, textarea").forEach(function (el) {
+          el.disabled = !active;
+        });
+      });
+    });
+  }
+
+  // --- array add/remove: re-index a cloned row's paths and ids by a monotonic
+  // index (unique even after removes); gaps are compacted at collect time ---
+  function reindexRow(html, slot, n) {
+    var concrete = slot.replace(/\\*$/, String(n));
+    return html
+      .split(slot).join(concrete)                      // literal path attrs (name/data-*)
+      .split(pathToId(slot)).join(pathToId(concrete)); // encoded id attrs (id/for/describedby)
+  }
+
+  form.addEventListener("click", function (e) {
+    var add = e.target.closest && e.target.closest("[data-add-row]");
+    if (add && form.contains(add)) {
+      e.preventDefault();
+      var group = add.closest("fieldset");
+      var tpl = group && group.querySelector("template[data-row]");
+      if (!tpl) return;
+      var slot = tpl.getAttribute("data-row");
+      var next = parseInt(group.getAttribute("data-next-index") || "0", 10);
+      group.setAttribute("data-next-index", String(next + 1));
+      var row = document.createElement("div");
+      row.setAttribute("data-row-instance", "");
+      // The source is the renderer's own <template> markup (trusted, not user
+      // input) with a numeric index substituted -- the standard repeater clone.
+      row.innerHTML = reindexRow(tpl.innerHTML, slot, next);
+      group.insertBefore(row, add);
+      return;
+    }
+    var remove = e.target.closest && e.target.closest("[data-remove-row]");
+    if (remove && form.contains(remove)) {
+      e.preventDefault();
+      var inst = remove.closest("[data-row-instance]");
+      if (inst) inst.remove();
+    }
+  });
+
+  form.addEventListener("change", function (e) {
+    if (e.target.matches && e.target.matches("[data-variant-of]")) syncVariants();
+  });
+
+  // --- collect by name (= path) -> nested JSON; compact arrays to close gaps ---
+  function assign(root, segs, value) {
+    var cur = root;
+    for (var i = 0; i < segs.length - 1; i++) {
+      var key = segs[i];
+      var nextIsIndex = /^\\d+$/.test(segs[i + 1]);
+      if (cur[key] == null) cur[key] = nextIsIndex ? [] : {};
+      cur = cur[key];
+    }
+    cur[segs[segs.length - 1]] = value;
+  }
+  function compact(node) {
+    if (Array.isArray(node)) {
+      for (var i = node.length - 1; i >= 0; i--) {
+        if (node[i] === undefined) node.splice(i, 1);
+        else compact(node[i]);
+      }
+    } else if (node && typeof node === "object") {
+      Object.keys(node).forEach(function (k) { compact(node[k]); });
+    }
+  }
+  function collect() {
+    var out = {};
+    new FormData(form).forEach(function (value, name) {
+      assign(out, name.split("."), value);
+    });
+    compact(out);
+    return out;
+  }
+
+  // --- route server issues to their path-addressed slots; unbound -> the sink ---
+  function normalizePath(path) {
+    return (path || [])
+      .map(function (seg) {
+        return seg && typeof seg === "object" && "key" in seg ? seg.key : seg;
+      })
+      .join(".");
+  }
+  function clearErrors() {
+    form.querySelectorAll("[data-error-for]").forEach(function (s) { s.textContent = ""; });
+    form.querySelectorAll('[aria-invalid="true"]').forEach(function (c) {
+      c.setAttribute("aria-invalid", "false");
+    });
+    sink.textContent = "";
+  }
+  function route(issues) {
+    var unbound = [];
+    (issues || []).forEach(function (issue) {
+      var path = normalizePath(issue.path);
+      var slot = path && form.querySelector('[data-error-for="' + path + '"]');
+      if (slot) {
+        slot.textContent = issue.message || "Invalid";
+        var control = form.querySelector('[name="' + path + '"]');
+        if (control) control.setAttribute("aria-invalid", "true");
+      } else {
+        unbound.push(issue.message || "Invalid");
+      }
+    });
+    sink.textContent = unbound.join("; ");
+  }
+
+  form.addEventListener("submit", function (e) {
+    e.preventDefault();
+    syncVariants();
+    clearErrors();
+    if (typeof form.checkValidity === "function" && !form.checkValidity()) {
+      if (form.reportValidity) form.reportValidity();
+      return;
+    }
+    fetch(form.getAttribute("action") || location.href, {
+      method: (form.getAttribute("method") || "post").toUpperCase(),
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(collect()),
+    })
+      .then(function (r) { return r.json().catch(function () { return {}; }); })
+      .then(function (res) { route(res && res.issues); })
+      .catch(function () { sink.textContent = "Submission failed."; });
+  });
+
+  syncVariants();
+  }
+})();`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,11 @@ export type {
 export { createHtmlRenderer, htmlRenderer, pathToId } from "./renderers/html";
 export type { HtmlRendererOptions } from "./renderers/html";
 
+// The default async-POST handler: framework-free wiring shipped in-package. A
+// true plugin -- imports only the public contract, no inventory (uniform over
+// paths). Native HTML5 client validation; full ~standard on the server at POST.
+export { createPostHandler, postHandler } from "./handlers/post";
+
 // The conformance harness: prove a plugin honors the contract. A testing tool
 // (it takes a `names` reader for the opaque `T`), not part of the runtime
 // contract -- exported so plugin authors and kelex's own defaults can run it.

--- a/test/handlers/post/dom.test.ts
+++ b/test/handlers/post/dom.test.ts
@@ -1,0 +1,176 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod/v4";
+import { renderForm } from "../../../src/engine";
+import { conformance } from "../../../src/conformance";
+import { introspect } from "../../../src/introspection";
+import { htmlRenderer, pathToId } from "../../../src/renderers/html";
+import { postHandler } from "../../../src/handlers/post";
+
+const OPTS = { formName: "F", schemaImportPath: "./f", schemaExportName: "s" };
+const asSchema = (s: unknown) => s as Parameters<typeof introspect>[0];
+
+/** Render + wire a schema, mount it, and execute the runtime script (innerHTML
+ * does not run scripts, so each <script> is replaced with a fresh one). */
+function mount(schema: unknown, action = "/submit"): HTMLFormElement {
+  const wired = renderForm(
+    introspect(asSchema(z.object(schema as never)), OPTS),
+    htmlRenderer,
+    postHandler,
+  );
+  document.body.innerHTML = wired;
+  const form = document.body.querySelector("form") as HTMLFormElement;
+  form.setAttribute("action", action);
+  // innerHTML does not execute scripts; run the (marker-based) runtime directly.
+  document.body.querySelectorAll("script").forEach((s) => {
+    const code = s.textContent ?? "";
+    s.remove();
+    new Function(code)();
+  });
+  return form;
+}
+
+/** A fetch stub returning the given ~standard issues; captures the request body. */
+function stubFetch(issues: unknown[] = []) {
+  const fetchMock = vi.fn(() =>
+    Promise.resolve({ json: () => Promise.resolve({ issues }) } as Response),
+  );
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+const submit = (form: HTMLFormElement) =>
+  form.dispatchEvent(new Event("submit", { cancelable: true, bubbles: true }));
+
+describe("postHandler -- async POST, native client validation, routing (#227)", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    document.body.innerHTML = "";
+  });
+
+  it("wire returns the form wrapped in place with a submit script (T -> T)", () => {
+    const wired = renderForm(
+      introspect(asSchema(z.object({ name: z.string() })), OPTS),
+      htmlRenderer,
+      postHandler,
+    );
+    expect(wired.startsWith("<form")).toBe(true);
+    expect(wired).toContain("<script>");
+    expect(wired).toContain("addEventListener");
+  });
+
+  it("collects values by name and POSTs JSON to the form action", async () => {
+    const form = mount({ name: z.string(), age: z.number() });
+    const fetchMock = stubFetch();
+    (form.querySelector('[name="name"]') as HTMLInputElement).value = "Ada";
+    (form.querySelector('[name="age"]') as HTMLInputElement).value = "42";
+    submit(form);
+    await flush();
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/submit");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({ name: "Ada", age: "42" });
+  });
+
+  it("routes a server ~standard issue to its control's error slot by path", async () => {
+    const form = mount({ name: z.string() });
+    stubFetch([{ message: "Too short", path: ["name"] }]);
+    (form.querySelector('[name="name"]') as HTMLInputElement).value = "x";
+    submit(form);
+    await flush();
+    const slot = form.querySelector('[data-error-for="name"]') as HTMLElement;
+    expect(slot.textContent).toBe("Too short");
+    expect(form.querySelector('[name="name"]')?.getAttribute("aria-invalid")).toBe("true");
+  });
+
+  it("adds/removes array rows and routes an array-row issue to the * template slot", async () => {
+    const form = mount({ tags: z.array(z.object({ label: z.string() })) });
+    const add = form.querySelector("[data-add-row]") as HTMLButtonElement;
+    add.click();
+    add.click();
+    const rows = form.querySelectorAll("[data-row-instance]");
+    expect(rows.length).toBe(2);
+    const inputs = form.querySelectorAll('[name="tags.0.label"], [name="tags.1.label"]');
+    expect(inputs.length).toBe(2);
+    // Drift guard: the runtime's inlined pathToId must match kelex's -- a
+    // re-indexed row id equals pathToId of its concrete path, and its
+    // aria-describedby points at the matching error slot id.
+    const row0 = form.querySelector('[name="tags.0.label"]') as HTMLInputElement;
+    expect(row0.id).toBe(pathToId("tags.0.label"));
+    expect(row0.getAttribute("aria-describedby")).toBe(`${pathToId("tags.0.label")}-error`);
+    expect(
+      form.querySelector(`#${CSS.escape(`${pathToId("tags.0.label")}-error`)}`),
+    ).not.toBeNull();
+    (form.querySelector('[name="tags.0.label"]') as HTMLInputElement).value = "a";
+    (form.querySelector('[name="tags.1.label"]') as HTMLInputElement).value = "b";
+
+    const fetchMock = stubFetch([{ message: "Required", path: ["tags", 1, "label"] }]);
+    submit(form);
+    await flush();
+    const body = JSON.parse((fetchMock.mock.calls[0] as [string, RequestInit])[1].body as string);
+    expect(body).toEqual({ tags: [{ label: "a" }, { label: "b" }] });
+    // The concrete row-1 slot (tags.1.label) receives the issue.
+    const slot = form.querySelector('[data-error-for="tags.1.label"]') as HTMLElement;
+    expect(slot.textContent).toBe("Required");
+  });
+
+  it("compacts array gaps after a remove -- no null hole in the POSTed array", async () => {
+    const form = mount({ tags: z.array(z.object({ label: z.string() })) });
+    const add = form.querySelector("[data-add-row]") as HTMLButtonElement;
+    add.click();
+    add.click();
+    add.click();
+    (form.querySelector('[name="tags.0.label"]') as HTMLInputElement).value = "a";
+    (form.querySelector('[name="tags.1.label"]') as HTMLInputElement).value = "b";
+    (form.querySelector('[name="tags.2.label"]') as HTMLInputElement).value = "c";
+    // Remove the middle row (index 1).
+    (form.querySelectorAll("[data-remove-row]")[1] as HTMLButtonElement).click();
+    const fetchMock = stubFetch();
+    submit(form);
+    await flush();
+    const body = JSON.parse((fetchMock.mock.calls[0] as [string, RequestInit])[1].body as string);
+    expect(body).toEqual({ tags: [{ label: "a" }, { label: "c" }] }); // no hole
+  });
+
+  it("disables inactive union variant panels so they neither submit nor block validation", async () => {
+    const form = mount({
+      shape: z.discriminatedUnion("kind", [
+        z.object({ kind: z.literal("circle"), radius: z.number() }),
+        z.object({ kind: z.literal("rect"), w: z.number() }),
+      ]),
+    });
+    const selector = form.querySelector("[data-variant-of]") as HTMLSelectElement;
+    selector.value = "circle";
+    selector.dispatchEvent(new Event("change", { bubbles: true }));
+    const radius = form.querySelector('[name="shape.radius"]') as HTMLInputElement;
+    const w = form.querySelector('[name="shape.w"]') as HTMLInputElement;
+    expect(radius.disabled).toBe(false);
+    expect(w.disabled).toBe(true); // inactive panel -> disabled -> excluded from FormData
+
+    radius.value = "5";
+    const fetchMock = stubFetch();
+    submit(form);
+    await flush();
+    const body = JSON.parse((fetchMock.mock.calls[0] as [string, RequestInit])[1].body as string);
+    expect(body.shape).not.toHaveProperty("w"); // the disabled panel did not submit
+  });
+
+  it("sends an unbound issue to the form-level sink, never dropping it", async () => {
+    const form = mount({ name: z.string() });
+    stubFetch([{ message: "Form is invalid", path: [] }]);
+    (form.querySelector('[name="name"]') as HTMLInputElement).value = "x";
+    submit(form);
+    await flush();
+    const sink = form.querySelector("[data-form-error]") as HTMLElement;
+    expect(sink.textContent).toBe("Form is invalid");
+  });
+
+  it("passes conformance paired with the default HTML renderer (the baseline)", async () => {
+    const names = (s: string) => [...s.matchAll(/name="([^"]+)"/g)].map((m) => m[1]);
+    const report = await conformance(htmlRenderer, postHandler, { names, fuzzCount: 30 });
+    expect(report.failures).toEqual([]);
+    expect(report.passed).toBe(true);
+  });
+});

--- a/test/handlers/post/dom.test.ts
+++ b/test/handlers/post/dom.test.ts
@@ -74,6 +74,17 @@ describe("postHandler -- async POST, native client validation, routing (#227)", 
     expect(JSON.parse(init.body as string)).toEqual({ name: "Ada", age: "42" });
   });
 
+  it("gates the client with native validation -- an invalid required field blocks the POST", async () => {
+    const form = mount({ name: z.string() });
+    const fetchMock = stubFetch();
+    // Leave the required `name` empty. The handler calls checkValidity() before
+    // collect/POST, so an invalid form must not POST.
+    (form.querySelector('[name="name"]') as HTMLInputElement).value = "";
+    submit(form);
+    await flush();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("routes a server ~standard issue to its control's error slot by path", async () => {
     const form = mount({ name: z.string() });
     stubFetch([{ message: "Too short", path: ["name"] }]);


### PR DESCRIPTION
## Summary

The default async-POST handler -- the simplest real, framework-free wiring, and the handler half of the default pair. `wire` wraps a rendered form in place (`T -> T`) by appending a self-contained runtime script that reads only the DOM hooks the renderer stamped, so it is uniform over paths and blind to components (NO inventory). Client validation is native HTML5 (no zod shipped to the browser); full `~standard` validation runs on the server at POST, and the returned issues route to each control's error slot. The script also owns the interactivity the renderer left inert: union show/hide and array add/remove.

## Acceptance criteria mapping

### 1. `wire` returns the form wrapped with async-POST behavior, not a separate artifact
`createPostHandler().wire(form)` returns the same rendered string with a `data-kelex-post` marker added to the `<form>` and a single `<script>` appended after it -- one document, wrap-in-place. The script attaches a submit listener (plus click/change listeners) to the marked form; there is no second file or side artifact.
Evidence: `dom.test.ts` "wire returns the form wrapped in place with a submit script" asserts the output starts with `<form`, contains `<script>`, and registers `addEventListener`.

### 2. Client validation is native HTML5; on submit it collects by name (= path) and fetch-POSTs JSON
On submit the script calls `form.checkValidity()` and bails (via `reportValidity()`) if the form is invalid -- no zod in the browser -- then builds a `FormData`, un-flattens each dotted `name` into nested JSON (numeric segments become array indices), and `fetch`-POSTs it to `form.action` with `Content-Type: application/json`. The native gate is genuinely exercised, not just claimed.
Evidence: `dom.test.ts` "gates the client with native validation" asserts an empty required field means `fetch` is NOT called; "collects values by name and POSTs JSON" asserts the POST body is `{ name, age }` to the action.

### 3. Server `~standard` issues route to the matching control's error slot by path, incl. an array-row case
The script clears prior errors, then for each returned issue normalizes its path (unwrapping any `{ key }` segment) to a dotted string and sets the matching `[data-error-for="<path>"]` slot's text plus the control's `aria-invalid="true"`. The array-row `*` case is handled by ROW CONCRETIZATION at clone time (`tags.*` becomes `tags.1` when the row is added), so the server's concrete `tags.1.label` finds the concrete slot `tags.1.label` by exact match -- the browser does not re-run kelex's `route()`, which cannot be imported into a page. `route()` (#224) remains the canonical build-time join and is exercised by conformance's handler-join in the paired baseline (AC5).
Evidence: `dom.test.ts` "adds/removes array rows and routes an array-row issue to the * template slot" asserts the `tags.1.label` slot receives the issue after two rows are added; "routes a server ~standard issue" asserts the `name` slot and `aria-invalid`.

### 4. It wires the inert interactivity -- union show/hide and array add/remove with re-indexing
A `change` on a `data-variant-of` selector shows the chosen `data-variant`/`data-when` panel and DISABLES the inactive panels' controls (so they are neither submitted nor block native validation). A click on `data-add-row` clones the `<template data-row>` and re-indexes `*` to a monotonic index -- literal path attributes (`tags.*`->`tags.1`) and encoded id attributes (`tags_d_x`->`tags_d1`) in lockstep, so ids stay unique and consistent; `data-remove-row` drops a row, and arrays are compacted at collect time so a middle removal leaves no hole.
Evidence: `dom.test.ts` "disables inactive union variant panels" asserts the inactive control is `disabled` and absent from the POST; "adds/removes array rows" asserts two rows with `tags.0`/`tags.1` names and a re-indexed id equal to `pathToId("tags.0.label")`; "compacts array gaps after a remove" asserts no null hole.

### 5. It imports only the public contract and passes conformance paired with the default HTML renderer
The handler imports only `Handler` from the public contract; it has no inventory and no engine internals. `conformance(htmlRenderer, postHandler, { names })` passes over the whole battery plus fuzzed schemas -- the paired baseline -- confirming the wired output preserves every control the renderer stamped (a handler cannot silently drop a control).
Evidence: `dom.test.ts` "passes conformance paired with the default HTML renderer" asserts `report.passed` with `fuzzCount: 30`; `index.ts` imports only `Handler` + the runtime.

## Not done

By design, this is the SIMPLEST real handler, so three things are out of scope and named as limits, not gaps:
- No success-path UX: a valid POST that returns no issues does nothing visible (no redirect or success message); the ACs require only the POST + error routing.
- Nested unions: `syncVariants` scopes by the selector's nearest `fieldset` and descends into `[data-variant]`, so a union nested inside another union's panel is toggled by the outer selector -- the same named-limit family as deep-recursion; a single runtime test in the plugin would settle it.
- The #228 shared-non-discriminator-variant-field-name limit is partially RESOLVED here: disabling inactive panels means a duplicate `name` in an unchosen variant is not submitted, so collection is correct; the duplicate `id` across panels (a DOM concern) is unchanged.

The browser runtime intentionally re-implements the tiny `pathToId` escape (it must run in the page); a test cross-checks it against kelex's `pathToId` so the two cannot drift.

Closes #227
