### PR TITLE
test(stress): run the default plugins over the 11 real schemas

### DIFF
--- a/test/stress/stress.spec.ts
+++ b/test/stress/stress.spec.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
+import { renderForm, validateRenderer } from "../../src/engine";
+import { controlPaths } from "../../src/engine/paths";
 import type { FieldConstraints, FieldType } from "../../src/introspection";
 import { introspect } from "../../src/introspection";
+import { postHandler } from "../../src/handlers/post";
+import { htmlRenderer } from "../../src/renderers/html";
 import { writeSchema } from "../../src/schema-writer/writer";
 import { evaluateSchemaCode } from "../helpers/evaluate-schema";
 
@@ -623,6 +627,49 @@ describe("Stress test: complex Zod v4 schemas", () => {
             }
           }
         }
+      });
+    });
+  }
+});
+
+// The form pipeline (render + wire) over the same real-world schemas -- the
+// default plugins must produce a complete, conformant form for every one. Real
+// schemas exercise nesting, unions, records, and optionals the fuzzer does not.
+const namesOf = (html: string): string[] => [...html.matchAll(/name="([^"]+)"/g)].map((m) => m[1]);
+
+describe("Form pipeline: default renderer + handler over real schemas", () => {
+  it("the default HTML renderer covers the full floor (every FieldType)", () => {
+    expect(validateRenderer(htmlRenderer)).toEqual([]);
+  });
+
+  for (const testCase of schemas) {
+    describe(testCase.name, () => {
+      it("renders a complete, wired, classless form", () => {
+        const descriptor = introspect(
+          testCase.schema as Parameters<typeof introspect>[0],
+          INTROSPECT_OPTS,
+        );
+        const html = renderForm(descriptor, htmlRenderer, postHandler);
+        expect(html.startsWith("<form")).toBe(true);
+        expect(html).toContain("<script>"); // the handler wired it
+        expect(html).not.toMatch(/\sclass=/); // classless
+        // Never falls to the inert fallback marker for a real field.
+        expect(html).not.toContain("kelex: no leaf control");
+      });
+
+      it("stamps every control path -- path-preservation on a real schema", () => {
+        const descriptor = introspect(
+          testCase.schema as Parameters<typeof introspect>[0],
+          INTROSPECT_OPTS,
+        );
+        // Render without the handler so the extracted names are the form's own,
+        // not the runtime script's string literals.
+        const html = renderForm(descriptor, htmlRenderer);
+        const stamped = new Set(namesOf(html));
+        const missing = controlPaths(descriptor)
+          .map((c) => c.key)
+          .filter((key) => !stamped.has(key));
+        expect(missing, `unstamped controls: ${missing.join(", ")}`).toEqual([]);
       });
     });
   }


### PR DESCRIPTION
## Summary

The stress suite trusted the 11 real-world domain schemas for introspection and schema-writer round-trip, but never ran them through the new form pipeline. This extends it: every real schema is rendered and wired through the default `htmlRenderer` + `postHandler`, and asserted to produce a complete, conformant form. Real schemas combine nesting, discriminated unions, records, dates, and deep optionals the conformance fuzzer does not, so this is high-signal coverage for the default plugins. It found no regressions -- all 11 pass -- which is itself the result: the defaults are robust over realistic input, not just fuzzed and battery input.

## Acceptance criteria mapping

### 1. Every real schema renders through renderForm with the default renderer + handler
A new `describe("Form pipeline: default renderer + handler over real schemas")` iterates the same `schemas` fixture array the introspection tests use and calls `renderForm(descriptor, htmlRenderer, postHandler)` for each -- so all 11 domains (healthcare through government) exercise the full pipeline, reusing the fixtures rather than redefining them.
Evidence: `stress.spec.ts` the `for (const testCase of schemas)` loop in the new describe; each `renders a complete, wired, classless form` test calls `renderForm(descriptor, htmlRenderer, postHandler)`.

### 2. Each form is asserted complete, wired, classless, and fallback-free
The "renders a complete, wired, classless form" test asserts the output starts with `<form`, contains the handler's `<script>` (it was wired), matches no `class=` (classless), and does not contain the inert `kelex: no leaf control` fallback marker (no real field was dropped).
Evidence: `stress.spec.ts` the four assertions in "renders a complete, wired, classless form" (`startsWith("<form")`, `toContain("<script>")`, `not.toMatch(/\sclass=/)`, `not.toContain("kelex: no leaf control")`).

### 3. Path-preservation is asserted per schema
The "stamps every control path" test renders each schema WITHOUT the handler (so the extracted `name` values are the form's own, not the runtime script's string literals), collects the stamped names, and asserts no `controlPaths(descriptor)` key is missing -- path-preservation on a real schema, the invariant most likely to crack on an unusual real shape.
Evidence: `stress.spec.ts` "stamps every control path" filters `controlPaths(descriptor).map(c => c.key)` against `new Set(namesOf(html))` and expects `missing` to be `[]`, with the offending keys in the failure message.

### 4. The full floor is asserted once
Before the per-schema loop, one test asserts `validateRenderer(htmlRenderer)` returns no gaps -- the default renderer covers every FieldType (the full floor), which is a renderer-level property and belongs outside the per-schema loop.
Evidence: `stress.spec.ts` "the default HTML renderer covers the full floor (every FieldType)" asserts `validateRenderer(htmlRenderer)` equals `[]`.

### 5. `pnpm test:spec` passes
The extended `stress.spec` and the existing `cli.spec` both pass under the spec harness (build-then-spec).
Evidence: `pnpm test:spec` runs 55 tests green (10 cli + 45 stress: 11x2 introspection/round-trip + 1 floor + 11x2 pipeline).

## Not done

Coverage only -- no source change. The pipeline assertions are structural (complete/wired/classless/path-preservation); they do not execute the handler's browser runtime over these schemas (that is the happy-dom DOM test's job, #227) nor assert rendered validation-attribute values per field (the leaf/container renderer unit tests, #226/#228). Full `conformance()` still runs its own battery+fuzz; this adds the real-schema dimension it structurally cannot generate.

Closes #240
