### PR TITLE
fix(handler-post): collect typed values so number/boolean POST correctly

### DIFF
--- a/src/handlers/post/runtime.ts
+++ b/src/handlers/post/runtime.ts
@@ -124,9 +124,27 @@ export const RUNTIME = `(function () {
       Object.keys(node).forEach(function (k) { compact(node[k]); });
     }
   }
+  // Collect TYPED values (not FormData's raw strings) so the POSTed JSON matches
+  // the schema: number/range -> number, checkbox -> boolean. Otherwise a
+  // z.number()/z.boolean() field fails the server's ~standard on every submit.
+  // A blank non-checkbox is omitted (an optional field stays undefined); a date
+  // stays a string (JSON has no Date -- the server needs z.coerce.date).
   function collect() {
     var out = {};
-    new FormData(form).forEach(function (value, name) {
+    form.querySelectorAll("[name]").forEach(function (el) {
+      if (el.disabled) return;
+      var name = el.getAttribute("name");
+      var type = (el.getAttribute("type") || el.tagName).toLowerCase();
+      var value;
+      if (type === "checkbox") {
+        value = el.checked;
+      } else if (type === "radio") {
+        if (!el.checked) return;
+        value = el.value;
+      } else {
+        if (el.value === "") return;
+        value = type === "number" || type === "range" ? Number(el.value) : el.value;
+      }
       assign(out, name.split("."), value);
     });
     compact(out);

--- a/test/handlers/post/dom.test.ts
+++ b/test/handlers/post/dom.test.ts
@@ -161,7 +161,7 @@ describe("postHandler -- async POST, native client validation, routing (#227)", 
     const radius = form.querySelector('[name="shape.radius"]') as HTMLInputElement;
     const w = form.querySelector('[name="shape.w"]') as HTMLInputElement;
     expect(radius.disabled).toBe(false);
-    expect(w.disabled).toBe(true); // inactive panel -> disabled -> excluded from FormData
+    expect(w.disabled).toBe(true); // inactive panel -> disabled -> skipped by collect()
 
     radius.value = "5";
     const fetchMock = stubFetch();
@@ -169,6 +169,18 @@ describe("postHandler -- async POST, native client validation, routing (#227)", 
     await flush();
     const body = JSON.parse((fetchMock.mock.calls[0] as [string, RequestInit])[1].body as string);
     expect(body.shape).not.toHaveProperty("w"); // the disabled panel did not submit
+  });
+
+  it("collects only the checked option of a radio group (few-value enum)", async () => {
+    const form = mount({ role: z.enum(["admin", "user"]) });
+    expect(form.querySelectorAll('[name="role"][type="radio"]').length).toBe(2);
+    const [, second] = form.querySelectorAll('[name="role"]') as NodeListOf<HTMLInputElement>;
+    second.checked = true; // choose "user"
+    const fetchMock = stubFetch();
+    submit(form);
+    await flush();
+    const body = JSON.parse((fetchMock.mock.calls[0] as [string, RequestInit])[1].body as string);
+    expect(body).toEqual({ role: "user" }); // only the checked radio, once
   });
 
   it("sends an unbound issue to the form-level sink, never dropping it", async () => {

--- a/test/handlers/post/dom.test.ts
+++ b/test/handlers/post/dom.test.ts
@@ -60,18 +60,21 @@ describe("postHandler -- async POST, native client validation, routing (#227)", 
     expect(wired).toContain("addEventListener");
   });
 
-  it("collects values by name and POSTs JSON to the form action", async () => {
-    const form = mount({ name: z.string(), age: z.number() });
+  it("collects TYPED values by name and POSTs JSON to the form action", async () => {
+    const form = mount({ name: z.string(), age: z.number(), agree: z.boolean() });
     const fetchMock = stubFetch();
     (form.querySelector('[name="name"]') as HTMLInputElement).value = "Ada";
     (form.querySelector('[name="age"]') as HTMLInputElement).value = "42";
+    (form.querySelector('[name="agree"]') as HTMLInputElement).checked = true;
     submit(form);
     await flush();
     expect(fetchMock).toHaveBeenCalledOnce();
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(url).toBe("/submit");
     expect(init.method).toBe("POST");
-    expect(JSON.parse(init.body as string)).toEqual({ name: "Ada", age: "42" });
+    // number stays a number, checkbox a boolean -- so the server's zod schema
+    // (z.number()/z.boolean(), no coercion) validates on the first try.
+    expect(JSON.parse(init.body as string)).toEqual({ name: "Ada", age: 42, agree: true });
   });
 
   it("gates the client with native validation -- an invalid required field blocks the POST", async () => {


### PR DESCRIPTION
## Summary

The post handler (#227, merged in #237) collected its POST body with `new FormData(form)`, which stringifies every value -- so a `z.number()`/`z.boolean()` field failed the server's `~standard` on every submit (zod does not coerce, and the server validates with the same schema that rendered the form). This replaces the collection with a typed one that reads each named control's real value, so the default renderer+handler pair produces a form that validates on the first try. The bug is live in `main`; this is its follow-up PR (the review caught it after #237 auto-merged).

## Acceptance criteria mapping

### 1. Numbers and booleans POST with their real JSON types
`collect()` now iterates the form's named controls and reads a typed value: `input[type=number|range]` -> `Number(el.value)`, `input[type=checkbox]` -> `el.checked`. So a number field serializes as a JSON number and a checkbox as a JSON boolean, which the server's `z.number()`/`z.boolean()` accept without coercion.
Evidence: `dom.test.ts` "collects TYPED values by name and POSTs JSON" asserts the body is `{ name: "Ada", age: 42, agree: true }` -- `42` is a number and `true` a boolean, not strings.

### 2. Blank controls omitted; disabled controls still excluded
A blank non-checkbox control is skipped (`el.value === ""` -> `return`), so an optional field stays `undefined` rather than posting `""` or `null`. A disabled control is skipped up front (`if (el.disabled) return`), preserving the exclusion `FormData` used to give for free -- the inactive union variant panel's controls are disabled, so they do not submit.
Evidence: `dom.test.ts` "disables inactive union variant panels" asserts the disabled `shape.w` is absent from the POST body under the typed collector.

### 3. A radio group posts only the checked option, once
For `input[type=radio]` the collector reads the value only when `el.checked`, so a few-value enum rendered as a radio group contributes exactly one value (the selection), never one entry per option.
Evidence: `dom.test.ts` "collects only the checked option of a radio group" checks the second radio and asserts the body is `{ role: "user" }` -- the checked option alone.

### 4. Array add/remove, compaction, and issue routing are unchanged
The change is confined to `collect()`'s value-reading; `assign` (un-flatten), `compact` (close array gaps), and `route` (issue -> slot) are untouched, so the repeater and routing behavior does not regress.
Evidence: `dom.test.ts` "adds/removes array rows...", "compacts array gaps after a remove", and "routes a server ~standard issue..." pass unchanged (10/10 in the suite).

### 5. The date-over-JSON limitation is documented
A `<input type="date">` posts a `YYYY-MM-DD` string; JSON has no Date type, so a `z.date()` field needs `z.coerce.date()` server-side. This is stated in the collector's comment (number and boolean, by contrast, are coerced client-side and need no server change).
Evidence: `runtime.ts` `collect()` comment: "a date stays a string (JSON has no Date -- the server needs z.coerce.date)".

## Not done

Scope is exactly the typed-collection fix plus the two review nits it surfaced (a radio-group test, and correcting a stale `FormData` comment on the disabled-panel assertion). The renderer-side discriminated-union error-slot gap noted in review belongs to #228 and is not touched here.

Closes #238
